### PR TITLE
Fix player critical bug

### DIFF
--- a/feeluown/player/base_player.py
+++ b/feeluown/player/base_player.py
@@ -191,7 +191,6 @@ class AbstractPlayer(metaclass=ABCMeta):
         """
         if song is not None:
             if media is None:
-                self._playlist.mark_as_bad(song)
                 self._playlist.next()
             else:
                 self.play(media)

--- a/feeluown/player/player.py
+++ b/feeluown/player/player.py
@@ -132,59 +132,45 @@ class Playlist(_Playlist):
         super().init_from(songs)
 
     async def a_set_current_song(self, song):
-        """
-        1. prepare media for song
-        2. if media is valid, just play it
-        3.
-        """
         song_str = f'song:{song.source}:{song.title_display}'
 
         task_spec = self._app.task_mgr.get_or_create('prepare-media')
-        is_bad_song = False
         try:
             media = await task_spec.bind_blocking_io(self.prepare_media, song)
         except MediaNotFound:
-            is_bad_song = True
-        except ProviderIOError:
-            logger.exception('prepare media failed')
-            # Try to play next song if the song is invalid
-            if self.next_song is song:
-                self.next()
+            logger.info(f'{song_str} has no valid media, mark it as bad')
+            self.mark_as_bad(song)
+
+            # if mode is fm mode, do not find standby song,
+            # just skip the song
+            if self.mode is not PlaylistMode.fm:
+                self._app.show_msg(f'{song_str} is invalid, try to find standby')
+                logger.info(f'try to find standby for {song_str}')
+                songs = await self._app.library.a_list_song_standby(song)
+                if songs:
+                    final_song = songs[0]
+                    logger.info('find song standby success: %s', final_song)
+                    # NOTE: a_list_song_standby ensure that the song.url is not empty
+                    # FIXME: maybe a_list_song_standby should return media directly
+                    self._set_current_song(final_song, final_song.url)
+                else:
+                    logger.info('find song standby failed: not found')
+                    final_song = song
+                    self._set_current_song(final_song, None)
             else:
-                media = None  # the song has
+                self.next()
+        except ProviderIOError as e:
+            # FIXME: This may cause infinite loop when the prepare media always fails
+            logger.error(f'prepare media failed: {e}, try next song')
+            self._set_current_song(song, None)
         except:  # noqa
-            # The failure may lead to infinite loop
             # When the exception is unknown, we mark the song as bad.
             logger.exception('prepare media failed due to unknown error, '
                              'so we mark the song as a bad one')
             self.mark_as_bad(song)
             self.next()
         else:
-            # The song is ok, and we just play it
             self._set_current_song(song, media)
-            return
-
-        logger.info(f'{song_str} has no valid media, mark it as bad')
-        self.mark_as_bad(song)
-
-        # if mode is fm mode, do not find standby song,
-        # just skip the song
-        if self.mode is not PlaylistMode.fm:
-            self._app.show_msg(f'{song_str} is invalid, try to find standby')
-            logger.info(f'try to find standby for {song_str}')
-            songs = await self._app.library.a_list_song_standby(song)
-            if songs:
-                final_song = songs[0]
-                logger.info('find song standby success: %s', final_song)
-                # NOTE: a_list_song_standby ensure that the song.url is not empty
-                # FIXME: maybe a_list_song_standby should return media directly
-                self._set_current_song(final_song, final_song.url)
-            else:
-                logger.info('find song standby failed: not found')
-                final_song = song
-                self._set_current_song(final_song, None)
-        else:
-            self.next()
 
     @_Playlist.playback_mode.setter
     def playback_mode(self, playback_mode):

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -104,8 +104,9 @@ class Playlist:
                     self._songs.remove(song)
                     self.current_song = self.next_song
                 else:
-                    self.current_song = self.next_song
+                    next_song = self.next_song
                     self._songs.remove(song)
+                    self.current_song = next_song
             else:
                 self._songs.remove(song)
             logger.debug('Remove {} from player playlist'.format(song))

--- a/feeluown/widgets/songs.py
+++ b/feeluown/widgets/songs.py
@@ -392,7 +392,7 @@ class SongsTableDelegate(QStyledItemDelegate):
 
         if index.column() == Column.artist:
             song = index.data(role=Qt.UserRole)
-            future = aio.run_in_executor(lambda: song.artists)
+            future = aio.run_in_executor(None, lambda: song.artists)
             future.add_done_callback(cb)
 
     def setModelData(self, editor, model, index):

--- a/tests/feeluown/test_player.py
+++ b/tests/feeluown/test_player.py
@@ -108,6 +108,24 @@ async def test_prepare_media_in_non_mainthread(app_mock, song):
         pytest.fail('Prepare media in non mainthread should work')
 
 
+@pytest.mark.asyncio
+async def test_play_next_bad_song(app_mock, song, song1, mocker):
+    """
+    Prepare media for song raises unknown error, the song should
+    be marked as bad.
+    """
+    pl = Playlist(app_mock)
+    mocker.patch.object(pl, 'prepare_media', side_effect=Exception())
+    mock_mark_as_bad = mocker.patch.object(pl, 'mark_as_bad')
+    mock_next = mocker.patch.object(pl, 'next')
+    pl.add(song)
+    pl.add(song1)
+    pl._current_song = song
+    await pl.a_set_current_song(pl.next_song)
+    assert mock_mark_as_bad.called
+    assert mock_next.called
+
+
 def test_play_all(app_mock):
     player = Player(app_mock)
     playlist = player.playlist


### PR DESCRIPTION
当 prepare_media 函数出错时，会有许多 corner case

1. 如果下一首歌曲没有可用的 media，下面情形有可能死循环或程序崩溃
  1. 用户点击了 next
  2. 用户移除了当前歌曲