### PR TITLE
Fix an error raised in mpris2.py when song.duration is None

### DIFF
--- a/feeluown/linux/mpris2.py
+++ b/feeluown/linux/mpris2.py
@@ -135,7 +135,7 @@ class Mpris2Service(dbus.service.Object):
                 # KDE will not update artist field if the length>=2
                 'xesam:artist': [song.artists_name_display] or ['Unknown'],
                 'xesam:url': media.url if media else '',
-                'mpris:length': dbus.Int64(song.duration*1000),
+                'mpris:length': dbus.Int64(song.duration * 1000 if song.duration else 0),
                 'mpris:trackid': to_track_id(song),
                 'mpris:artUrl': art_url,
                 'xesam:album': song.album_name_display,


### PR DESCRIPTION
```
[2021-05-06 19:35:54,899 feeluown.task:83] [WARNING]: Task mpris2-update-property failed: unsupported operand type(s) for *: 'NoneType' and 'int'
[2021-05-06 19:35:54,899 feeluown.linux.mpris2:119] [ERROR]: mpris update song props failed
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/feeluown/linux/mpris2.py", line 117, in cb
    future.result()
  File "/usr/lib/python3.9/site-packages/feeluown/task.py", line 81, in _cb
    future.result()
  File "/usr/lib/python3.9/site-packages/qasync/__init__.py", line 140, in run
    r = callback(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/feeluown/linux/mpris2.py", line 138, in _update_song_props
    'mpris:length': dbus.Int64(song.duration*1000),
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```