### PR TITLE
[Feature & Fix] Make song title rolling if it's too long

### DIFF
--- a/feeluown/containers/player_control_panel.py
+++ b/feeluown/containers/player_control_panel.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from PyQt5.QtCore import Qt, QTimer, QRect
-from PyQt5.QtGui import QFontMetrics, QPainter, QColorConstants
+from PyQt5.QtGui import QFontMetrics, QPainter
 from PyQt5.QtWidgets import (
     QApplication, QLabel, QFrame, QHBoxLayout, QVBoxLayout,
     QPushButton, QSizePolicy, QMenu,
@@ -31,7 +31,7 @@ class SongBriefLabel(QLabel):
 
         self._app = app
         self._timer = QTimer()
-        self._txt = self._raw_text = '...'
+        self._txt = self._raw_text = self.default_text
         self._font_metrics = QFontMetrics(QApplication.font())
         self._text_rect = self._font_metrics.boundingRect(self._raw_text)
         # text's position, keep changing to make text roll
@@ -72,7 +72,7 @@ class SongBriefLabel(QLabel):
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.setFont(QApplication.font())
-        painter.setPen(self.palette().color(self.palette().Text))
+        painter.setPen(self._app.palette().color(self._app.palette().Text))
 
         if self._timer.isActive():
             self._txt = self._raw_text

--- a/feeluown/containers/player_control_panel.py
+++ b/feeluown/containers/player_control_panel.py
@@ -44,6 +44,7 @@ class SongBriefLabel(QLabel):
             self.newX = 0
             return
         if self.text_rect.width() + self.newX > 0:
+            # control the speed of rolling
             self.newX -= 5
         else:
             self.newX = self.width()
@@ -57,6 +58,7 @@ class SongBriefLabel(QLabel):
 
     def enterEvent(self, event):
         if self.txt != self.raw_text:
+            # decrease to make rolling more fluent
             self.t.start(150)
 
     def leaveEvent(self, event):


### PR DESCRIPTION
- Long song title (longer than song_title_label 's width) will scroll when cursor is on it.
- Fix some small problems caused by long song title, such as window will be stretched a little wider when change to a song with long name.
- Increase the width of position_label and duration_label to make them can be fully displayed.