### PR TITLE
Fix a warning from setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal=0
 
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [pep8]
 ignore = E402


### PR DESCRIPTION
```
/usr/lib/python3.10/site-packages/setuptools/dist.py:771: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```