### PR TITLE
add a_list_song_standby_v2 API

### DIFF
--- a/feeluown/library/__init__.py
+++ b/feeluown/library/__init__.py
@@ -10,4 +10,5 @@ from .models import ModelFlags, BaseModel, ModelType, \
     BriefCommentModel, CommentModel, \
     BriefUserModel, UserModel, \
     cook_artists_name
-from .excs import NotSupported, NoUserLoggedIn, ModelNotFound
+from .excs import NotSupported, NoUserLoggedIn, ModelNotFound, \
+    ProviderAlreadyExists

--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -244,6 +244,76 @@ class Library:
                         break
         return result
 
+    async def a_list_song_standby_v2(self, song,
+                                     audio_select_policy='>>>', source_in=None,
+                                     score_fn=None, min_score=5, limit=1):
+        """list song standbys and their media
+
+        .. versionadded:: 3.7.8
+        """
+
+        def default_score_fn(origin, standby):
+            score = 10
+            if origin.artists_name_display != standby.artists_name_display:
+                score -= 4
+            if origin.title_display != standby.title_display:
+                score -= 3
+            if origin.album_name_display != standby.album_name_display:
+                score -= 2
+            return score
+
+        async def prepare_media(standby, policy):
+            media = None
+            try:
+                media = await aio.run_in_executor(None,
+                                                  self.song_prepare_media,
+                                                  standby, policy)
+            except MediaNotFound:
+                pass
+            except:  # noqa
+                logger.exception(f'get standby:{standby} media failed')
+            return media
+
+        if source_in is None:
+            pvd_ids = self._providers_standby or [pvd.identifier for pvd in self.list()]
+        else:
+            pvd_ids = [pvd.identifier for pvd in self._filter(identifier_in=source_in)]
+        if score_fn is None:
+            score_fn = default_score_fn
+        limit = max(limit, 1)
+
+        q = '{} {}'.format(song.title_display, song.artists_name_display)
+        standby_score_list = []  # [(standby, score), (standby, score)]
+        song_media_list = []     # [(standby, media), (standby, media)]
+        async for result in self.a_search(q, source_in=pvd_ids):
+            if result is None:
+                continue
+            # Only check the first 3 songs
+            for standby in result.songs:
+                score = score_fn(song, standby)
+                if score == 10:  # full mark
+                    media = await prepare_media(standby, audio_select_policy)
+                    if media is None:
+                        continue
+                    logger.info(f'find full mark standby for song:{q}')
+                    song_media_list.append((standby, media))
+                    if len(song_media_list) >= limit:
+                        # Return as early as possible to get better performance
+                        return song_media_list
+                elif score >= min_score:
+                    standby_score_list.append((standby, score))
+        # Limit try times since prapare_media is an expensive IO operation
+        max_try = len(pvd_ids) * 2
+        for standby, score in sorted(standby_score_list,
+                                     key=lambda song_score: song_score[1],
+                                     reverse=True)[:max_try]:
+            media = await prepare_media(standby, audio_select_policy)
+            if media is not None:
+                song_media_list.append((standby, media))
+                if len(song_media_list) >= limit:
+                    return song_media_list
+        return song_media_list
+
     #
     # methods for v2
     #

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -386,9 +386,12 @@ class Playlist:
             if self.mode is not PlaylistMode.fm:
                 self._app.show_msg(f'{song_str} is invalid, try to find standby')
                 logger.info(f'try to find standby for {song_str}')
-                standby_candidates = await self._app.library.a_list_song_standby(song)
+                standby_candidates = await self._app.library.a_list_song_standby_v2(
+                    song,
+                    self.audio_select_policy
+                )
                 if standby_candidates:
-                    standby = standby_candidates[0]
+                    standby, media = standby_candidates[0]
                     self._app.show_msg(f'Song standby was found in {standby.source} ✅')
                     # Insert the standby song after the song
                     if song in self._songs and standby not in self._songs:
@@ -396,7 +399,7 @@ class Playlist:
                         self._songs.insert(index + 1, standby)
                     # NOTE: a_list_song_standby ensure that the song.url is not empty
                     # FIXME: maybe a_list_song_standby should return media directly
-                    self.pure_set_current_song(standby, standby.url)
+                    self.pure_set_current_song(standby, media)
                 else:
                     self._app.show_msg('Song standby not found')
                     self.pure_set_current_song(song, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,18 @@ def song(artist, album):
 
 
 @pytest.fixture
+def song_standby(song):
+    return FakeSongModel(
+        identifier=100,
+        title=song.title,
+        artists=song.artists,
+        album=song.album,
+        duration=song.duration,
+        url='standby.mp3'
+    )
+
+
+@pytest.fixture
 def song1(): return _song1
 
 

--- a/tests/feeluown/test_playlist.py
+++ b/tests/feeluown/test_playlist.py
@@ -31,7 +31,7 @@ def pl_list_standby_return_empty(mocker, pl):
     pl._app.library.a_list_song_standby
     f2 = asyncio.Future()
     f2.set_result([])
-    mock_a_list_standby = pl._app.library.a_list_song_standby
+    mock_a_list_standby = pl._app.library.a_list_song_standby_v2
     mock_a_list_standby.return_value = f2
 
 
@@ -39,8 +39,8 @@ def pl_list_standby_return_empty(mocker, pl):
 def pl_list_standby_return_song2(mocker, pl, song2):
     pl._app.library.a_list_song_standby
     f2 = asyncio.Future()
-    f2.set_result([song2])
-    mock_a_list_standby = pl._app.library.a_list_song_standby
+    f2.set_result([(song2, song2.url)])
+    mock_a_list_standby = pl._app.library.a_list_song_standby_v2
     mock_a_list_standby.return_value = f2
 
 
@@ -107,7 +107,6 @@ async def test_set_current_song_with_bad_song_2(
     await pl.a_set_current_song(song2)
     # A song that has no valid media should be marked as bad
     assert mock_mark_as_bad.called
-    # Since there exists standby songs, the media should the url
     mock_pure_set_current_song.assert_called_once_with(song2, song2.url)
 
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,7 +1,10 @@
+import random
+
 import pytest
 
 from fuocore.library import Library
 from fuocore.provider import dummy_provider
+from feeluown.models import SearchModel
 
 
 def test_library_search(library):
@@ -14,6 +17,52 @@ def test_library_search(library):
 async def test_library_a_search(library):
     result = [x async for x in library.a_search('xxx')][0]
     assert result.q == 'xxx'
+
+
+def test_score_fn():
+    """A test to check if our score fn works well
+    """
+    from feeluown.library.models import BriefSongModel
+    from feeluown.library.library import default_score_fn, FULL_SCORE, MIN_SCORE
+
+    def create_song(title, artists_name, album_name, duration_ms):
+        return BriefSongModel(identifier=random.randint(0, 1000),
+                              source='x',
+                              title=title,
+                              artists_name=artists_name,
+                              album_name=album_name,
+                              duration_ms=duration_ms)
+
+    # 一个真实案例：歌曲来自 a 平台，候选歌曲来自 b 平台的搜索结果。
+    # 人为判断，第一个结果是符合预期的。
+    #
+    # 这里有一个特点：第一个结果的标题有个后缀，但这个后缀是多余且无影响的信息。
+    # 这个现象在 kuwo 平台非常常见。
+    song = create_song('暖暖', '梁静茹', '亲亲', '04:03')
+    candidates = [create_song(*x) for x in [
+        ('暖暖-《周末父母》电视剧片头曲', '梁静茹', '亲亲', '04:06'),
+        ('暖暖', '梁静茹', '“青春19潮我看”湖南卫视2018-2019跨年演唱会', '01:57'),
+        ('暖暖 (2011音乐万万岁现场)', '梁静茹', '', '03:50'),
+        ('暖暖 (2015江苏卫跨年演唱会)', '梁静茹', '', '02:05'),
+        ('暖暖 (纯音乐)', '梁静茹', '', '03:20'),
+        ('暖暖 (DJ版)', '梁静茹', '', '03:16'),
+        ('暖暖(Cover 梁静茹)', '釉哥哥&光光', '暖暖-梁静茹', '04:06'),
+    ]]
+    assert default_score_fn(song, candidates[0]) > \
+        default_score_fn(song, candidates[1])
+
+    # 字符串上一模一样，理应返回满分
+    song = create_song('我很想爱他', 'Twins', '八十块环游世界', '04:27')
+    candidates = [create_song('我很想爱他', 'Twins', '八十块环游世界', '04:27')]
+    assert default_score_fn(song, candidates[0]) == FULL_SCORE
+
+    # 根据人工判断，分数应该有 9 分，期望目标算法最起码不能忽略这首歌曲
+    song = create_song('很爱很爱你 (Live)', '刘若英',
+                       '脱掉高跟鞋 世界巡回演唱会', '05:55')
+    candidates = [
+        create_song('很爱很爱你', '刘若英', '脱掉高跟鞋世界巡回演唱会', '05:24')
+    ]
+    assert default_score_fn(song, candidates[0]) >= MIN_SCORE
 
 
 def test_library_list_songs_standby(library, song):
@@ -47,6 +96,21 @@ async def test_library_a_list_songs_standby_with_specified_providers(song):
     song.source = 'dummy-1'
     songs = await library.a_list_song_standby(song)
     assert len(songs) == 0
+
+
+@pytest.mark.asyncio
+async def test_library_a_list_songs_standby_v2(library, provider,
+                                               song, song1, song_standby, mocker):
+    mock_search = mocker.patch.object(provider, 'search')
+    mock_search.return_value = SearchModel(q='xx', songs=[song1, song_standby])
+
+    song_media_list = await library.a_list_song_standby_v2(song)
+    for standby, media in song_media_list:
+        if standby is song_standby:
+            assert media.url == 'standby.mp3'
+            break
+    else:
+        assert False, 'song_standby should be a stanby option'
 
 
 def test_library_register_should_emit_signal(library, mocker):


### PR DESCRIPTION
- [x] 解决 https://github.com/feeluown/FeelUOwn/pull/400 提到的问题
- [x] 接口层面，允许自定义 score_fn，理论上对这个 https://github.com/feeluown/FeelUOwn/issues/434 提到的问题（在一些情况下可能会更容易搜到翻唱歌曲而不是原曲）也有一定程度的解决
- [x] 修改单测，添加新单测