### PR TITLE
improves UI for desktop lyrics widget

### DIFF
--- a/feeluown/widgets/lyric.py
+++ b/feeluown/widgets/lyric.py
@@ -19,10 +19,9 @@ class Window(QWidget):
     def __init__(self):
         super().__init__(parent=None)
         flags = self.windowFlags() | Qt.WindowStaysOnTopHint \
-            | Qt.FramelessWindowHint | Qt.ToolTip
+            | Qt.FramelessWindowHint | Qt.Tool | Qt.BypassWindowManagerHint
         self.setWindowFlags(flags)
         self.setAttribute(Qt.WA_TranslucentBackground)
-        self.setAttribute(Qt.WA_AlwaysShowToolTips)
         self.c = Container(self)
         self._layout = QVBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
- add fade-in & fade-out animation
- make lyrics widget not identified as a window
- focus the lyrics widget will not activate main window

@cosven need a test on macOS & Windows.