### PR TITLE
Fix goto() with only path

### DIFF
--- a/feeluown/browser.py
+++ b/feeluown/browser.py
@@ -44,14 +44,15 @@ class Browser:
     def goto(self, model=None, path=None, uri=None, query=None):
         """跳转到 model 页面或者具体的地址
 
-        必须提供 model 或者 uri 其中一个参数，都提供时，以 model 为准。
+        必须提供 model 或者 path 其中一个参数，都提供时，以 model 为准。
         """
         if uri is not None:
             warnings.warn('please use path instead of uri')
+            path = uri
         if query:
             qs = urlencode(query)
-            uri = (path or uri) + '?' + qs
-        self._goto(model, uri)
+            path = path + '?' + qs
+        self._goto(model, path)
         if self._last_uri is not None and self._last_uri != self.current_uri:
             self._back_stack.append(self._last_uri)
         self._forward_stack.clear()


### PR DESCRIPTION
The warning suggests to use path instead of uri, but if only path is specified (without a query), the following exception would be raised:

```
  File "/usr/lib/python3.8/site-packages/feeluown/browser.py", line 54, in goto
    self._goto(model, uri)
  File "/usr/lib/python3.8/site-packages/feeluown/browser.py", line 88, in _goto
    model = resolve(uri)
  File "/usr/lib/python3.8/site-packages/fuocore/models/uri.py", line 145, in resolve
    model, path = parse_line(line)
  File "/usr/lib/python3.8/site-packages/fuocore/models/uri.py", line 110, in parse_line
    line = line.strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

This change fixes this behavior, and also updated the docstring accordingly.