### PR TITLE
feat:support fuo file metadata storage

### DIFF
--- a/feeluown/collection.py
+++ b/feeluown/collection.py
@@ -17,7 +17,7 @@ DEFAULT_COLL_ALBUMS = 'Albums'
 SONGS_FILENAME = 'Songs.fuo'
 ALBUMS_FILENAME = 'Albums.fuo'
 
-TOML_DELIMLF = "+ + +\n"
+TOML_DELIMLF = "+++\n"
 
 
 class CollectionType(Enum):

--- a/fuocore/models/uri.py
+++ b/fuocore/models/uri.py
@@ -63,16 +63,6 @@ class Resolver:
         cls.loop = asyncio.get_event_loop()
 
 
-# def _model_unescape(model_str):
-#     # \- => -
-#     return model_str.replace('\\-', '-').replace('\\\\', '\\')
-#
-#
-# def _model_escape(model_str):
-#     # - => \-
-#     return model_str.replace('\\', '\\\\').replace('-', '\\-')
-#
-
 def _field_unescape(filed: str) -> str:
     # '"\" \" \\"' => '" " \'
     if len(filed) >= 2 and filed.startswith('"') and filed.endswith('"'):
@@ -86,20 +76,6 @@ def _field_escape(filed: str) -> str:
         filed = filed.replace('\\', '\\\\').replace('"', '\\"')
         return '"{}"'.format(filed)
     return filed
-
-
-# def _split(s, num):
-#     # 这里使用'- '的原因是为了解决:无网络条件下无法获取在线歌曲时长,
-#     # 导致写出格式存在问题,之前的_split无法解析下列异常情况
-#     # 'fuo://xiami/songs/1769834090	# Flower Dance - DJ OKAWARI -  -'
-#     # FIXME:修改写入部分的代码,而不是hack parse 过程
-#     DELIMITER = ' -'
-#     values = s.split(DELIMITER)
-#     values = [v.strip() for v in values]
-#     current = len(values)
-#     if current < num:
-#         values.extend([''] * (num - current))
-#     return values
 
 
 def _split(s: str, num: int) -> list:
@@ -125,7 +101,7 @@ def _split(s: str, num: int) -> list:
                 continue
             # 针对含有空白字段"Flower Dance - DJ OKAWARI -  - 4:23"
             if ch == '-':
-                fields.append("")
+                fields.append('""')
                 continue
             if ch == '"':
                 parse_state = ParseState.parse_quoted_filed
@@ -160,7 +136,7 @@ def _split(s: str, num: int) -> list:
             + 'but get {} fields:\n{}'.format(current, fields))
 
         if current < num:
-            fields.extend([''] * (num - current))
+            fields.extend(['""'] * (num - current))
 
     return fields
 
@@ -276,7 +252,7 @@ def do_reverse(fields: list) -> str:
         if not field:
             field = '""'
         line += _field_escape(field.strip()) + ' - '
-    line += fields[-1] if fields[-1] else ' '
+    line += fields[-1] if fields[-1] else '""'
     return line
 
 

--- a/fuocore/models/uri.py
+++ b/fuocore/models/uri.py
@@ -18,6 +18,8 @@ Currently, there is not way to achieve this.
 
 import asyncio
 import re
+import logging
+from enum import Enum
 
 from fuocore.models import ModelType, ModelExistence
 from fuocore.provider import dummy_provider
@@ -61,28 +63,106 @@ class Resolver:
         cls.loop = asyncio.get_event_loop()
 
 
-def _model_unescape(model_str):
-    # \- => -
-    return model_str.replace('\\-', '-').replace('\\\\', '\\')
+# def _model_unescape(model_str):
+#     # \- => -
+#     return model_str.replace('\\-', '-').replace('\\\\', '\\')
+#
+#
+# def _model_escape(model_str):
+#     # - => \-
+#     return model_str.replace('\\', '\\\\').replace('-', '\\-')
+#
+
+def _field_unescape(filed: str) -> str:
+    # '"\" \" \\"' => '" " \'
+    if len(filed) >= 2 and filed.startswith('"') and filed.endswith('"'):
+        filed = filed.replace('\\"', '"').replace('\\\\', '\\')
+    return filed
 
 
-def _model_escape(model_str):
-    # - => \-
-    return model_str.replace('\\', '\\\\').replace('-', '\\-')
+def _field_escape(filed: str) -> str:
+    # 如果字段中存在'-',则进行转义
+    if filed.find('-') != -1:
+        filed = filed.replace('\\', '\\\\').replace('"', '\\"')
+        return '"{}"'.format(filed)
+    return filed
 
 
-def _split(s, num):
-    # 这里使用'- '的原因是为了解决:无网络条件下无法获取在线歌曲时长,
-    # 导致写出格式存在问题,之前的_split无法解析下列异常情况
-    # 'fuo://xiami/songs/1769834090	# Flower Dance - DJ OKAWARI -  -'
-    # FIXME:修改写入部分的代码,而不是hack parse 过程
-    DELIMITER = ' -'
-    values = s.split(DELIMITER)
-    values = [v.strip() for v in values]
-    current = len(values)
-    if current < num:
-        values.extend([''] * (num - current))
-    return values
+# def _split(s, num):
+#     # 这里使用'- '的原因是为了解决:无网络条件下无法获取在线歌曲时长,
+#     # 导致写出格式存在问题,之前的_split无法解析下列异常情况
+#     # 'fuo://xiami/songs/1769834090	# Flower Dance - DJ OKAWARI -  -'
+#     # FIXME:修改写入部分的代码,而不是hack parse 过程
+#     DELIMITER = ' -'
+#     values = s.split(DELIMITER)
+#     values = [v.strip() for v in values]
+#     current = len(values)
+#     if current < num:
+#         values.extend([''] * (num - current))
+#     return values
+
+
+def _split(s: str, num: int) -> list:
+    class ParseState(Enum):
+        # 寻找下一个字段
+        find_next_filed = 0
+        # 解析字段
+        parse_normal_filed = 1
+        # 解析转义字段
+        parse_quoted_filed = 2
+        # 解析分隔符
+        parse_delimiter = 3
+
+    # filed1 - filed2 - filed3 - "filed4"
+    parse_state = ParseState.find_next_filed
+
+    fields = []
+    field = ""
+    # TODO:修复类似这样的解析"Flower Dance - DJ OKAWARI -  - "
+    # 特别注意这种形式"Flower Dance - DJ OKAWARI -  - 4:23"
+    # 中间字段的空白可能导致解析错位
+    s += '\n'
+    for ch in s:
+        if parse_state is ParseState.find_next_filed:
+            if ch == ' ' or ch == '\n':
+                continue
+            if ch == '"':
+                parse_state = ParseState.parse_quoted_filed
+            else:
+                parse_state = ParseState.parse_normal_filed
+                field += ch
+        elif parse_state is ParseState.parse_normal_filed:
+            if ch == '\n':
+                fields.append(field)
+                field = ""
+            elif ch == '-':
+                # TODO:去除末尾空格
+                fields.append(field)
+                field = ""
+                parse_state = ParseState.find_next_filed
+            else:
+                field += ch
+        elif parse_state is ParseState.parse_quoted_filed:
+            if ch == '"':
+                fields.append(field)
+                field = ""
+                parse_state = ParseState.parse_delimiter
+            else:
+                field += ch
+        elif parse_state is ParseState.parse_delimiter:
+            if ch == '-':
+                parse_state = ParseState.find_next_filed
+    if len(fields) != num:
+        current = len(fields)
+
+        logging.warning(
+            '_split("{}") expect to get {} fields,'.format(s, num, )
+            + 'but get {} fields:\n{}'.format(current, fields))
+
+        if current < num:
+            fields.extend([''] * (num - current))
+
+    return fields
 
 
 def parse_song_str(song_str):
@@ -133,7 +213,6 @@ def parse_line(line):
     parts = line.split('#', maxsplit=1)
     if len(parts) == 2:
         uri, model_str = parts
-        model_str = _model_unescape(model_str)
     else:
         uri, model_str = parts[0], ''
     ns_list = list(TYPE_NS_MAP.values())
@@ -183,8 +262,22 @@ def resolve(line, model=None):
                 method_name = 'resolve_' + path.replace('/', '_')
                 handler = getattr(model, method_name)
                 return handler()
-        raise ResolverNotFound('resolver-not-found for {}/{}'.format(str(model), path))
+        raise ResolverNotFound(
+            'resolver-not-found for {}/{}'.format(str(model), path))
     return model
+
+
+def do_reverse(fields: list) -> str:
+    length = len(fields)
+    if length == 0:
+        return ""
+    line = ""
+    for field in fields[0:-1]:
+        if not field:
+            field = ' '
+        line += _field_escape(field) + ' - '
+    line += fields[-1] if fields[-1] else ' '
+    return line
 
 
 def reverse(model, path='', as_line=False):
@@ -200,23 +293,27 @@ def reverse(model, path='', as_line=False):
     if as_line:
         if model.meta.model_type == ModelType.song:
             song = model
-            model_str = '{} - {} - {} - {}'.format(
-                _model_escape(song.title_display),
-                _model_escape(song.artists_name_display),
-                _model_escape(song.album_name_display),
-                _model_escape(song.duration_ms_display)
+            model_str = do_reverse(
+                [
+                    song.title_display,
+                    song.artists_name_display,
+                    song.album_name_display,
+                    song.duration_ms_display
+                ]
             )
         elif model.meta.model_type == ModelType.album:
             album = model
-            model_str = '{} - {}'.format(
-                _model_escape(album.name_display),
-                _model_escape(album.artists_name_display)
+            model_str = do_reverse(
+                [
+                    album.name_display,
+                    album.artists_name_display
+                ]
             )
 
         elif model.meta.model_type == ModelType.artist:
             artist = model
-            model_str = '{}'.format(
-                _model_escape(artist.name_display)
+            model_str = do_reverse(
+                [artist.name_display]
             )
         else:
             model_str = ''

--- a/fuocore/models/uri.py
+++ b/fuocore/models/uri.py
@@ -72,6 +72,10 @@ def _model_escape(model_str):
 
 
 def _split(s, num):
+    # 这里使用'- '的原因是为了解决:无网络条件下无法获取在线歌曲时长,
+    # 导致写出格式存在问题,之前的_split无法解析下列异常情况
+    # 'fuo://xiami/songs/1769834090	# Flower Dance - DJ OKAWARI -  -'
+    # FIXME:修改写入部分的代码,而不是hack parse 过程
     DELIMITER = ' -'
     values = s.split(DELIMITER)
     values = [v.strip() for v in values]

--- a/fuocore/models/uri.py
+++ b/fuocore/models/uri.py
@@ -118,13 +118,14 @@ def _split(s: str, num: int) -> list:
 
     fields = []
     field = ""
-    # TODO:修复类似这样的解析"Flower Dance - DJ OKAWARI -  - "
-    # 特别注意这种形式"Flower Dance - DJ OKAWARI -  - 4:23"
-    # 中间字段的空白可能导致解析错位
     s += '\n'
     for ch in s:
         if parse_state is ParseState.find_next_filed:
             if ch == ' ' or ch == '\n':
+                continue
+            # 针对含有空白字段"Flower Dance - DJ OKAWARI -  - 4:23"
+            if ch == '-':
+                fields.append("")
                 continue
             if ch == '"':
                 parse_state = ParseState.parse_quoted_filed
@@ -136,8 +137,7 @@ def _split(s: str, num: int) -> list:
                 fields.append(field)
                 field = ""
             elif ch == '-':
-                # TODO:去除末尾空格
-                fields.append(field)
+                fields.append(field.lstrip())
                 field = ""
                 parse_state = ParseState.find_next_filed
             else:
@@ -274,8 +274,8 @@ def do_reverse(fields: list) -> str:
     line = ""
     for field in fields[0:-1]:
         if not field:
-            field = ' '
-        line += _field_escape(field) + ' - '
+            field = '""'
+        line += _field_escape(field.strip()) + ' - '
     line += fields[-1] if fields[-1] else ' '
     return line
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         'requests',
         'pyopengl',
         'qasync',
+        'toml',
     ],
     extras_require={
         'battery': ['fuo-local>=0.2.1',


### PR DESCRIPTION
 

#302 

## header

- header部分的数据格式暂定为toml
- 使用 `+++`来标识header的开始与结束

## body部分

问题主要出现在 '#'，'-' 这两个字符的解析上

-  '#'的处理方式,将第一个出现的'#'作为定界符,将后续的'#'视为正常字符
-  '-' 修改字段的解析方式

### 字段parse 和 dumps 的新方案

#### parse

- 放弃之前使用 `{space}-{space}`进行元素分割的方案,采用逐字段分割
- 遇到首字符为`"`的字段,意味着为转义字符串
    - `\"`\=> `"`,`\\`=>`\`
- 遇到非` `,意味着下一个字段是普通字符串(字面量)
- 遇到`\n`,解析结束

#### dumps

- 如果字段中存在`-`，首先将字段中出现的`"`进行转义然后在字段两端加上`"`,即 `filed` => `"filed"`
- 转义方案: `\`=>`\\` ,`"`=>`\"`
- 空字段处理方案:补一个空格上去,这里可能破坏原有格式的兼容性


### TODOS
- [x] 确认 header 格式，并实现相应的 load/dump 逻辑
- [x] fuo 文件支持解析 header 部分
- [x] 修改body部分的parse和dumps的逻辑
- [x] 支持更新fuo的header部分(仅支持updated_at字段的更新)
- [x] feeluown GUI 实现相应支持(仅支持updated_at、title字段)
- [ ] 修改测试用例
- [ ] 编写歌单迁移脚本