### PR TITLE
feat: add serializers for model

### DIFF
--- a/fuocore/serializers/__init__.py
+++ b/fuocore/serializers/__init__.py
@@ -6,6 +6,8 @@
 #    Provider: ProviderSerializer,
 # }
 #
+import json
+
 _MAPPING = {}
 
 
@@ -24,7 +26,7 @@ def get_serializer(format):
     return _MAPPING.get(format)
 
 
-def serialize(format, obj, **options):
+def serialize(format, obj, dump=False, **options):
     """
 
     Usage::
@@ -59,8 +61,11 @@ def serialize(format, obj, **options):
     - format related options: `as_line`
     """
     serializer = get_serializer(format)(**options)
-    return serializer.serialize(obj)
+    result = serializer.serialize(obj)
+    if dump and format == 'json':
+        return json.dumps(result, indent=4)
+    return result
 
 
-from .plain import PlainSerializer
-from .json import JsonSerializer
+from .plain import PlainSerializer  # noqa
+from .json_ import JsonSerializer  # noqa

--- a/fuocore/serializers/__init__.py
+++ b/fuocore/serializers/__init__.py
@@ -1,13 +1,11 @@
-# ObjectType Serializer mapping
+from .base import SerializerError
+
+# format Serializer mapping, like::
 #
 # {
-#    int:  XSerializer,
-#    BaseModel: ModelSerializer,
-#    Provider: ProviderSerializer,
+#    'json':  JsonSerializer,
+#    'plain': PlainSerializer
 # }
-#
-import json
-
 _MAPPING = {}
 
 
@@ -23,10 +21,12 @@ def _load_serializers():
 def get_serializer(format):
     if not _MAPPING:
         _load_serializers()
+    if format not in _MAPPING:
+        raise SerializerError("Serializer for format:{} not found".format(format))
     return _MAPPING.get(format)
 
 
-def serialize(format, obj, dump=False, **options):
+def serialize(format, obj, **options):
     """
 
     Usage::
@@ -34,12 +34,9 @@ def serialize(format, obj, dump=False, **options):
         # serialize song
         # real use case: fuo show fuo://local/songs/1
         serialize('plain', song)
-        serialize('plain', song, brief=False, fetch=True)
-        serialize('plain', song, brief=False, fetch=False)
 
         # serialize song to a single line
         # real use case: fuo play fuo://local/songs/1
-        serialize('plain', song, as_line=True)
         serialize('plain', song, as_line=True, fetch=True)
 
         # serialize songs
@@ -47,10 +44,6 @@ def serialize(format, obj, dump=False, **options):
         #   currently, this should never fetch each song detail,
         #   even we set fetch to True.
         serialize('plain', songs)
-
-        # serialize song in json format
-        serialize('json', song)
-        serialize('json', song, brief=False, fetch=True)
 
         # serialize list of provider
         serialize('json', providers)
@@ -61,10 +54,7 @@ def serialize(format, obj, dump=False, **options):
     - format related options: `as_line`
     """
     serializer = get_serializer(format)(**options)
-    result = serializer.serialize(obj)
-    if dump and format == 'json':
-        return json.dumps(result, indent=4)
-    return result
+    return serializer.serialize(obj)
 
 
 from .plain import PlainSerializer  # noqa

--- a/fuocore/serializers/__init__.py
+++ b/fuocore/serializers/__init__.py
@@ -27,31 +27,17 @@ def get_serializer(format):
 
 
 def serialize(format, obj, **options):
-    """
+    """serialize python object defined in fuocore package
+
+    :raises SerializerError:
 
     Usage::
 
-        # serialize song
-        # real use case: fuo show fuo://local/songs/1
-        serialize('plain', song)
-
-        # serialize song to a single line
-        # real use case: fuo play fuo://local/songs/1
+        serialize('plain', song, as_line=True)
         serialize('plain', song, as_line=True, fetch=True)
-
-        # serialize songs
-        # real use case: fuo show fuo://local/playlist/1/songs
-        #   currently, this should never fetch each song detail,
-        #   even we set fetch to True.
-        serialize('plain', songs)
-
-        # serialize list of provider
+        serialize('json', songs, indent=4)
+        serialize('json', songs, indent=4, fetch=True)
         serialize('json', providers)
-
-    **Options**
-
-    - fields related options: `brief`, `fetch`
-    - format related options: `as_line`
     """
     serializer = get_serializer(format)(**options)
     return serializer.serialize(obj)

--- a/fuocore/serializers/__init__.py
+++ b/fuocore/serializers/__init__.py
@@ -1,0 +1,66 @@
+# ObjectType Serializer mapping
+#
+# {
+#    int:  XSerializer,
+#    BaseModel: ModelSerializer,
+#    Provider: ProviderSerializer,
+# }
+#
+_MAPPING = {}
+
+
+def register_serializer(type_, serializer_cls):
+    _MAPPING[type_] = serializer_cls
+
+
+def _load_serializers():
+    register_serializer('plain', PlainSerializer)
+    register_serializer('json', JsonSerializer)
+
+
+def get_serializer(format):
+    if not _MAPPING:
+        _load_serializers()
+    return _MAPPING.get(format)
+
+
+def serialize(format, obj, **options):
+    """
+
+    Usage::
+
+        # serialize song
+        # real use case: fuo show fuo://local/songs/1
+        serialize('plain', song)
+        serialize('plain', song, brief=False, fetch=True)
+        serialize('plain', song, brief=False, fetch=False)
+
+        # serialize song to a single line
+        # real use case: fuo play fuo://local/songs/1
+        serialize('plain', song, as_line=True)
+        serialize('plain', song, as_line=True, fetch=True)
+
+        # serialize songs
+        # real use case: fuo show fuo://local/playlist/1/songs
+        #   currently, this should never fetch each song detail,
+        #   even we set fetch to True.
+        serialize('plain', songs)
+
+        # serialize song in json format
+        serialize('json', song)
+        serialize('json', song, brief=False, fetch=True)
+
+        # serialize list of provider
+        serialize('json', providers)
+
+    **Options**
+
+    - fields related options: `brief`, `fetch`
+    - format related options: `as_line`
+    """
+    serializer = get_serializer(format)(**options)
+    return serializer.serialize(obj)
+
+
+from .plain import PlainSerializer
+from .json import JsonSerializer

--- a/fuocore/serializers/_plain_formatter.py
+++ b/fuocore/serializers/_plain_formatter.py
@@ -52,7 +52,12 @@ class WideFormatter(Formatter):
     '+': _fit_text(*, filling=True)
     """
 
+    def format(self, format_string, *args, **kwargs):
+        return super().vformat(format_string, args, kwargs)
+
     def format_field(self, value, format_spec):
+        if value is None:
+            value = 'null'
         fmt_type = format_spec[0] if format_spec else None
         if fmt_type == "_":
             return _fit_text(value, int(format_spec[1:]), filling=False)

--- a/fuocore/serializers/_plain_formatter.py
+++ b/fuocore/serializers/_plain_formatter.py
@@ -1,7 +1,9 @@
+from bisect import bisect
 from string import Formatter
 
 
 widths = [
+    (0, 1),
     (126, 1), (159, 0), (687, 1), (710, 0), (711, 1),
     (727, 0), (733, 1), (879, 0), (1154, 1), (1161, 0),
     (4347, 1), (4447, 2), (7467, 1), (7521, 0), (8369, 1),
@@ -11,16 +13,15 @@ widths = [
     (65131, 2), (65279, 1), (65376, 2), (65500, 1), (65510, 2),
     (120831, 1), (262141, 2), (1114109, 1),
 ]
+points = [w[0] for w in widths]
 
 
 def char_len(c):
     ord_code = ord(c)
     if ord_code == 0xe or ord_code == 0xf:
         return 0
-    for num, wid in widths:
-        if ord_code <= num:
-            return wid
-    return 1
+    i = bisect(points, ord_code)
+    return widths[i][1]
 
 
 def _fit_text(text, length, filling=True):
@@ -51,13 +52,10 @@ class WideFormatter(Formatter):
     '+': _fit_text(*, filling=True)
     """
 
-    def format(self, format_string, *args, **kwargs):
-        return super().vformat(format_string, args, kwargs)
-
     def format_field(self, value, format_spec):
         fmt_type = format_spec[0] if format_spec else None
         if fmt_type == "_":
             return _fit_text(value, int(format_spec[1:]), filling=False)
-        if fmt_type == "+":
+        elif fmt_type == "+":
             return _fit_text(value, int(format_spec[1:]), filling=True)
-        return format(value, format_spec)
+        return super().format_field(value, format_spec)

--- a/fuocore/serializers/_plain_formatter.py
+++ b/fuocore/serializers/_plain_formatter.py
@@ -1,0 +1,63 @@
+from string import Formatter
+
+
+widths = [
+    (126, 1), (159, 0), (687, 1), (710, 0), (711, 1),
+    (727, 0), (733, 1), (879, 0), (1154, 1), (1161, 0),
+    (4347, 1), (4447, 2), (7467, 1), (7521, 0), (8369, 1),
+    (8426, 0), (9000, 1), (9002, 2), (11021, 1), (12350, 2),
+    (12351, 1), (12438, 2), (12442, 0), (19893, 2), (19967, 1),
+    (55203, 2), (63743, 1), (64106, 2), (65039, 1), (65059, 0),
+    (65131, 2), (65279, 1), (65376, 2), (65500, 1), (65510, 2),
+    (120831, 1), (262141, 2), (1114109, 1),
+]
+
+
+def char_len(c):
+    ord_code = ord(c)
+    if ord_code == 0xe or ord_code == 0xf:
+        return 0
+    for num, wid in widths:
+        if ord_code <= num:
+            return wid
+    return 1
+
+
+def _fit_text(text, length, filling=True):
+    assert 80 >= length >= 5
+
+    text_len = 0
+    len_index_map = {}
+    for i, c in enumerate(text):
+        text_len += char_len(c)
+        len_index_map[text_len] = i
+
+    if text_len <= length:
+        if filling:
+            return text + (length - text_len) * ' '
+        return text
+
+    remain = length - 1
+    if remain in len_index_map:
+        return text[:(len_index_map[remain] + 1)] + '…'
+    else:
+        return text[:(len_index_map[remain - 1] + 1)] + ' …'
+
+
+class WideFormatter(Formatter):
+    """
+    Custom string formatter that handles new format parameters:
+    '_': _fit_text(*, filling=False)
+    '+': _fit_text(*, filling=True)
+    """
+
+    def format(self, format_string, *args, **kwargs):
+        return super().vformat(format_string, args, kwargs)
+
+    def format_field(self, value, format_spec):
+        fmt_type = format_spec[0] if format_spec else None
+        if fmt_type == "_":
+            return _fit_text(value, int(format_spec[1:]), filling=False)
+        if fmt_type == "+":
+            return _fit_text(value, int(format_spec[1:]), filling=True)
+        return format(value, format_spec)

--- a/fuocore/serializers/base.py
+++ b/fuocore/serializers/base.py
@@ -1,0 +1,45 @@
+class Serializer:
+    def __init__(self, **options):
+        self.options = options
+        self.options['as_line'] = options.get('as_line', True)
+        self.options['brief'] = options.get('brief', True)
+        self.options['fetch'] = options.get('fetch', False)
+
+    def serialize(self, obj):
+        serializer_cls = self.get_serializer_cls(obj)
+        return serializer_cls(**self.options).serialize(obj)
+
+    @classmethod
+    def get_serializer_cls(cls, model):
+        for model_cls, serialize_cls in cls._mapping.items():
+            if isinstance(model, model_cls):
+                return serialize_cls
+        # TODO: raise error here.
+
+
+class SerializerMeta(type):
+    def __new__(cls, name, bases, attrs):
+        """magic
+
+        TODO: add comments and error handling
+        """
+        Meta = attrs.pop('Meta', None)
+        mapping = attrs.pop('_mapping', None)
+        for base in bases:
+            if Meta is None and hasattr(base, 'Meta'):
+                Meta = base.Meta
+            if mapping is None and hasattr(base, '_mapping'):
+                mapping = base._mapping
+        klass = type.__new__(cls, name, bases, attrs)
+        if Meta:
+            for type_ in Meta.types:
+                mapping[type_] = klass
+            fields = getattr(Meta, 'fields', None)
+            if fields is not None:
+                klass._declared_fields = fields
+
+            # ModelPlainSerializer can have line_fmt attribute
+            line_fmt = getattr(Meta, 'line_fmt', None)
+            if line_fmt is not None:
+                klass._line_fmt = line_fmt
+        return klass

--- a/fuocore/serializers/base.py
+++ b/fuocore/serializers/base.py
@@ -1,3 +1,11 @@
+class InvalidOptionsCombination(Exception):
+    pass
+
+
+class SerializerError(Exception):
+    pass
+
+
 class Serializer:
     def __init__(self, **options):
         self.options = options
@@ -14,7 +22,7 @@ class Serializer:
         for model_cls, serialize_cls in cls._mapping.items():
             if isinstance(model, model_cls):
                 return serialize_cls
-        # TODO: raise error here.
+        raise SerializerError("no serializer for {}".format(model))
 
 
 class SerializerMeta(type):

--- a/fuocore/serializers/base.py
+++ b/fuocore/serializers/base.py
@@ -1,17 +1,53 @@
-class InvalidOptionsCombination(Exception):
-    pass
-
-
 class SerializerError(Exception):
+    """
+    this error will be raised when
+
+    * Serializer initialization faield
+    * Serializer not found
+    * Serializer serialization failed
+    """
     pass
 
 
 class Serializer:
+    """Serializer abstract base class
+
+    The subclass MUST has an class attribute `_mapping` if we want to
+    get_serializer_cls method, it should store the mapping relation
+    between Object-Class and Serializer-Class.
+    For example::
+
+        {
+            int: IntSerializer,
+            SongModel: ModelSerializer,
+        }
+
+    the subclass also should implement `serialize` method.
+
+    See JsonSerializer for more details.
+    """
+
     def __init__(self, **options):
+        """
+        Subclass should validate and parse options by themselves, here,
+        we list three commonly used options.
+
+        as_line is a *format* option:
+
+        - as_line: line format of a object (mainly designed for PlainSerializer)
+
+        brief and fetch are *representation* options:
+
+        - brief: a minimum human readable representation of the object.
+          we hope that people can *identify which object it is* through
+          this representation.
+          For example, if an object has ten attributes, this representation
+          may only contain three attributes.
+
+        - fetch: if this option is specified, the attribute value
+          should be authoritative.
+        """
         self.options = options
-        self.options['as_line'] = options.get('as_line', True)
-        self.options['brief'] = options.get('brief', True)
-        self.options['fetch'] = options.get('fetch', False)
 
     def serialize(self, obj):
         serializer_cls = self.get_serializer_cls(obj)

--- a/fuocore/serializers/json.py
+++ b/fuocore/serializers/json.py
@@ -1,7 +1,7 @@
 import json
 
 from .base import Serializer, SerializerMeta
-from .model_helpers import serialize_model, SongSerializerMixin, \
+from .model_helpers import ModelSerializerMixin, SongSerializerMixin, \
     ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
     UserSerializerMixin
 
@@ -10,27 +10,16 @@ class JsonSerializer(Serializer):
     _mapping = {}
 
 
-class ModelSerializer(JsonSerializer):
+class ModelSerializer(ModelSerializerMixin, JsonSerializer):
 
     def __init__(self, **options):
         super().__init__(**options)
 
-    def serialize(self, model):
-        # maybe we should add format option: `indent`,
-        # currently, use 4 as default should be good enough?
-        return serialize_model(model, self)
-
-    def setup(self):
+    def setup(self, model, fields):
         self._json = {}
-
-    def before_handle_field(self, model, fields):
-        pass
 
     def handle_field(self, field, value):
         self._json[field] = value
-
-    def after_handle_field(self, model, fields):
-        pass
 
     def get_result(self):
         return self._json

--- a/fuocore/serializers/json.py
+++ b/fuocore/serializers/json.py
@@ -1,0 +1,88 @@
+import json
+
+from .base import Serializer, SerializerMeta
+from .model_helpers import serialize_model, SongSerializerMixin, \
+    ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
+    UserSerializerMixin
+
+
+class JsonSerializer(Serializer):
+    _mapping = {}
+
+
+class ModelSerializer(JsonSerializer):
+
+    def __init__(self, **options):
+        super().__init__(**options)
+
+    def serialize(self, model):
+        # maybe we should add format option: `indent`,
+        # currently, use 4 as default should be good enough?
+        return serialize_model(model, self)
+
+    def setup(self):
+        self._json = {}
+
+    def before_handle_field(self, model, fields):
+        pass
+
+    def handle_field(self, field, value):
+        self._json[field] = value
+
+    def after_handle_field(self, model, fields):
+        pass
+
+    def get_result(self):
+        return self._json
+
+    def teardown(self):
+        del self._json
+
+
+class ListSerializer(JsonSerializer, metaclass=SerializerMeta):
+    class Meta:
+        types = (list, )
+
+    def serialize(self, list_):
+        if not list_:
+            return []
+        item0 = list_[0]
+        serializer_cls = JsonSerializer.get_serializer_cls(item0)
+        serializer = serializer_cls(brief=True, fetch=False)
+        result = []
+        for item in list_:
+            result.append(serializer.serialize(item))
+        return result
+
+
+class SimpleTypePlainSerializer(JsonSerializer, metaclass=SerializerMeta):
+    class Meta:
+        types = (str, int, float)
+
+    def serialize(self, object):
+        return object
+
+
+class SongSerializer(ModelSerializer, SongSerializerMixin,
+                     metaclass=SerializerMeta):
+    pass
+
+
+class ArtistSerializer(ModelSerializer, ArtistSerializerMixin,
+                       metaclass=SerializerMeta):
+    pass
+
+
+class AlbumSerializer(ModelSerializer, AlbumSerializerMixin,
+                      metaclass=SerializerMeta):
+    pass
+
+
+class PlaylistSerializer(ModelSerializer, PlaylistSerializerMixin,
+                         metaclass=SerializerMeta):
+    pass
+
+
+class UserSerializer(ModelSerializer, UserSerializerMixin,
+                     metaclass=SerializerMeta):
+    pass

--- a/fuocore/serializers/json_.py
+++ b/fuocore/serializers/json_.py
@@ -4,6 +4,16 @@ from .python import PythonSerializer
 
 class JsonSerializer(PythonSerializer):
 
+    def __init__(self, **options):
+        dump_options_keys = ['skipkeys', 'ensure_ascii', 'check_circular',
+                             'allow_nan', 'cls', 'indent', 'separators',
+                             'default', 'sort_keys', ]
+        self.dump_options = {}
+        for key in dump_options_keys:
+            if key in options:
+                self.dump_options[key] = options.pop(key)
+        super().__init__(**options)
+
     def serialize(self, obj):
         dict_ = super().serialize(obj)
-        return json.dumps(dict_)
+        return json.dumps(dict_, **self.dump_options)

--- a/fuocore/serializers/json_.py
+++ b/fuocore/serializers/json_.py
@@ -1,76 +1,9 @@
-from .base import Serializer, SerializerMeta, InvalidOptionsCombination
-from .model_helpers import ModelSerializerMixin, SongSerializerMixin, \
-    ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
-    UserSerializerMixin
+import json
+from .python import PythonSerializer
 
 
-class JsonSerializer(Serializer):
-    _mapping = {}
+class JsonSerializer(PythonSerializer):
 
-
-class ModelSerializer(JsonSerializer, ModelSerializerMixin):
-
-    def __init__(self, **options):
-        if options.get('brief') is False and options.get('fetch') is False:
-            raise InvalidOptionsCombination(
-                "fetch can't be False when brief is False")
-        super().__init__(**options)
-        if self.options['brief'] is False:
-            self.options['fetch'] = True
-
-    def serialize(self, model):
-        json_ = {}
-        for field, value in self._get_items(model):
-            serializer_cls = self.get_serializer_cls(value)
-            value_json = serializer_cls(brief=True, fetch=False).serialize(value)
-            json_[field] = value_json
-        return json_
-
-
-class ListSerializer(JsonSerializer, metaclass=SerializerMeta):
-    class Meta:
-        types = (list, )
-
-    def serialize(self, list_):
-        if not list_:
-            return []
-        item0 = list_[0]
-        serializer_cls = JsonSerializer.get_serializer_cls(item0)
-        serializer = serializer_cls(brief=True, fetch=False)
-        result = []
-        for item in list_:
-            result.append(serializer.serialize(item))
-        return result
-
-
-class SimpleTypePlainSerializer(JsonSerializer, metaclass=SerializerMeta):
-    class Meta:
-        types = (str, int, float)
-
-    def serialize(self, object):
-        return object
-
-
-class SongSerializer(ModelSerializer, SongSerializerMixin,
-                     metaclass=SerializerMeta):
-    pass
-
-
-class ArtistSerializer(ModelSerializer, ArtistSerializerMixin,
-                       metaclass=SerializerMeta):
-    pass
-
-
-class AlbumSerializer(ModelSerializer, AlbumSerializerMixin,
-                      metaclass=SerializerMeta):
-    pass
-
-
-class PlaylistSerializer(ModelSerializer, PlaylistSerializerMixin,
-                         metaclass=SerializerMeta):
-    pass
-
-
-class UserSerializer(ModelSerializer, UserSerializerMixin,
-                     metaclass=SerializerMeta):
-    pass
+    def serialize(self, obj):
+        dict_ = super().serialize(obj)
+        return json.dumps(dict_)

--- a/fuocore/serializers/model_helpers.py
+++ b/fuocore/serializers/model_helpers.py
@@ -1,0 +1,95 @@
+from fuocore.models import BaseModel, SongModel, ArtistModel, \
+    AlbumModel, PlaylistModel, UserModel
+
+
+def serialize_model(model, root_serializer):
+    #
+    # setup root_serializer
+    #
+    root_serializer.setup()
+
+    # initialize fields that need to be serialized
+    # if as_line option is set, we always use fields_display
+    if root_serializer.options['as_line'] or root_serializer.options['brief']:
+        fields = model.meta.fields_display
+    else:
+        fields = root_serializer._declared_fields
+
+    # keep the fields order
+    common_fields = ['provider', 'identifier', 'uri']
+    all_fields = common_fields + list(fields)
+
+    #
+    # before handle each field
+    #
+    root_serializer.before_handle_field(model, all_fields)
+
+    #
+    # handle each field
+    #
+    store = {"provider": model.source,
+             "identifier": model.identifier,
+             "uri": str(model)}
+    for field in fields:
+        obj = getattr(
+            model,
+            field if root_serializer.options['fetch'] else field + "_display"
+        )
+        store[field] = obj
+    for field, value in store.items():
+        serializer_cls = root_serializer.get_serializer_cls(value)
+        serializer = serializer_cls(brief=True,
+                                    fetch=False,
+                                    as_line=True)
+        value = serializer.serialize(value)
+        root_serializer.handle_field(field, value)
+
+    #
+    # after handle each field
+    #
+    root_serializer.after_handle_field(model, all_fields)
+
+    # TODO: use streaming if root_serializer support
+    # Theoretically, yaml and plain root_serializer support streaming
+    result = root_serializer.get_result()
+
+    #
+    # do some cleanup
+    #
+    root_serializer.teardown()
+    return result
+
+
+class SongSerializerMixin:
+    class Meta:
+        types = (SongModel, )
+        fields = ('title', 'duration', 'url', 'artists', 'album')
+        line_fmt = '{uri:{uri_length}}\t# {title:_18} - {artists_name:_20}'
+
+
+class ArtistSerializerMixin:
+    class Meta:
+        types = (ArtistModel, )
+        fields = ('name', 'songs')
+        line_fmt = '{uri:{uri_length}}\t# {name:_40}'
+
+
+class AlbumSerializerMixin:
+    class Meta:
+        types = (AlbumModel, )
+        fields = ('name', 'artists', 'songs')
+        line_fmt = '{uri:{uri_length}}\t# {name:_18} - {artists_name:_20}'
+
+
+class PlaylistSerializerMixin:
+    class Meta:
+        types = (PlaylistModel, )
+        fields = ('name', )
+        line_fmt = '{uri:{uri_length}}\t# {name:_40}'
+
+
+class UserSerializerMixin:
+    class Meta:
+        types = (UserModel, )
+        fields = ('name', 'playlists')
+        line_fmt = '{uri:{uri_length}}\t# {name:_40}'

--- a/fuocore/serializers/model_helpers.py
+++ b/fuocore/serializers/model_helpers.py
@@ -11,14 +11,14 @@ class ModelSerializerMixin:
     def _get_items(self, model):
         # initialize fields that need to be serialized
         # if as_line option is set, we always use fields_display
-        if self.options['as_line'] or self.options['brief']:
+        if self.options.get('as_line') or self.options.get('brief'):
             fields = model.meta.fields_display
         else:
             fields = self._declared_fields
         items = [("provider", model.source),
                  ("identifier", model.identifier),
                  ("uri", str(model))]
-        if self.options['fetch']:
+        if self.options.get('fetch'):
             for field in fields:
                 items.append((field, getattr(model, field)))
         else:

--- a/fuocore/serializers/model_helpers.py
+++ b/fuocore/serializers/model_helpers.py
@@ -7,60 +7,31 @@ simple_fields = set({'title', 'duration', 'url',
 
 
 class ModelSerializerMixin:
-    def serialize(self, model):
+
+    def _get_items(self, model):
         # initialize fields that need to be serialized
         # if as_line option is set, we always use fields_display
         if self.options['as_line'] or self.options['brief']:
             fields = model.meta.fields_display
-            are_display_fields = True
         else:
             fields = self._declared_fields
-            are_display_fields = False
-
-        # keep the fields order
-        common_fields = ['provider', 'identifier', 'uri']
-        all_fields = common_fields + list(fields)
-
-        #
-        # setup self
-        #
-        self.setup(model, all_fields)
-
-        #
-        # handle each field
-        #
-        # perf: since we know these fields will not change after serialization,
-        # so we handle them directly
-        self.handle_field("provider", model.source)
-        self.handle_field("identifier", model.identifier)
-        self.handle_field("uri", str(model))
-        for field in fields:
-            if are_display_fields is True:
-                value = getattr(model, field + "_display")
-                # perf: display field's value is a string, handle them directly
-                self.handle_field(field, value)
-            else:
-                value = getattr(model, field)
-                serializer_cls = self.get_serializer_cls(value)
-                serializer = serializer_cls(brief=True, fetch=False, as_line=True)
-                value = serializer.serialize(value)
-                self.handle_field(field, value)
-
-        # TODO: use streaming if self support
-        # Theoretically, yaml and plain self support streaming
-        result = self.get_result()
-
-        #
-        # do some cleanup
-        #
-        self.teardown()
-        return result
+        items = [("provider", model.source),
+                 ("identifier", model.identifier),
+                 ("uri", str(model))]
+        if self.options['fetch']:
+            for field in fields:
+                items.append((field, getattr(model, field)))
+        else:
+            for field in fields:
+                items.append((field, getattr(model, field + '_display')))
+        return items
 
 
 class SongSerializerMixin:
     class Meta:
         types = (SongModel, )
-        fields = ('title', 'duration', 'url', 'artists', 'album')
+        # since url can be too long, we put it at last
+        fields = ('title', 'duration', 'album', 'artists', 'url')
         line_fmt = '{uri:{uri_length}}\t# {title:_18} - {artists_name:_20}'
 
 

--- a/fuocore/serializers/plain.py
+++ b/fuocore/serializers/plain.py
@@ -1,0 +1,141 @@
+"""
+Usage::
+
+    serializer = PlainSerializer(**options)
+    text = serializer.serialize(model)
+
+    song_serializer = SongPlainSerializer(**options)
+    text = song_serializer.serialize(model)
+"""
+
+from .base import Serializer, SerializerMeta
+from .model_helpers import serialize_model, SongSerializerMixin, \
+    ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
+    UserSerializerMixin
+from ._plain_formatter import WideFormatter
+
+formatter = WideFormatter()
+fmt = formatter.format
+
+
+class PlainSerializer(Serializer):
+    _mapping = {}
+
+
+class ModelSerializer(PlainSerializer):
+
+    def __init__(self, **options):
+        super().__init__(**options)
+
+        # format options
+        self._as_line = options.get('as_line', True)
+        self._uri_length = options.get('uri_length', '')
+
+    def serialize(self, model):
+        return serialize_model(model, self)
+
+    def setup(self):
+        if self._as_line:
+            self._store = {}
+        else:
+            self._key_length = None
+            self._text_list = []
+            self._normal_field_tpl = None
+            self._list_field_tpl = None
+
+    def before_handle_field(self, model, fields):
+        if not self._as_line:
+            key_length = max(len(key) for key in fields) + 1
+            self._key_length = key_length
+            self._normal_field_tpl = '{key:>%d}:  {value}' % key_length
+            self._list_field_tpl = '{key:>%d}::' % (key_length - 1)
+
+    def handle_field(self, field, value):
+        if self._as_line:
+            self._store[field] = value
+        else:
+            if isinstance(value, list):
+                # append key
+                text = fmt(self._list_field_tpl, key=field)
+                self._text_list.append(text)
+                # append value
+                if value:
+                    padding = ' ' * (self._key_length + 3)
+                    self._text_list.extend(
+                        (padding + line for line in value.split('\n')))
+            else:
+                text = fmt(self._normal_field_tpl, key=field, value=value)
+                self._text_list.append(text)
+
+    def after_handle_field(self, model, fields):
+        pass
+
+    def get_result(self):
+        if self._as_line:
+            return fmt(self._line_fmt,
+                       uri_length=self._uri_length,
+                       **self._store)
+        return '\n'.join(self._text_list)
+
+    def teardown(self):
+        if self._as_line:
+            del self._store
+        else:
+            del self._key_length
+            del self._text_list
+            del self._normal_field_tpl
+            del self._list_field_tpl
+
+
+class SimpleTypePlainSerializer(PlainSerializer, metaclass=SerializerMeta):
+    class Meta:
+        types = (str, int, float)
+
+    def serialize(self, object):
+        return object
+
+
+class ListPlainSerializer(PlainSerializer, metaclass=SerializerMeta):
+    class Meta:
+        types = (list, )
+
+    def serialize(self, list_):
+        if not list_:
+            return ''
+        item0 = list_[0]
+        serializer_cls = PlainSerializer.get_serializer_cls(item0)
+        if isinstance(serializer_cls, ModelSerializer):
+            # FIXME: use reverse
+            uri_length = max(len(str(item)) for item in list_)
+            serializer = serializer_cls(as_line=True, uri_length=uri_length)
+        else:
+            serializer = serializer_cls(as_line=True)
+        text_list = []
+        for item in list_:
+            text_list.append(serializer.serialize(item))
+        return '\n'.join(text_list)
+
+
+class SongSerializer(ModelSerializer, SongSerializerMixin,
+                     metaclass=SerializerMeta):
+    pass
+
+
+class ArtistSerializer(ModelSerializer, ArtistSerializerMixin,
+                       metaclass=SerializerMeta):
+    pass
+
+
+class AlbumSerializer(ModelSerializer, AlbumSerializerMixin,
+                      metaclass=SerializerMeta):
+    pass
+
+
+class PlaylistSerializer(ModelSerializer, PlaylistSerializerMixin,
+                         metaclass=SerializerMeta):
+    pass
+
+
+class UserSerializer(ModelSerializer, UserSerializerMixin,
+                     metaclass=SerializerMeta):
+    pass

--- a/fuocore/serializers/plain.py
+++ b/fuocore/serializers/plain.py
@@ -9,7 +9,7 @@ Usage::
 """
 
 from .base import Serializer, SerializerMeta
-from .model_helpers import serialize_model, SongSerializerMixin, \
+from .model_helpers import ModelSerializerMixin, SongSerializerMixin, \
     ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
     UserSerializerMixin
 from ._plain_formatter import WideFormatter
@@ -22,7 +22,7 @@ class PlainSerializer(Serializer):
     _mapping = {}
 
 
-class ModelSerializer(PlainSerializer):
+class ModelSerializer(ModelSerializerMixin, PlainSerializer):
 
     def __init__(self, **options):
         super().__init__(**options)
@@ -31,20 +31,10 @@ class ModelSerializer(PlainSerializer):
         self._as_line = options.get('as_line', True)
         self._uri_length = options.get('uri_length', '')
 
-    def serialize(self, model):
-        return serialize_model(model, self)
-
-    def setup(self):
+    def setup(self, model, fields):
         if self._as_line:
             self._store = {}
         else:
-            self._key_length = None
-            self._text_list = []
-            self._normal_field_tpl = None
-            self._list_field_tpl = None
-
-    def before_handle_field(self, model, fields):
-        if not self._as_line:
             key_length = max(len(key) for key in fields) + 1
             self._key_length = key_length
             self._normal_field_tpl = '{key:>%d}:  {value}' % key_length
@@ -66,9 +56,6 @@ class ModelSerializer(PlainSerializer):
             else:
                 text = fmt(self._normal_field_tpl, key=field, value=value)
                 self._text_list.append(text)
-
-    def after_handle_field(self, model, fields):
-        pass
 
     def get_result(self):
         if self._as_line:

--- a/fuocore/serializers/plain.py
+++ b/fuocore/serializers/plain.py
@@ -1,15 +1,5 @@
-"""
-Usage::
-
-    serializer = PlainSerializer(**options)
-    text = serializer.serialize(model)
-
-    song_serializer = SongPlainSerializer(**options)
-    text = song_serializer.serialize(model)
-"""
-
 from textwrap import indent
-from .base import Serializer, SerializerMeta, InvalidOptionsCombination
+from .base import Serializer, SerializerMeta, SerializerError
 from .model_helpers import ModelSerializerMixin, SongSerializerMixin, \
     ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
     UserSerializerMixin
@@ -30,16 +20,19 @@ class ModelSerializer(PlainSerializer, ModelSerializerMixin):
         if all([options.get('as_line') is False,
                 options.get('brief') is False,
                 options.get('fetch') is False]):
-            raise InvalidOptionsCombination(
+            raise SerializerError(
                     "as_line, brief, fetch can't be false at same time")
         if options.get('as_line') is True and options.get('brief') is False:
-            raise InvalidOptionsCombination(
+            raise SerializerError(
                 "brief can't be False when as_line is True")
         if options.get('brief') is False and options.get('fetch') is False:
-            raise InvalidOptionsCombination(
+            raise SerializerError(
                 "fetch can't be False when brief is False")
 
         super().__init__(**options)
+        self.options['as_line'] = options.get('as_line', True)
+        self.options['brief'] = options.get('brief', True)
+        self.options['fetch'] = options.get('fetch', False)
 
         self._as_line = options.get('as_line', True)
         if self._as_line is True:
@@ -49,13 +42,15 @@ class ModelSerializer(PlainSerializer, ModelSerializerMixin):
         self._uri_length = options.get('uri_length', '')
 
     def serialize(self, model):
+        """serialize a model"""
+
         items = self._get_items(model)
         if self._as_line:
             return fmt(self._line_fmt, uri_length=self._uri_length, **dict(items))
 
-        key_length = max(len(key) for key, _ in items) + 1
-        normal_field_tpl = '{key:>%d}:  {value}' % key_length
-        list_field_tpl = '{key:>%d}::' % (key_length - 1)
+        key_length = max(len(key) for key, _ in items)
+        normal_field_tpl = '{key:>%d}:  {value}' % (key_length + 1)
+        list_field_tpl = '{key:>%d}::' % (key_length)
         text_list = []
         for field, value in items:
             if isinstance(value, list):
@@ -66,9 +61,10 @@ class ModelSerializer(PlainSerializer, ModelSerializerMixin):
                 if value:
                     serialize_cls = self.get_serializer_cls(value)
                     value_text = serialize_cls(fetch=False).serialize(value)
-                    text_list.append(indent(value_text, ' ' * (key_length + 3)))
+                    text_list.append(indent(value_text, ' ' * (key_length + 4)))
             else:
                 serialize_cls = self.get_serializer_cls(value)
+                # field value should be formatted as one line
                 value_text = serialize_cls(as_line=True, fetch=False).serialize(value)
                 text = fmt(normal_field_tpl, key=field, value=value_text)
                 text_list.append(text)
@@ -77,10 +73,12 @@ class ModelSerializer(PlainSerializer, ModelSerializerMixin):
 
 class SimpleTypePlainSerializer(PlainSerializer, metaclass=SerializerMeta):
     class Meta:
-        types = (str, int, float)
+        types = (str, int, float, type(None))
 
     def serialize(self, object):
-        return object
+        if object is None:
+            return 'null'
+        return str(object)
 
 
 class ListPlainSerializer(PlainSerializer, metaclass=SerializerMeta):
@@ -98,6 +96,7 @@ class ListPlainSerializer(PlainSerializer, metaclass=SerializerMeta):
             serializer = serializer_cls(as_line=True, fetch=False,
                                         uri_length=uri_length)
         else:
+            # list item should be formatted as one line
             serializer = serializer_cls(as_line=True, fetch=False)
         text_list = []
         for item in list_:

--- a/fuocore/serializers/plain.py
+++ b/fuocore/serializers/plain.py
@@ -8,7 +8,8 @@ Usage::
     text = song_serializer.serialize(model)
 """
 
-from .base import Serializer, SerializerMeta
+from textwrap import indent
+from .base import Serializer, SerializerMeta, InvalidOptionsCombination
 from .model_helpers import ModelSerializerMixin, SongSerializerMixin, \
     ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
     UserSerializerMixin
@@ -22,56 +23,56 @@ class PlainSerializer(Serializer):
     _mapping = {}
 
 
-class ModelSerializer(ModelSerializerMixin, PlainSerializer):
+class ModelSerializer(PlainSerializer, ModelSerializerMixin):
 
     def __init__(self, **options):
+        # do some validation
+        if all([options.get('as_line') is False,
+                options.get('brief') is False,
+                options.get('fetch') is False]):
+            raise InvalidOptionsCombination(
+                    "as_line, brief, fetch can't be false at same time")
+        if options.get('as_line') is True and options.get('brief') is False:
+            raise InvalidOptionsCombination(
+                "brief can't be False when as_line is True")
+        if options.get('brief') is False and options.get('fetch') is False:
+            raise InvalidOptionsCombination(
+                "fetch can't be False when brief is False")
+
         super().__init__(**options)
 
-        # format options
         self._as_line = options.get('as_line', True)
+        if self._as_line is True:
+            self.options['brief'] = True
+        if self.options['brief'] is False:
+            self.options['fetch'] = True
         self._uri_length = options.get('uri_length', '')
 
-    def setup(self, model, fields):
+    def serialize(self, model):
+        items = self._get_items(model)
         if self._as_line:
-            self._store = {}
-        else:
-            key_length = max(len(key) for key in fields) + 1
-            self._key_length = key_length
-            self._normal_field_tpl = '{key:>%d}:  {value}' % key_length
-            self._list_field_tpl = '{key:>%d}::' % (key_length - 1)
+            return fmt(self._line_fmt, uri_length=self._uri_length, **dict(items))
 
-    def handle_field(self, field, value):
-        if self._as_line:
-            self._store[field] = value
-        else:
+        key_length = max(len(key) for key, _ in items) + 1
+        normal_field_tpl = '{key:>%d}:  {value}' % key_length
+        list_field_tpl = '{key:>%d}::' % (key_length - 1)
+        text_list = []
+        for field, value in items:
             if isinstance(value, list):
                 # append key
-                text = fmt(self._list_field_tpl, key=field)
-                self._text_list.append(text)
-                # append value
+                text = fmt(list_field_tpl, key=field)
+                text_list.append(text)
+                # append value with indent
                 if value:
-                    padding = ' ' * (self._key_length + 3)
-                    self._text_list.extend(
-                        (padding + line for line in value.split('\n')))
+                    serialize_cls = self.get_serializer_cls(value)
+                    value_text = serialize_cls(fetch=False).serialize(value)
+                    text_list.append(indent(value_text, ' ' * (key_length + 3)))
             else:
-                text = fmt(self._normal_field_tpl, key=field, value=value)
-                self._text_list.append(text)
-
-    def get_result(self):
-        if self._as_line:
-            return fmt(self._line_fmt,
-                       uri_length=self._uri_length,
-                       **self._store)
-        return '\n'.join(self._text_list)
-
-    def teardown(self):
-        if self._as_line:
-            del self._store
-        else:
-            del self._key_length
-            del self._text_list
-            del self._normal_field_tpl
-            del self._list_field_tpl
+                serialize_cls = self.get_serializer_cls(value)
+                value_text = serialize_cls(as_line=True, fetch=False).serialize(value)
+                text = fmt(normal_field_tpl, key=field, value=value_text)
+                text_list.append(text)
+        return '\n'.join(text_list)
 
 
 class SimpleTypePlainSerializer(PlainSerializer, metaclass=SerializerMeta):
@@ -94,9 +95,10 @@ class ListPlainSerializer(PlainSerializer, metaclass=SerializerMeta):
         if isinstance(serializer_cls, ModelSerializer):
             # FIXME: use reverse
             uri_length = max(len(str(item)) for item in list_)
-            serializer = serializer_cls(as_line=True, uri_length=uri_length)
+            serializer = serializer_cls(as_line=True, fetch=False,
+                                        uri_length=uri_length)
         else:
-            serializer = serializer_cls(as_line=True)
+            serializer = serializer_cls(as_line=True, fetch=False)
         text_list = []
         for item in list_:
             text_list.append(serializer.serialize(item))

--- a/fuocore/serializers/python.py
+++ b/fuocore/serializers/python.py
@@ -1,0 +1,81 @@
+from .base import Serializer, SerializerMeta, SerializerError
+from .model_helpers import ModelSerializerMixin, SongSerializerMixin, \
+    ArtistSerializerMixin, AlbumSerializerMixin, PlaylistSerializerMixin, \
+    UserSerializerMixin
+
+
+class PythonSerializer(Serializer):
+    _mapping = {}
+
+
+class ModelSerializer(PythonSerializer, ModelSerializerMixin):
+
+    def __init__(self, **options):
+        if options.get('brief') is False and options.get('fetch') is False:
+            raise SerializerError(
+                "fetch can't be False when brief is False")
+
+        super().__init__(**options)
+        self.options['as_line'] = options.get('as_line', False)
+        self.options['brief'] = options.get('brief', True)
+        self.options['fetch'] = options.get('fetch', False)
+
+        if self.options['brief'] is False:
+            self.options['fetch'] = True
+
+    def serialize(self, model):
+        dict_ = {}
+        for field, value in self._get_items(model):
+            serializer_cls = self.get_serializer_cls(value)
+            value_dict = serializer_cls(brief=True, fetch=False).serialize(value)
+            dict_[field] = value_dict
+        return dict_
+
+
+class ListSerializer(PythonSerializer, metaclass=SerializerMeta):
+    class Meta:
+        types = (list, )
+
+    def serialize(self, list_):
+        if not list_:
+            return []
+        item0 = list_[0]
+        serializer_cls = PythonSerializer.get_serializer_cls(item0)
+        serializer = serializer_cls(brief=True, fetch=False)
+        result = []
+        for item in list_:
+            result.append(serializer.serialize(item))
+        return result
+
+
+class SimpleTypePlainSerializer(PythonSerializer, metaclass=SerializerMeta):
+    class Meta:
+        types = (str, int, float, type(None))
+
+    def serialize(self, object):
+        return object
+
+
+class SongSerializer(ModelSerializer, SongSerializerMixin,
+                     metaclass=SerializerMeta):
+    pass
+
+
+class ArtistSerializer(ModelSerializer, ArtistSerializerMixin,
+                       metaclass=SerializerMeta):
+    pass
+
+
+class AlbumSerializer(ModelSerializer, AlbumSerializerMixin,
+                      metaclass=SerializerMeta):
+    pass
+
+
+class PlaylistSerializer(ModelSerializer, PlaylistSerializerMixin,
+                         metaclass=SerializerMeta):
+    pass
+
+
+class UserSerializer(ModelSerializer, UserSerializerMixin,
+                     metaclass=SerializerMeta):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     ],
     # FIXME depends on PyQt5
     install_requires=[
-        'quamash>=0.5.5',
+        # 'quamash>=0.5.5',
         'janus',
         'requests',
         'pyopengl',


### PR DESCRIPTION
**Usage**

```python
from fuocore.serializers import serialize
song = ...
print(serialize('json', song))
```

**简介**

这个 PR 是 json-output 的第三个 PR。

个人认为第一个 PR 存在的问题有两个
1. serializer 相关逻辑和 model 放在一起，理论上感觉分开比较好
2. model.to_dict 和 serializer 这两层可以合并

个人认为第二个 PR 存在的问题有一个
1. serializer 和 dumper 逻辑重复

**其它**
1. 这个 PR 只实现了 serializers，需要配合第一个 PR 的一些逻辑才能真正工作
2. 这个 PR 的性能比第二个似乎差一些，serialize 4k 首歌，大概 0.23s 左右，第二个 PR 0.15s 左右，第一个 PR 没缓存时 0.3s 左右，有缓存时 0.13s 左右
