### PR TITLE
Avoid importing pkg_resources

### DIFF
--- a/feeluown/plugin.py
+++ b/feeluown/plugin.py
@@ -3,7 +3,6 @@
 import importlib
 import logging
 import os
-import pkg_resources
 import sys
 
 from feeluown.utils.dispatch import Signal
@@ -141,7 +140,13 @@ class PluginsManager:
 
         https://packaging.python.org/guides/creating-and-discovering-plugins/
         """
-        for entry_point in pkg_resources.iter_entry_points('fuo.plugins_v1'):
+        try:
+            import importlib.metadata
+            entry_points = importlib.metadata.entry_points().get('fuo.plugins_v1', [])
+        except ImportError:
+            import pkg_resources
+            entry_points = pkg_resources.iter_entry_points('fuo.plugins_v1')
+        for entry_point in entry_points:
             try:
                 module = entry_point.load()
             except Exception as e:  # noqa

--- a/feeluown/version.py
+++ b/feeluown/version.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from functools import partial
-from pkg_resources import parse_version
+from packaging import version
 
 import requests
 from requests.exceptions import ConnectionError, Timeout
@@ -30,8 +30,8 @@ class VersionManager(object):
             logger.warning('检查更新失败')
         else:
             rv = resp.json()
-            latest = parse_version(rv['info']['version'])
-            current = parse_version(__version__)
+            latest = version.parse(rv['info']['version'])
+            current = version.parse(__version__)
             if latest > current:
                 msg = '检测到新版本 %s，当前版本为 %s' % (latest, current)
                 logger.warning(msg)


### PR DESCRIPTION
pkg_resources is expensive to load, which takes more than 400ms here.

Let's use importlib.metadata from stdlib for Python 3.8+ for entry points,
and packaging.version for version parsing instead. It boosts start up
time significantly.

Some benchmark data:

On `fuo --help`, which involves the version parsing but not the entry
points:

Before: 0.908s
After: 0.398s

On `fuo search test` with an added "sys.exit(1)" clause right after
scanning the entry points:

Before: 0.991s
After: 0.502s