### PR TITLE
WIP: support json/plain output

### DIFF
--- a/fuocore/cmds/dumpers.py
+++ b/fuocore/cmds/dumpers.py
@@ -1,0 +1,116 @@
+from fuocore.excs import FuoException
+
+from .formatter import WideFormatter
+from .serializers import SONG, ARTIST, ALBUM, USER, PLAYLIST
+
+
+formatter = WideFormatter()
+fmt = formatter.format
+
+
+class DumpError(FuoException):
+    pass
+
+
+class SequenceDumper:
+    def dump(self, list_):
+        if not list_:
+            return ''
+        item0 = list_[0]
+        if isinstance(item0, dict):
+            uri_length = max(len(item['uri']) for item in list_)
+            dump_cls = ModelBaseDumper.get_dumper_cls(item0)
+            dumper = dump_cls(as_line=True, uri_length=uri_length)
+            text_list = []
+            for item in list_:
+                text_list.append(dumper.dump(item))
+            return '\n'.join(text_list)
+        # this may not happen
+        return '\n'.join(list_)
+
+
+class ModelBaseDumper:
+    _mapping = {}
+
+    def __init__(self, as_line=True, uri_length=None):
+        self._as_line = as_line
+        self._uri_length = uri_length
+
+    @classmethod
+    def get_dumper_cls(cls, json_):
+        type_ = json_.get('type')
+        if type_ is None:
+            raise DumpError("can't dump json without type key")
+        return cls._mapping[type_]
+
+    def dump(self, json_):
+        if self._as_line:
+            uri_length = self._uri_length
+            if uri_length is None:
+                uri_length = ''
+            text = fmt(self._line_fmt, uri_length=uri_length, **json_)
+        else:
+            key_length = max(len(key) for key in json_.keys()) + 1
+            text_list = []
+            tpl = '{key:>%d}:  {value}' % key_length
+            list_tpl = '{key:>%d}::' % (key_length - 1)
+            for key, value in json_.items():
+                if isinstance(value, dict):
+                    dumper_cls = ModelBaseDumper.get_dumper_cls(value)
+                    dumper = dumper_cls(as_line=True)
+                    value_text = dumper.dump(value)
+                    text_list.append(fmt(tpl, key=key, value=value_text))
+                elif isinstance(value, list):
+                    dumper = SequenceDumper()
+                    value_text = dumper.dump(value)
+                    text_list.append(fmt(list_tpl, key=key))
+                    if value_text:
+                        padding = ' ' * (key_length + 3)
+                        text_list.extend((padding + line
+                                          for line in value_text.split('\n')))
+                else:
+                    line = fmt(tpl, key=key, value=value)
+                    text_list.append(line)
+            text = '\n'.join(text_list)
+        return text
+
+
+class ModelDumperMeta(type):
+    def __new__(cls, name, bases, attrs):
+        Meta = attrs.pop('Meta', None)
+        klass = type.__new__(cls, name, bases, attrs)
+        if Meta:
+            line_fmt = getattr(Meta, 'line_fmt', [])
+            ModelBaseDumper._mapping[Meta.type_] = klass
+            klass._line_fmt = line_fmt
+        return klass
+
+
+class SongDumper(ModelBaseDumper, metaclass=ModelDumperMeta):
+    class Meta:
+        type_ = SONG
+        line_fmt = '{uri:{uri_length}}\t# {title:_18} - {artists_name:_20}'
+
+
+class AlbumDumper(ModelBaseDumper, metaclass=ModelDumperMeta):
+    class Meta:
+        type_ = ALBUM
+        line_fmt = '{uri:{uri_length}}\t# {name:_18} - {artists_name:_20}'
+
+
+class ArtistDumper(ModelBaseDumper, metaclass=ModelDumperMeta):
+    class Meta:
+        type_ = ARTIST
+        line_fmt = '{uri:{uri_length}}\t# {name:_40}'
+
+
+class PlaylistDumper(ModelBaseDumper, metaclass=ModelDumperMeta):
+    class Meta:
+        type_ = PLAYLIST
+        line_fmt = '{uri:{uri_length}}\t# {name:_40}'
+
+
+class UserDumper(ModelBaseDumper, metaclass=ModelDumperMeta):
+    class Meta:
+        type_ = USER
+        line_fmt = '{uri:{uri_length}}\t# {name:_40}'

--- a/fuocore/cmds/formatter.py
+++ b/fuocore/cmds/formatter.py
@@ -1,0 +1,66 @@
+from functools import lru_cache
+from string import Formatter
+
+
+widths = [
+    (126, 1), (159, 0), (687, 1), (710, 0), (711, 1),
+    (727, 0), (733, 1), (879, 0), (1154, 1), (1161, 0),
+    (4347, 1), (4447, 2), (7467, 1), (7521, 0), (8369, 1),
+    (8426, 0), (9000, 1), (9002, 2), (11021, 1), (12350, 2),
+    (12351, 1), (12438, 2), (12442, 0), (19893, 2), (19967, 1),
+    (55203, 2), (63743, 1), (64106, 2), (65039, 1), (65059, 0),
+    (65131, 2), (65279, 1), (65376, 2), (65500, 1), (65510, 2),
+    (120831, 1), (262141, 2), (1114109, 1),
+]
+
+
+@lru_cache(maxsize=1024)
+def char_len(c):
+    ord_code = ord(c)
+    if ord_code == 0xe or ord_code == 0xf:
+        return 0
+    for num, wid in widths:
+        if ord_code <= num:
+            return wid
+    return 1
+
+
+def _fit_text(text, length, filling=True):
+    assert 80 >= length >= 5
+
+    text_len = 0
+    len_index_map = {}
+    for i, c in enumerate(text):
+        text_len += char_len(c)
+        len_index_map[text_len] = i
+
+    if text_len <= length:
+        if filling:
+            return text + (length - text_len) * ' '
+        return text
+
+    remain = length - 1
+    if remain in len_index_map:
+        return text[:(len_index_map[remain] + 1)] + '…'
+    else:
+        return text[:(len_index_map[remain - 1] + 1)] + ' …'
+
+
+class WideFormatter(Formatter):
+    """
+    Custom string formatter that handles new format parameters:
+    '_': _fit_text(*, filling=False)
+    '+': _fit_text(*, filling=True)
+    """
+    @lru_cache(maxsize=1024)
+    def format(self, format_string, *args, **kwargs):
+        return super().vformat(format_string, args, kwargs)
+
+    @lru_cache(maxsize=1024)
+    def format_field(self, value, format_spec):
+        fmt_type = format_spec[0] if format_spec else None
+        if fmt_type == "_":
+            return _fit_text(value, int(format_spec[1:]), filling=False)
+        if fmt_type == "+":
+            return _fit_text(value, int(format_spec[1:]), filling=True)
+        return format(value, format_spec)

--- a/fuocore/cmds/serializers.py
+++ b/fuocore/cmds/serializers.py
@@ -1,0 +1,146 @@
+"""
+
+**brief**
+
+line, subset of fields_display::
+
+    fuo://local/songs/1  # title - artists - album
+
+json, only display fields::
+
+    {...}
+
+
+**detail**
+
+display, show all fields::
+
+    identifier:   1
+      provider:   local
+         title:   title
+         album:   fuo://lcaol/album  # name
+      artists::
+                  fuo://local/artists/1  # name
+                  fuo://local/artists/2  # name
+
+json, show all fields::
+
+    {...}
+"""
+
+from fuocore.models import BaseModel, SongModel, ArtistModel, AlbumModel, \
+    PlaylistModel, UserModel
+
+
+SONG = 'song'
+ARTIST = 'artist'
+ALBUM = 'album'
+USER = 'user'
+PLAYLIST = 'playlist'
+
+
+class AbstractSerializer:
+    def serialize(self, obj):
+        pass
+
+
+class SequenceSerializer:
+    """list/tuple serializer
+
+    string/bytes is not in consideration
+    """
+
+    def serialize(self, obj):
+        if len(obj) > 0 and isinstance(obj[0], BaseModel):
+            serializer_cls = ModelBaseSerializer.get_serializer_cls(obj[0])
+            serializer = serializer_cls(brief=True, fetch=False)
+            value = [serializer.serialize(item) for item in obj]
+        else:
+            value = obj
+        return value
+
+
+class ModelBaseSerializer(AbstractSerializer):
+    _mapping = {}  # model serializer mapping
+
+    def __init__(self, brief=True, fetch=None, **kwargs):
+        self._brief = brief
+        self._fetch = fetch or not brief
+
+    def serialize(self, model):
+        json_ = {"provider": model.source,
+                 "type": self._type,
+                 "identifier": model.identifier,
+                 "uri": str(model)}
+
+        if self._brief:
+            fields = model.meta.fields_display
+        else:
+            fields = self._declared_fields
+        for field in fields:
+            obj = getattr(model, field if self._fetch else field + "_display")
+            if isinstance(obj, BaseModel):
+                serializer_cls = self.get_serializer_cls(obj)
+                serializer = serializer_cls(brief=True, fetch=False)
+                value = serializer.serialize(obj)
+            elif isinstance(obj, (list, tuple)):
+                serializer = SequenceSerializer()
+                value = serializer.serialize(obj)
+            else:
+                value = obj
+            json_[field] = value
+        return json_
+
+    @classmethod
+    def get_serializer_cls(cls, obj):
+        for model_cls, serializer_cls in cls._mapping.items():
+            if isinstance(obj, model_cls):
+                return serializer_cls
+        return None
+
+
+class ModelSerializerMeta(type):
+    def __new__(cls, name, bases, attrs):
+        Meta = attrs.pop('Meta', None)
+        klass = type.__new__(cls, name, bases, attrs)
+        if Meta:  # we assume
+            fields = getattr(Meta, 'fields', [])
+            ModelBaseSerializer._mapping[Meta.model] = klass
+            klass._declared_fields = fields
+            klass._type = Meta.type_
+        return klass
+
+
+class SongSerializer(ModelBaseSerializer, metaclass=ModelSerializerMeta):
+    class Meta:
+        type_ = SONG
+        model = SongModel
+        fields = ('title', 'duration', 'url', 'artists', 'album')
+
+
+class ArtistSerializer(ModelBaseSerializer, metaclass=ModelSerializerMeta):
+    class Meta:
+        type_ = ARTIST
+        model = ArtistModel
+        fields = ('name', 'songs')
+
+
+class AlbumSerializer(ModelBaseSerializer, metaclass=ModelSerializerMeta):
+    class Meta:
+        type_ = ALBUM
+        model = AlbumModel
+        fields = ('name', 'artists', 'songs')
+
+
+class PlaylistSerializer(ModelBaseSerializer, metaclass=ModelSerializerMeta):
+    class Meta:
+        type_ = PLAYLIST
+        model = PlaylistModel
+        fields = ('name', )
+
+
+class UserSerializer(ModelBaseSerializer, metaclass=ModelSerializerMeta):
+    class Meta:
+        type_ = USER
+        model = UserModel
+        fields = ('name', 'playlists')


### PR DESCRIPTION
## 使用姿势

```python
from serializers import serialize

def serialize(format, obj, **kwargs):
    """

    if we can't find serializer for object, raise SerializeError("object is not serializable")
    """

providers = library.list_provider()
# 需要注意的是，这里需要能指定 List 里面的类型
text = serialize('plain', provider)


song = provider.Song.get(1)
json_ = serialize('json', song)
```

```python
def serialize(format, obj, **options):
    """

    Usage::

        # serialize song
        # real use case: fuo show fuo://local/songs/1
        serialize('plain', song)
        serialize('plain', song, brief=False, fetch=True)
        serialize('plain', song, brief=False, fetch=False)

        # serialize song to a single line
        # real use case: fuo play fuo://local/songs/1
        serialize('plain', song, as_line=True)
        serialize('plain', song, as_line=True, fetch=True)

        # serialize songs
        # real use case: fuo show fuo://local/playlist/1/songs
        #   currently, this should never fetch each song detail,
        #   even we set fetch to True.
        serialize('plain', songs)

        # serialize song in json format
        serialize('json', song)
        serialize('json', song, brief=False, fetch=True)

        # serialize list of provider
        serialize('json', providers)

    **Options**

    - fields options: `brief`, `fetch`
    - format options: `as_line`
    """
    serializer = get_serializer(format)()

```

## 关于 Serializer 和 Dumper 是否合并的问题

假设不合并，在处理一个非 BaseModel 类型的对象时，会比较难办。以 provider 为例

```python
class Provider:
     identifier = 'local'
     name = 'Local'
     auth = user     

# 转成 dict 就是 
{"identifier": "local", "name: "Local", "auth": "fuo://local/users/1"}

# 转成 dict 后，按照第一个 commit 的设计，Dumper 将无法 dump 这个东西？
```
### 子问题：为什么量子老师的 PR 不会出现类似问题？

量子老师在 model 上实现了 `to_dict` 和 `to_str`，所以遇到 provider 这种非 model 对象的时候。它只要实现 to_dict 和 to_str 就好了，后续的 dumper 只需要处理它产生的结果就好了。所以对于上面这个 case，是没有问题的。我理解，隐藏在这个设计后面，有一个含义，只有一层会知道原始对象的细节，也就是 model 层。

在这个 PR 中，会有两层知道对象的细节，serializer 和 dumper。所以就有重复代码，并且需要 type 来标识 dict 的类型。

### 关于 django-rest 等 serializer 的实现为什么要声明 field，而这里没有？
这里依赖 `isinstance(obj, BaseModel)` 来判断类型，如果是 BaseModel，就可以找 ModelSerializer 来处理。所以，当我们的 serializer 要处理其它类型时，就会比较傻。首先需要用 isinstance 来判断 field 类型，然后找 Serializer，而 django 等标准的 serializer 则是声明式的。

## 性能

简单的测试性能的脚本

```python
import time
from pprint import pprint
from fuo_netease import provider
from fuocore.cmds.serializers import SongSerializer, SequenceSerializer
from fuocore.cmds.dumpers import SongDumper, SequenceDumper


pl = provider.Playlist.get(6771804)
songs = list(pl.create_songs_g())
json_ = SequenceSerializer().serialize(songs)
start = time.time()
text = SequenceDumper().dump(json_)
# print(text)
print(f'songs count:{len(songs)}, {time.time() - start}')
```

serialize + dump 时间总共大概在 0.2-0.3s 区间。

