### PR TITLE
fix app crash

### DIFF
--- a/feeluown/ui.py
+++ b/feeluown/ui.py
@@ -516,7 +516,7 @@ class Ui:
 
     def _play_mv(self):
         song = self._app.player.current_song
-        mv = song.mv
+        mv = song.mv if song else None
         if mv is not None:
             if mv.meta.support_multi_quality:
                 media, _ = mv.select_media()

--- a/feeluown/widgets/songs_table.py
+++ b/feeluown/widgets/songs_table.py
@@ -82,7 +82,7 @@ class SongsTableModel(QAbstractTableModel):
     def flags(self, index):
         song = index.data(Qt.UserRole)
         flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
-        if song.exists == ModelExistence.no or \
+        if song and song.exists == ModelExistence.no or \
            index.column() in (Column.source, Column.index, Column.duration):
             return Qt.ItemIsSelectable
         if index.column() == Column.song:


### PR DESCRIPTION
修复以下两种情况的客户端闪退：
1. 没有歌曲时点击下方的mv按钮，报错：

```
[2019-08-15 10:25:47,758 WARNING model_parser] : invalid model url
Traceback (most recent call last):
  File "/Users/hejl/JianGuo/FeelUOwn/feeluown/ui.py", line 519, in _play_mv
    mv = song.mv
AttributeError: 'NoneType' object has no attribute 'mv'
[1]    84428 abort      fuo
```

2. 在客户端的播放列表界面中，有正在播放的歌曲时，通过fuo clear命令删除歌曲列表:
```
[2019-08-15 10:32:58,304 WARNING model_parser] : invalid model url
Traceback (most recent call last):
  File "/Users/hejl/JianGuo/FeelUOwn/feeluown/widgets/songs_table.py", line 85, in flags
    if song.exists == ModelExistence.no or \
AttributeError: 'NoneType' object has no attribute 'exists'
[1]    84580 abort      fuo
```