### PR TITLE
fix a crash bug

### DIFF
--- a/fuocore/mpvplayer.py
+++ b/fuocore/mpvplayer.py
@@ -176,8 +176,9 @@ class MpvPlayer(AbstractPlayer):
 
     @position.setter
     def position(self, position):
-        self._mpv.seek(position, reference='absolute')
-        self._position = position
+        if self.current_song:
+            self._mpv.seek(position, reference='absolute')
+            self._position = position
 
     @AbstractPlayer.volume.setter
     def volume(self, value):
@@ -186,7 +187,7 @@ class MpvPlayer(AbstractPlayer):
 
     @property
     def video_format(self):
-        self._video_format
+        return self._video_format
 
     @video_format.setter
     def video_format(self, vformat):


### PR DESCRIPTION
修bug，当没有歌曲播放时，拖动进度条导致app会crash
```
(fuo)  ✘ hejl@hejldeIMAC  ~/JianGuo/FeelUOwn   master  fuo -ns
/usr/local/lib/python3.7/site-packages/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')
Traceback (most recent call last):
  File "/Users/hejl/JianGuo/FeelUOwn/feeluown/containers/player_control_panel.py", line 146, in <lambda>
    lambda value: setattr(player, 'position', value))
  File "/Users/hejl/JianGuo/FeelUOwn/fuocore/mpvplayer.py", line 179, in position
    self._mpv.seek(position, reference='absolute')
  File "/Users/hejl/JianGuo/FeelUOwn/mpv.py", line 649, in seek
    self.command('seek', amount, reference, precision)
  File "/Users/hejl/JianGuo/FeelUOwn/mpv.py", line 636, in command
    _mpv_command(self.handle, (c_char_p*len(args))(*args))
  File "/Users/hejl/JianGuo/FeelUOwn/mpv.py", line 110, in raise_for_ec
    raise ex(ec, *args)
SystemError: ('Error running mpv command', -12, (<MpvHandle object at 0x10e987a70>, <mpv.c_char_p_Array_5 object at 0x120d7fef0>))
[1]    83293 abort      fuo -ns
```