### PR TITLE
docs: fix simple typo, siganl -> signal

### DIFF
--- a/feeluown/fuoexec.py
+++ b/feeluown/fuoexec.py
@@ -136,7 +136,7 @@ def add_hook(signal_symbol, func, use_symbol=False):
     """add hook on signal
 
     :param signal_symbol: app.{object}.{signal_name}
-    :param func: siganl callback function
+    :param func: signal callback function
 
     >>> def func(): pass
     >>> add_hook('app.initialized', func)


### PR DESCRIPTION
There is a small typo in feeluown/fuoexec.py.

Should read `signal` rather than `siganl`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md