### PR TITLE
fix install error on macos

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -52,7 +52,8 @@ macOS
 
     # macOS 11 可能不能正常安装
     # https://github.com/feeluown/FeelUOwn/issues/421
-    brew install feeluown/feeluown/feeluown --with-battery
+    brew tap feeluown/feeluown
+    brew install feeluown --with-battery # 更多选项见 `brew info feeluown`
     feeluown-genicon  # 在桌面会生成一个 FeelUOwn 图标
 
 Windows


### PR DESCRIPTION
Fix the error when executing `brew install feeluown/feeluown/feeluown --with-battery`:
![image](https://user-images.githubusercontent.com/44015907/142973840-9881a846-c8bb-4345-9966-741c751f8f4c.png)
