### PR TITLE
modify search to support multi search type

### DIFF
--- a/fuocore/cmds/helpers.py
+++ b/fuocore/cmds/helpers.py
@@ -145,6 +145,9 @@ def show_playlist(playlist, brief=False):
         content = '\n'.join(parts)
     return content
 
+def show_playlists(playlists):
+    return '\n'.join([show_playlist(song,brief=True) for song in playlists])
+
 
 def show_user(user):
     parts = [
@@ -153,3 +156,10 @@ def show_user(user):
     ]
     parts += ['\t' + show_playlist(p, brief=True) for p in user.playlists]
     return '\n'.join(parts)
+
+
+def show_results(results, stype):
+    if stype == 1:
+        return show_songs(results)
+    elif stype == 1000:
+        return show_playlists(results)

--- a/fuocore/cmds/search.py
+++ b/fuocore/cmds/search.py
@@ -1,6 +1,6 @@
 import logging
 from .base import AbstractHandler
-from .helpers import show_songs
+from .helpers import show_results
 
 logger = logging.getLogger(__name__)
 
@@ -9,17 +9,54 @@ class SearchHandler(AbstractHandler):
     cmds = 'search'
 
     def handle(self, cmd):
-        return self.search_songs(cmd.args[0])
+        """
+        Support command:
+        - fuo search keyword
+        - fuo search keyword@type=playlist
+        TODO:
+        - fuo search keyword[type=all]
+        - fuo search keyword[type=all, format=json, source=netease, limit=10]
+        :param cmd:
+        :return:
+        """
+        options = {}
+        if '@' in cmd.args[0]:
+            pos = cmd.args[0].find('@')
+            keyword = cmd.args[0][:pos]
+            option_str = cmd.args[0][pos+1:]
+            # convert "type=all, format=json," to dict
+            options.update([item.split('=') for item in option_str.split(',')])
+        else:
+            keyword = cmd.args[0]
 
-    def search_songs(self, query):
-        logger.debug('搜索 %s ...', query)
+        if options.get('type') in ('playlists', 'playlist', 'pl'):
+            stype = 1000
+        else:
+            stype = 1
+
+        if len(options) >= 2 or (len(options) == 1 and 'type' not in options):
+            logging.warning('have not support more options yet')
+
+        return self.search(keyword, stype)
+
+    def search(self, query, stype=1):
+        """
+        :param query:  string
+        :param stype:  int  1->songs, 1000->playlists
+        TODO 10->albums, 100->artists, -1->all
+        :return:
+        """
+        logger.debug(f'搜索 {query} ...')
         providers = self.library.list()
         source_in = [provd.identifier for provd in providers
                      if provd.Song.meta.allow_get]
-        songs = []
-        for result in self.library.search(query, source_in=source_in):
-            logger.debug('从 %s 搜索到 %d 首歌曲，取前 20 首',
-                         result.source, len(result.songs))
-            songs.extend(result.songs[:20])
-        logger.debug('总共搜索到 %d 首歌曲', len(songs))
-        return show_songs(songs)
+        results = []
+        for result in self.library.search(query, stype=stype, source_in=source_in):
+            if result.songs:
+                logger.debug(f'从 {result.source} 搜索到 {len(result.songs)} 条歌曲，取前 20 条')
+                results.extend(result.songs[:20])
+            if result.playlists:
+                logger.debug(f'从 {result.source} 搜索到 {len(result.playlists)} 张专辑，取前 20 条')
+                results.extend(result.playlists[:20])
+        logger.debug(f'总共搜索到 {len(results)} 条记录')
+        return show_results(results, stype)

--- a/fuocore/library.py
+++ b/fuocore/library.py
@@ -73,18 +73,18 @@ class Library(object):
             return iter(self._providers)
         return filter(lambda p: p.identifier in identifier_in, self.list())
 
-    def search(self, keyword, source_in=None, **kwargs):
-        """search song/artist/album by keyword
+    def search(self, keyword, stype=1, source_in=None, **kwargs):
+        """search song/artist/album/playlist by keyword
 
         - TODO: support search album or artist
         - TODO: support search with filters(by artist or by source)
 
         :param keyword: search keyword
-        :param source_id: None or provider identifier list
+        :param source_in: None or provider identifier list
         """
         for provider in self._filter(identifier_in=source_in):
             try:
-                result = provider.search(keyword=keyword)
+                result = provider.search(keyword=keyword, stype=stype, **kwargs)
             except Exception as e:
                 logger.exception(str(e))
                 logger.error('Search %s in %s failed.' % (keyword, provider))

--- a/fuocore/models.py
+++ b/fuocore/models.py
@@ -417,9 +417,9 @@ class SearchModel(BaseModel):
     class Meta:
         model_type = ModelType.dummy.value
 
-        # XXX: songs should be a empty list instead of None
-        # when there is not song.
-        fields = ['q', 'songs']
+        # XXX: songs/playlists should be a empty list instead of None
+        # when there is not result.
+        fields = ['q', 'songs', 'playlists']
         fields_no_get = ['q']
 
     def __str__(self):


### PR DESCRIPTION
目前只修改了cli部分，使用方法可以是fuo search jay --options type=playlist 去搜索歌单

但还只处理了网易云音乐插件，且由于部分修改对其他搜索场景未支持好，发出来主要探讨下方向等问题（需结合网易云音乐插件的相应PR）

考虑搜索这个使用场景，个人认为搜索歌单还是挺有必要的，下一步就可以去做播放歌单等，一方面可以方便的播放热门歌单，另外也可以不需要登录就能搜索到并播放自己的歌单。