### PR TITLE
Silent an error when lyric is not present

### DIFF
--- a/feeluown/lyric/live_lyric.py
+++ b/feeluown/lyric/live_lyric.py
@@ -74,7 +74,7 @@ class LiveLyric(object):
         future.add_done_callback(cb)
 
     def _set_lyric(self, lyric):
-        if lyric is None:
+        if lyric is None or lyric.content is None:
             self._lyric = None
             self._pos_s_map = {}
         else:


### PR DESCRIPTION
The warning is still there, but the error and traceback below are gone after this simple change.

```
[2021-05-06 06:07:23,363 feeluown.models.base:444] [WARNING]: Model KuwoLyricModel get return None
[2021-05-06 06:07:23,364 qasync._QEventLoop:696] [ERROR]: Exception in callback LiveLyric.on_song_changed.<locals>.cb(<Future finis...7fef244a79d0>>) at /usr/lib/python3.9/site-packages/feeluown/lyric/live_lyric.py:64
handle: <Handle LiveLyric.on_song_changed.<locals>.cb(<Future finis...7fef244a79d0>>) at /usr/lib/python3.9/site-packages/feeluown/lyric/live_lyric.py:64>
Traceback (most recent call last):
  File "/usr/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/lib/python3.9/site-packages/feeluown/lyric/live_lyric.py", line 70, in cb
    self._set_lyric(lyric)
  File "/usr/lib/python3.9/site-packages/feeluown/lyric/live_lyric.py", line 83, in _set_lyric
    self._pos_s_map = parse(self._lyric)
  File "/usr/lib/python3.9/site-packages/feeluown/lyric/lyric.py", line 15, in parse
    lines = content.splitlines()
AttributeError: 'NoneType' object has no attribute 'splitlines'
```