### PR TITLE
Fix mpris:artUrl as None breaks the dbus encoding

### DIFF
--- a/feeluown/linux/mpris2.py
+++ b/feeluown/linux/mpris2.py
@@ -118,7 +118,7 @@ class Mpris2Service(dbus.service.Object):
             'xesam:url': song.url,
             'mpris:length': dbus.Int64(song.duration*1000),
             'mpris:trackid': to_track_id(song),
-            'mpris:artUrl': song.album.cover if song.album else '',
+            'mpris:artUrl': (song.album.cover if song.album else '') or '',
             'xesam:album': song.album_name,
             'xesam:title': song.title,
         }, signature='sv'))


### PR DESCRIPTION
Fixes mpris2 status not updating for local source, since its being none is very common.
```
[2020-10-13 01:46:37,224 DEBUG __init__] : Registering callback <function _chain_future.<locals>._call_check_cancel at 0x7f52be075e50> to be invoked with arguments (<Future finished exception=TypeError('Don\'t know which D-Bus type to use to encode type "NoneType"') cb=[_chain_future.<locals>._call_check_cancel() at /usr/lib/python3.8/asyncio/futures.py:360]>,) after 0 second(s)
```