### PR TITLE
(WIP)[bugfix]修复歌词窗口的部分问题

### DIFF
--- a/feeluown/widgets/lyric.py
+++ b/feeluown/widgets/lyric.py
@@ -15,7 +15,8 @@ class Window(QWidget):
 
     def __init__(self):
         super().__init__(parent=None)
-        self.setWindowFlags(Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint)
+        self.setWindowFlags(
+            Qt.Tool | Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint)
         self.setAttribute(Qt.WA_TranslucentBackground)
         self.c = Container(self)
         self._layout = QVBoxLayout(self)


### PR DESCRIPTION
#413
## TODO
- [ ] 解决在kde上歌词窗口单独占了一项任务栏项
- [ ] 解决在窗口隐藏时，歌词窗口获取焦点导致GUI重新显示