### PR TITLE
wip: have a try

### DIFF
--- a/feeluown/gui/widgets/danmaku.py
+++ b/feeluown/gui/widgets/danmaku.py
@@ -1,0 +1,70 @@
+import time
+
+from PyQt5.QtCore import Qt, QRectF, QTimer
+from PyQt5.QtGui import QPainter, QColor
+from PyQt5.QtWidgets import QWidget
+
+from feeluown.player import State
+
+
+class DanmakuOverlay(QWidget):
+    def __init__(self, app, parent=None):
+        super().__init__(parent=parent)
+        self._app = app
+        self.setAutoFillBackground(False)
+
+        self._timer = QTimer(self)  #: timer for hidding overlay
+        self._timeout = 15  # 60fps
+
+        self._running_danmaku = [
+            (5, 10, '感觉好卡呀，为啥呢，heyheyhey？'),
+            (10, 20, '周杰伦不香么？'),
+            (17, 10, '帧数不够'),
+            (23, 10, '尴尬!'),
+        ]
+
+        self._timer.timeout.connect(self.__on_timeout)
+        self._app.player.state_changed.connect(self._on_player_state_changed, aioqueue=True)
+
+    def _on_player_state_changed(self, state):
+        if self._app.player.state == State.playing:
+            print('start timer')
+            self._timer.start(self._timeout)
+        else:
+            print('stop timer')
+            self._timer.stop()
+
+    def __on_timeout(self):
+        self.parent().repaint()
+
+    def paint(self, painter):
+        # print(self._app.player.position)
+        print(time.time(), self._app.player.position)
+        #painter.begin(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        #painter.fillRect(self.rect(), QColor('transparent'))
+        if self._app.player.current_media:
+            from feeluown.gui.helpers import resize_font
+            w = self.width()
+            position = self._app.player.position
+            painter.save()
+            font = painter.font()
+            pen = painter.pen()
+            pen.setColor(QColor('red'))
+            painter.setPen(pen)
+            resize_font(font, 5)
+            painter.setFont(font)
+            fm = painter.fontMetrics()
+
+            for danmaku in self._running_danmaku:
+                start, end, text = danmaku
+                duration = 15
+                width = fm.horizontalAdvance(text)
+                if start < position < start+duration:
+                    x = w - ((position - start) / duration * w)
+                    painter.drawText(QRectF(x, 0, width, 60), Qt.AlignLeft, text)
+            painter.restore()
+        #painter.end()
+
+    #def paintEvent(self, e):
+    #    self.paint(painter)

--- a/feeluown/gui/widgets/mpv.py
+++ b/feeluown/gui/widgets/mpv.py
@@ -41,6 +41,7 @@ class MpvOpenGLWidget(VideoOpenGLWidget):
                                     'opengl',
                                     opengl_init_params=params)
         self.ctx.update_cb = self.on_update
+        #self.format().setSwapInterval(0)
 
     def shutdown(self):
         if self.ctx is not None:
@@ -60,6 +61,8 @@ class MpvOpenGLWidget(VideoOpenGLWidget):
                       'h': h,
                       'fbo': self.defaultFramebufferObject()}
         self.ctx.render(flip_y=True, opengl_fbo=opengl_fbo)
+        from PyQt5.QtGui import QPainter
+        self._danmaku_overlay.paint(QPainter(self))
 
     @pyqtSlot()
     def maybe_update(self):

--- a/feeluown/gui/widgets/video.py
+++ b/feeluown/gui/widgets/video.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import QVBoxLayout, QPushButton, QWidget, \
 from feeluown.player import State
 from feeluown.gui.widgets.progress_slider import ProgressSlider
 from feeluown.gui.widgets.size_grip import SizeGrip
+from feeluown.gui.widgets.danmaku import DanmakuOverlay
 from .labels import ProgressLabel, DurationLabel
 
 
@@ -83,6 +84,8 @@ class VideoOpenGLWidget(QOpenGLWidget):
         self._overlay_max_width = 480
         self._enable_overlay = False
 
+        self._danmaku_overlay = DanmakuOverlay(app=app, parent=self)
+        self._danmaku_overlay.setGeometry(0, 0, 100, 100)
         self._overlay = VideoOverlay(app=app, parent=self)
         self._size_grip = SizeGrip(parent=self)
         self._layout = QVBoxLayout(self)
@@ -131,6 +134,8 @@ class VideoOpenGLWidget(QOpenGLWidget):
         super().resizeEvent(e)
         max_width = min(self.width() - 50, self._overlay_max_width)
         self._overlay.setMaximumWidth(max_width)
+        self._danmaku_overlay.setFixedWidth(self.width())
+        self._danmaku_overlay.setFixedHeight(self.height())
 
     def enterEvent(self, e):
         super().enterEvent(e)


### PR DESCRIPTION
当前的发现
1. 如果把 mpv 的 render 函数注释掉，就能实现 60fps
2. flip_y 是旋转视频的，和 fps 无关
3. render 函数 skip_renderring 没有用

我试了这三种模式，都会有上面的问题
1. widget/(mpv-opengl-widget+danmaku-widget)
2. mpv-opengl-widget -> paintGL/(paint-mpv + paint danmaku)
3 opengl-widget/(paintGL + danmaku-widget.paintEvent)

看了下，qt 文档说同一个 window 下的 widget 会共享一个 opengl context，我 *感觉* 是这些 paint 都要公用这个东西，于是导致了最后的 30fps。 不过确实对这个不是很懂，不确定细节是什么样子。