### PR TITLE
gui: add page/model

### DIFF
--- a/feeluown/app.py
+++ b/feeluown/app.py
@@ -78,7 +78,7 @@ class App:
                     songs.append(song)
             playlist.init_from(songs)
             if songs and self.mode & App.GuiMode:
-                self.browser.goto(uri='/player_playlist')
+                self.browser.goto(page='/player_playlist')
 
             song = state['song']
 

--- a/feeluown/containers/left_panel.py
+++ b/feeluown/containers/left_panel.py
@@ -137,4 +137,4 @@ class _LeftPanel(QFrame):
 
     def show_coll(self, coll):
         coll_id = self._app.coll_uimgr.get_coll_id(coll)
-        self._app.browser.goto(uri='/colls/{}'.format(coll_id))
+        self._app.browser.goto(page='/colls/{}'.format(coll_id))

--- a/feeluown/gui/browser.py
+++ b/feeluown/gui/browser.py
@@ -8,7 +8,7 @@ from PyQt5.QtGui import QKeySequence
 
 from feeluown.utils import aio
 from feeluown.utils.router import Router, NotFound
-from feeluown.models.uri import resolve, reverse, ResolveFailed
+from feeluown.models.uri import resolve, reverse, ResolveFailed, parse_line
 
 logger = logging.getLogger(__name__)
 
@@ -45,18 +45,37 @@ class Browser:
         """跳转到 model 页面或者具体的地址
 
         必须提供 model 或者 path 其中一个参数，都提供时，以 model 为准。
+
+        Typical usage::
+
+            goto(model=model, path=path, query=xxx)
+            goto(uri=uri, query=xxx)
         """
-        if uri is not None:
-            warnings.warn('please use path instead of uri')
-            path = uri
         if query:
             qs = urlencode(query)
-            path = path + '?' + qs
-        self._goto(model, path)
-        if self._last_uri is not None and self._last_uri != self.current_uri:
-            self._back_stack.append(self._last_uri)
-        self._forward_stack.clear()
-        self.on_history_changed()
+        else:
+            qs = ''
+        try:
+            if model is not None:
+                if qs:
+                    path = (path or '') + '?' + qs
+                self._goto_model(model, path)
+            else:
+                # old code use goto(path=uri)
+                uri = uri or path
+                if qs:
+                    uri = uri + '?' + qs
+                if not uri.startswith('fuo://'):
+                    warnings.warn(f'browser uri should start with fuo://, {uri}')
+                    uri = f'fuo://{uri}'
+                self._goto_uri(uri)
+        except NotFound:
+            self._app.show_msg('-> {uri} ...failed', timeout=1)
+        else:
+            if self._last_uri is not None and self._last_uri != self.current_uri:
+                self._back_stack.append(self._last_uri)
+            self._forward_stack.clear()
+            self.on_history_changed()
 
     def back(self):
         try:
@@ -64,7 +83,7 @@ class Browser:
         except IndexError:
             logger.warning("Can't go back.")
         else:
-            self._goto(uri=uri)
+            self._goto_uri(uri=uri)
             self._forward_stack.append(self._last_uri)
             self.on_history_changed()
 
@@ -74,7 +93,7 @@ class Browser:
         except IndexError:
             logger.warning("Can't go forward.")
         else:
-            self._goto(uri=uri)
+            self._goto_uri(uri=uri)
             self._back_stack.append(self._last_uri)
             self.on_history_changed()
 
@@ -82,33 +101,41 @@ class Browser:
         """路由装饰器 (alpha)"""
         return self.router.route(rule)
 
-    def _goto(self, model=None, uri=None):
-        """真正的跳转逻辑"""
-        if model is None:
+    def _goto_uri(self, uri):
+        assert uri.startswith('fuo://')
+        # see if the uri match the two special cases
+        # fuo:///models/<provider>/<ns>/<identifier>
+        # fuo://<provider>/<ns>/<identifier>
+        if uri.startswith('fuo:///models/') or not uri.startswith('fuo:///'):
             try:
-                model = resolve(uri)
+                # FIXME: resolve is temporarily too magic
+                model_uri = 'fuo://' + uri[14:]
+                model, path = parse_line(model_uri)
+                model = resolve(reverse(model))
             except ResolveFailed:
                 model = None
-        else:
-            uri = reverse(model)
-        if not uri.startswith('fuo://'):
-            uri = 'fuo://' + uri
-        with self._app.create_action('-> {}'.format(uri)) as action:
-            if model is not None:
-                self._render_model(model)
+                logger.warning(f'invalid browser model uri:{uri}')
             else:
-                try:
-                    x = self.router.dispatch(uri, {'app': self._app})
-                    if inspect.iscoroutine(x):
-                        aio.create_task(x)
-                except NotFound:
-                    action.failed(f'{uri} not found.')
-                    return
-        self._last_uri = self.current_uri
-        if model is not None:
-            self.current_uri = reverse(model)
+                return self._goto_model(model, path)
         else:
-            self.current_uri = uri
+            self._goto(uri, {'app': self._app})
+
+    def _goto_model(self, model, path=''):
+        path = path or ''
+        base_uri = 'fuo:///models/' + reverse(model)[6:]
+        if path:
+            uri = f'{base_uri}/{path}'
+        else:
+            uri = base_uri
+        self._goto(uri, {'app': self._app, 'model': model})
+
+    def _goto(self, uri, ctx):
+        x = self.router.dispatch(uri, ctx)
+        if inspect.iscoroutine(x):
+            aio.create_task(x)
+
+        self._last_uri = self.current_uri
+        self.current_uri = uri
 
     @property
     def can_back(self):
@@ -121,10 +148,6 @@ class Browser:
     # --------------
     # UI Controllers
     # --------------
-
-    def _render_model(self, model):
-        """渲染 model 页面"""
-        self._app.ui.right_panel.show_model(model)
 
     def _render_coll(self, _, identifier):
         coll = self._app.coll_uimgr.get(int(identifier))
@@ -143,12 +166,12 @@ class Browser:
 
         1. bind routes with handler
         """
-        from feeluown.gui.pages import (
-            render_search,
-            render_player_playlist,
-        )
+        from feeluown.gui.pages.search import render as render_search
+        from feeluown.gui.pages.player_playlist import render as render_player_playlist
+        from feeluown.gui.pages.model import render as render_model
 
         urlpatterns = [
+            ('/models/<provider>/<ns>/<identifier>', render_model),
             ('/colls/<identifier>', self._render_coll),
             ('/search', render_search),
             ('/player_playlist', render_player_playlist),

--- a/feeluown/gui/pages/__init__.py
+++ b/feeluown/gui/pages/__init__.py
@@ -1,8 +1,0 @@
-from .search import render as render_search
-from .player_playlist import render as render_player_playlist
-
-
-__all__ = (
-    'render_search',
-    'render_player_playlist',
-)

--- a/feeluown/gui/pages/model.py
+++ b/feeluown/gui/pages/model.py
@@ -1,0 +1,4 @@
+async def render(req, **kwargs):
+    app = req.ctx['app']
+    model = req.ctx['model']
+    app.ui.right_panel.show_model(model)

--- a/feeluown/gui/pages/search.py
+++ b/feeluown/gui/pages/search.py
@@ -102,7 +102,7 @@ class SearchResultRenderer(Renderer):
             source_in = self._app.browser.local_storage.get(KeySourceIn, None)
             if source_in is not None:
                 query['source_in'] = source_in
-            self._app.browser.goto(uri='/search', query=query)
+            self._app.browser.goto(page='/search', query=query)
         return cb
 
 

--- a/feeluown/gui/ui.py
+++ b/feeluown/gui/ui.py
@@ -52,7 +52,7 @@ class Ui:
         self.toggle_video_btn = self.pc_panel.toggle_video_btn
 
         self.pc_panel.playlist_btn.clicked.connect(
-            lambda: self._app.browser.goto(uri='/player_playlist'))
+            lambda: self._app.browser.goto(page='/player_playlist'))
 
         self._setup_ui()
 

--- a/feeluown/models/uri.py
+++ b/feeluown/models/uri.py
@@ -19,6 +19,7 @@ Currently, there is not way to achieve this.
 import asyncio
 import json
 import re
+import warnings
 
 from .base import ModelType, ModelExistence
 
@@ -258,7 +259,9 @@ def resolve(line, model=None):
             model = model_cls(model)
     else:
         path = line
+    # NOTE: the path resolve logic is deprecated
     if path:
+        warnings.warn('model path resolver will be removed')
         for path_ in model.meta.paths:
             if path_ == path:
                 method_name = 'resolve_' + path.replace('/', '_')

--- a/feeluown/widgets/magicbox.py
+++ b/feeluown/widgets/magicbox.py
@@ -116,7 +116,6 @@ class MagicBox(QLineEdit):
             self._exec_code(text[4:])
         else:
             local_storage = self._app.browser.local_storage
-            path = '/search'
             type_ = local_storage.get(KeyType)
             source_in = local_storage.get(KeySourceIn)
             query = {'q': text}
@@ -124,7 +123,7 @@ class MagicBox(QLineEdit):
                 query['type'] = type_
             if source_in is not None:
                 query['source_in'] = source_in
-            self._app.browser.goto(path=path, query=query)
+            self._app.browser.goto(page='/search', query=query)
 
     def __on_timeout(self):
         self._set_mode('cmd')

--- a/tests/feeluown/gui/test_browser.py
+++ b/tests/feeluown/gui/test_browser.py
@@ -1,0 +1,26 @@
+from unittest import mock
+from feeluown.gui.browser import Browser
+
+
+def test_browser_basic(app_mock, mocker, album):
+    mock_r_search = mocker.patch(
+        'feeluown.gui.pages.search.render', new=mock.MagicMock)
+    mock_r_model = mocker.patch(
+        'feeluown.gui.pages.model.render', new=mock.MagicMock)
+    mocker.patch('feeluown.gui.browser.resolve', return_value=album)
+
+    browser = Browser(app_mock)
+    browser.initialize()
+    browser.goto(page='/search')
+    # renderer should be called once
+    mock_r_search.assert_called
+
+    browser.goto(model=album)
+    mock_r_model.assert_called
+    # history should be saved
+    assert browser.can_back
+    browser.back()
+    assert browser.current_page == '/search'
+
+    browser.forward()
+    assert browser.current_page.startswith('/models/')


### PR DESCRIPTION
### Summary
之前，browser 渲染 model 走的不是 route/dispatch 这一套统一的逻辑，这给维护和扩展带来了许多额外成本。

### Details
在这个 PR 里面，我们做了如下几件事情
- [x] 给 model 的展示页单独一个 page：`/models/<provider>/<ns>/<identifier>`
 - [x] 将 goto 拆分为两类，代码逻辑 **相对** 更清晰

### Thinking
以后的可以进一步优化：
1. 将 model 的展示逻辑从 table container 中移动到 page/model 中来。不过这个事情不急

另外，也有一些正在思考的点：
1. browser 是对外提供一个 `goto` 接口，还是对外提供 `goto_model_page` 以及 `goto_page` 两个接口 🤔