### PR TITLE
DNM: gui: use terminal like colortheme

### DIFF
--- a/feeluown/gui/theme/__init__.py
+++ b/feeluown/gui/theme/__init__.py
@@ -1,0 +1,6 @@
+from .theme import ThemeManager, Light, Dark
+
+
+__all__ = ('ThemeManager',
+           'Light',
+           'Dark')

--- a/feeluown/gui/theme/theme.py
+++ b/feeluown/gui/theme/theme.py
@@ -11,6 +11,8 @@ from PyQt5.QtGui import QGuiApplication, QPalette, QColor
 from PyQt5.QtWidgets import QApplication
 from feeluown.utils.utils import get_osx_theme
 
+from .xrdb import read_termlike_colors
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,7 +32,9 @@ Groups = ['Disabled', 'Active', 'Inactive']
 def read_resource(filename):
     filepath = os.path.abspath(__file__)
     dirname = os.path.dirname(filepath)
-    qssfilepath = os.path.join(dirname, 'assets/themes/{}'.format(filename))
+    qssfilepath = os.path.join(dirname,
+                               '..',
+                               'assets/themes/{}'.format(filename))
     with open(qssfilepath, encoding='UTF-8') as f:
         s = f.read()
     return s
@@ -49,6 +53,7 @@ class ThemeManager(QObject):
     def initialize(self):
         # XXX: I don't know why we should autoload twice
         # to make it work well on Linux(GNOME)
+        return
         self.autoload()
         self._app.initialized.connect(lambda app: self.autoload(), weak=False)
         QApplication.instance().paletteChanged.connect(lambda p: self.autoload())
@@ -113,6 +118,12 @@ class ThemeManager(QObject):
         palette = load_colors(colors)
         self._app.setPalette(palette)
         QApplication.instance().paletteChanged.connect(self.autoload)
+
+    def load_termlike_colors(self, name):
+        colors = read_termlike_colors(name)
+        palette = load_colors(colors)
+        self._app.setPalette(palette)
+        #QApplication.instance().paletteChanged.connect(self.autoload)
 
     def get_pressed_color(self):
         """pressed color for button-like widget

--- a/feeluown/gui/theme/xrdb.py
+++ b/feeluown/gui/theme/xrdb.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+import json
+from enum import Enum
+
+from PyQt5.QtGui import QColor
+
+
+class ColorName(Enum):
+    # Normal.
+    black = 'ansi_0_color'
+    red = 'ansi_1_color'
+    yellow = 'ansi_2_color'
+    green = 'ansi_3_color'
+    blue = 'ansi_4_color'
+    magenta = 'ansi_5_color'
+    cyan = 'ansi_6_color'
+    white = 'ansi_7_color'
+
+    # Bright.
+    b_black = 'ansi_8_color'
+    b_red = 'ansi_9_color'
+    b_yellow = 'ansi_10_color'
+    b_green = 'ansi_11_color'
+    b_blue = 'ansi_12_color'
+    b_magenta = 'ansi_13_color'
+    b_cyan = 'ansi_14_color'
+    b_white = 'ansi_15_color'
+
+    background = 'background_color'
+    foreground = 'foreground_color'
+    bold = 'bold_color'
+    cursor = 'cursor_color'
+    cursor_text = 'cursor_text_color'
+    selected = 'selection_color'
+    selected_text = 'selected_text_color'
+
+
+def read_xrdb(filepath):
+    xrdb = {}
+    with open(filepath) as f:
+        for line in f:
+            _, name, color = line.split(' ')
+            name, color = name.strip().lower(), color.strip()
+            try:
+                xrdb[ColorName(name)] = color
+            except ValueError:
+                print(f"unknown color name '{name}'")
+    return xrdb
+
+
+def active_colors(xrdb):
+    foreground = xrdb[ColorName.foreground]
+    background = xrdb[ColorName.background]
+
+    role_color_dict = {
+        'Background': background,
+        'Window': background,
+        'WindowText': foreground,
+        'Text': foreground,
+        'Foreground': foreground,
+
+        # According to qpalette docs, role and color have following mapping.
+        'Link': xrdb[ColorName.b_blue],
+        'LinkVisited': xrdb[ColorName.b_magenta],
+        'Highlight': xrdb[ColorName.blue],
+        'HighlightedText': xrdb[ColorName.b_white],
+        'PlaceholderText': foreground,
+
+        # The following mapping are decided according to experience (by cosven),
+        # which may be not accurate.
+        'Base': xrdb[ColorName.black],  # Same as the background.
+        'AlternateBase': xrdb[ColorName.black],  # Usually similar to background.
+        'BrightText': xrdb[ColorName.b_white],
+
+        'ButtonText': foreground,
+
+        # I found the button is usually lighter than the background.
+        'Button': xrdb[ColorName.black],
+        # Based on Button and following the qpalette rules,
+        # we choose colors for light.
+        'Light': xrdb[ColorName.b_black],
+        'MidLight': xrdb[ColorName.b_black],  # No corresponding color.
+        'Dark': xrdb[ColorName.background],
+        'Mid': xrdb[ColorName.background],   # No corresponding color.
+
+        'Shadow': xrdb[ColorName.black],
+        'NoRole': xrdb[ColorName.black],
+
+        'ToolTipBase': xrdb[ColorName.black],
+        'ToolTipText': foreground,
+    }
+    return role_color_dict
+
+
+def inactive_colors(xrdb):
+    colors = active_colors(xrdb)
+    colors['Highlight'] = QColor(xrdb[ColorName.blue]).darker(130).name()
+    return colors
+
+
+def disabled_colors(xrdb):
+    colors = active_colors(xrdb)
+    # Lighter than the base.
+    colors['Highlight'] = QColor(xrdb[ColorName.blue]).lighter(150).name()
+    # A color similar to background.
+    colors['ButtonText'] = QColor(xrdb[ColorName.background]).lighter(150).name()
+    return colors
+
+
+def read_termlike_colors(name):
+    xrdb = read_xrdb(f'feeluown/gui/assets/themes/xrdb/{name}.xrdb')
+    colors = {
+        "Active": active_colors(xrdb),
+        "Disabled": disabled_colors(xrdb),
+        "Inactive": inactive_colors(xrdb)
+    }
+    return colors
+
+
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
要想用上类似终端的主题，有几个问题需要解决
- [ ] 播放控制栏的颜色现在都是硬编码的 -> 最好用 qpalette，次之也可以考虑使用字符串替换等土方法
- [ ] 播放控制栏的图标颜色都是固定的 -> 用代码绘制图标（这一步可以先做！）
- [ ] 终端一个特点就是颜色丰富，而现在使用的颜色种类太少，需要修改一下设计

Grubbox Light
![image](https://user-images.githubusercontent.com/4962134/165586493-01009343-31c3-4ecc-85d3-fc266ea7a1c5.png)

Zenburn
![image](https://user-images.githubusercontent.com/4962134/165586860-57382059-095b-4ee9-9993-8ffbcd63ad81.png)
