### PR TITLE
artist splitter功能增强

### DIFF
--- a/feeluown/local/__init__.py
+++ b/feeluown/local/__init__.py
@@ -18,14 +18,22 @@ logger = logging.getLogger(__name__)
 
 
 def init_config(config):
-    config.deffield('MUSIC_FOLDERS', type_=list, default=[DEFAULT_MUSIC_FOLDER], desc='支持的音乐文件夹列表')
-    config.deffield('MUSIC_FORMATS', type_=list, default=DEFAULT_MUSIC_EXTS, desc='支持的音乐格式列表')
-    config.deffield('CORE_LANGUAGE', type_=str, default='auto', desc='默认显示的语言')
-    config.deffield('IDENTIFIER_DELIMITER', type_=str, default='', desc='生成identifier时的连接符')
-    config.deffield('EXPAND_ARTIST_SONGS', type_=bool, default=False, desc='将专辑艺术家的专辑中歌曲加入到该艺术家的歌曲中')
-    config.deffield('ARTIST_SPLITTER', type_=list, default=[',', '&'], desc='歌曲艺术家的分隔符')
-    config.deffield('ARTIST_SPLITTER_IGNORANCE', type_=list, default=None, desc='对艺术家信息使用分隔符时需要进行保护的字符串')
-    config.deffield('SPLIT_ALBUM_ARTIST_NAME', type_=bool, default=False, desc='支持使用分隔符分隔专辑艺术家')
+    config.deffield('MUSIC_FOLDERS', type_=list, default=[DEFAULT_MUSIC_FOLDER],
+                    desc='支持的音乐文件夹列表')
+    config.deffield('MUSIC_FORMATS', type_=list, default=DEFAULT_MUSIC_EXTS,
+                    desc='支持的音乐格式列表')
+    config.deffield('CORE_LANGUAGE', type_=str, default='auto',
+                    desc='默认显示的语言')
+    config.deffield('IDENTIFIER_DELIMITER', type_=str, default='',
+                    desc='生成identifier时的连接符')
+    config.deffield('EXPAND_ARTIST_SONGS', type_=bool, default=False,
+                    desc='将专辑艺术家的专辑中歌曲加入到该艺术家的歌曲中')
+    config.deffield('ARTIST_SPLITTER', type_=list, default=[',', '&'],
+                    desc='歌曲艺术家的分隔符')
+    config.deffield('ARTIST_SPLITTER_IGNORANCE', type_=list, default=None,
+                    desc='对艺术家信息使用分隔符时需要进行保护的字符串')
+    config.deffield('SPLIT_ALBUM_ARTIST_NAME', type_=bool, default=False,
+                    desc='支持使用分隔符分隔专辑艺术家')
 
 
 async def autoload(app):

--- a/feeluown/local/__init__.py
+++ b/feeluown/local/__init__.py
@@ -23,6 +23,9 @@ def init_config(config):
     config.deffield('CORE_LANGUAGE', type_=str, default='auto', desc='')
     config.deffield('IDENTIFIER_DELIMITER', type_=str, default='', desc='')
     config.deffield('EXPAND_ARTIST_SONGS', type_=bool, default=False, desc='')
+    config.deffield('ARTIST_SPLITTER', type_=list, default=[',', '&'], desc='')
+    config.deffield('ARTIST_SPLITTER_IGNORANCE', type_=list, default=None, desc='')
+    config.deffield('SPLIT_ALBUM_ARTIST_NAME', type_=bool, default=False, desc='')
 
 
 async def autoload(app):

--- a/feeluown/local/__init__.py
+++ b/feeluown/local/__init__.py
@@ -18,14 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 def init_config(config):
-    config.deffield('MUSIC_FOLDERS', type_=list, default=[DEFAULT_MUSIC_FOLDER], desc='')
-    config.deffield('MUSIC_FORMATS', type_=list, default=DEFAULT_MUSIC_EXTS, desc='')
-    config.deffield('CORE_LANGUAGE', type_=str, default='auto', desc='')
-    config.deffield('IDENTIFIER_DELIMITER', type_=str, default='', desc='')
-    config.deffield('EXPAND_ARTIST_SONGS', type_=bool, default=False, desc='')
-    config.deffield('ARTIST_SPLITTER', type_=list, default=[',', '&'], desc='')
-    config.deffield('ARTIST_SPLITTER_IGNORANCE', type_=list, default=None, desc='')
-    config.deffield('SPLIT_ALBUM_ARTIST_NAME', type_=bool, default=False, desc='')
+    config.deffield('MUSIC_FOLDERS', type_=list, default=[DEFAULT_MUSIC_FOLDER], desc='支持的音乐文件夹列表')
+    config.deffield('MUSIC_FORMATS', type_=list, default=DEFAULT_MUSIC_EXTS, desc='支持的音乐格式列表')
+    config.deffield('CORE_LANGUAGE', type_=str, default='auto', desc='默认显示的语言')
+    config.deffield('IDENTIFIER_DELIMITER', type_=str, default='', desc='生成identifier时的连接符')
+    config.deffield('EXPAND_ARTIST_SONGS', type_=bool, default=False, desc='将专辑艺术家的专辑中歌曲加入到该艺术家的歌曲中')
+    config.deffield('ARTIST_SPLITTER', type_=list, default=[',', '&'], desc='歌曲艺术家的分隔符')
+    config.deffield('ARTIST_SPLITTER_IGNORANCE', type_=list, default=None, desc='对艺术家信息使用分隔符时需要进行保护的字符串')
+    config.deffield('SPLIT_ALBUM_ARTIST_NAME', type_=bool, default=False, desc='支持使用分隔符分隔专辑艺术家')
 
 
 async def autoload(app):

--- a/feeluown/local/db.py
+++ b/feeluown/local/db.py
@@ -164,9 +164,31 @@ def read_audio_metadata(fpath, can_convert_chinese=False, lang='auto') -> Option
     return data
 
 
+def gen_artist_name_list(artists_name, splitter, splitter_ignorance):
+    # For example::
+    # artists_name: 'Years & Years & Jess Glynne'
+    # splitter: [',', '&']
+    # splitter_ignorance: ['Years & Years']
+    if splitter_ignorance is None:
+        splitter_ignorance = []
+    if splitter_ignorance:
+        artists_name = re.split(r'({})'.format('|'.join(splitter_ignorance)), artists_name)
+    else:
+        artists_name = [artists_name]
+    artist_name_list = []
+    for artist_name in artists_name:
+        if artist_name in splitter_ignorance:
+            artist_name_list.append(artist_name)
+        else:
+            artist_name_list.extend(re.split(r'{}'.format('|'.join(splitter)), artist_name))
+    return [artist_name.strip() for artist_name in artist_name_list if artist_name.strip()]
+
+
 def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contributors,
              can_convert_chinese=False, lang='auto',
-             delimiter='', expand_artist_songs=False):
+             delimiter='', expand_artist_songs=False,
+             artist_splitter=[',', '&'], artist_splitter_ignorance=None,
+             split_album_artist_name=False):
     """
     parse music file metadata with Easymp3 and return a song
     model.
@@ -178,9 +200,7 @@ def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contribut
     # NOTE: use {title}-{artists_name}-{album_name} as song identifier
     title = data['title']
     album_name = data['album_name']
-    artist_name_list = [
-        name.strip()
-        for name in re.split(r'[,&]', data['artists_name'])]
+    artist_name_list = gen_artist_name_list(data['artists_name'], artist_splitter, artist_splitter_ignorance)
     artists_name = ','.join(artist_name_list)
     duration = data['duration']
     album_artist_name = data['album_artist_name']
@@ -208,12 +228,21 @@ def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contribut
         return
 
     # 生成 album artist model
-    album_artist_id = gen_id(album_artist_name)
-    if album_artist_id not in g_artists:
-        album_artist = create_artist(album_artist_id, album_artist_name)
-        g_artists[album_artist_id] = album_artist
+    if split_album_artist_name:
+        album_artist_name_list = gen_artist_name_list(album_artist_name, artist_splitter, artist_splitter_ignorance)
     else:
-        album_artist = g_artists[album_artist_id]
+        album_artist_name_list = [album_artist_name]
+
+    album_artist_id_list, album_artist_list = [], []
+    for artist_name in album_artist_name_list:
+        artist_id = gen_id(artist_name)
+        if artist_id not in g_artists:
+            album_artist = create_artist(artist_id, artist_name)
+            g_artists[artist_id] = album_artist
+        else:
+            album_artist = g_artists[artist_id]
+        album_artist_id_list.append(artist_id)
+        album_artist_list.append(album_artist)
 
     # 生成 album model
     album_id_str = delimiter.join([album_name, album_artist_name])
@@ -227,11 +256,12 @@ def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contribut
         album = g_albums[album_id]
 
     # 处理专辑的歌手信息和歌曲信息，专辑歌手的专辑列表信息
-    for artist in album.artists:
-        if album_artist.identifier == artist.identifier:
-            break
-    else:
-        album.artists.append(to_brief_artist(album_artist))
+    for album_artist in album_artist_list:
+        for artist in album.artists:
+            if album_artist.identifier == artist.identifier:
+                break
+        else:
+            album.artists.append(to_brief_artist(album_artist))
 
     if song not in album.songs:
         album.songs.append(song)
@@ -251,13 +281,14 @@ def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contribut
             artist.hot_songs.append(song)
 
         # 处理歌曲歌手的参与作品信息(不与前面的重复)
-        if artist_id != album_artist_id \
-           and artist_id not in g_album_contributors[album_id]:
+        if artist_id not in album_artist_id_list \
+                and artist_id not in g_album_contributors[album_id]:
             g_album_contributors[album_id].append(artist_id)
 
     # 处理专辑歌手的歌曲信息: 有些作词人出合辑很少出现在歌曲歌手里(可选)
-    if expand_artist_songs and song not in album_artist.hot_songs:
-        album_artist.hot_songs.append(song)
+    for album_artist_ in album_artist_list:
+        if expand_artist_songs and song not in album_artist_.hot_songs:
+            album_artist_.hot_songs.append(song)
 
 
 def scan_directory(directory, exts, depth=2):
@@ -379,7 +410,9 @@ class DB:
             add_song(fpath, self._songs, self._artists,
                      self._albums, self._file_song, self._album_contributors,
                      is_cn_convert_enabled, config.CORE_LANGUAGE,
-                     config.IDENTIFIER_DELIMITER, config.EXPAND_ARTIST_SONGS)
+                     config.IDENTIFIER_DELIMITER, config.EXPAND_ARTIST_SONGS,
+                     config.ARTIST_SPLITTER, config.ARTIST_SPLITTER_IGNORANCE,
+                     config.SPLIT_ALBUM_ARTIST_NAME)
         logger.info('录入本地音乐库完毕')
 
     def after_scan(self):

--- a/feeluown/local/db.py
+++ b/feeluown/local/db.py
@@ -445,7 +445,7 @@ class DB:
                 if albums:
                     artist.pic_url = albums[0].cover
 
-            if artist.hot_songs:
+            if not artist.pic_url and artist.hot_songs:
                 # sort the artist hot_songs.
                 artist.hot_songs.sort(key=lambda x: x.title)
                 # Use a song's cover as artist cover.

--- a/feeluown/local/db.py
+++ b/feeluown/local/db.py
@@ -172,7 +172,8 @@ def gen_artist_name_list(artists_name, splitter, splitter_ignorance):
     if splitter_ignorance is None:
         splitter_ignorance = []
     if splitter_ignorance:
-        artists_name = re.split(r'({})'.format('|'.join(splitter_ignorance)), artists_name)
+        artists_name = re.split(r'({})'.format('|'.join(splitter_ignorance)),
+                                artists_name)
     else:
         artists_name = [artists_name]
     artist_name_list = []
@@ -180,8 +181,10 @@ def gen_artist_name_list(artists_name, splitter, splitter_ignorance):
         if artist_name in splitter_ignorance:
             artist_name_list.append(artist_name)
         else:
-            artist_name_list.extend(re.split(r'{}'.format('|'.join(splitter)), artist_name))
-    return [artist_name.strip() for artist_name in artist_name_list if artist_name.strip()]
+            artist_name_list.extend(re.split(r'{}'.format('|'.join(splitter)),
+                                             artist_name))
+    return [artist_name.strip()
+            for artist_name in artist_name_list if artist_name.strip()]
 
 
 def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contributors,
@@ -200,7 +203,8 @@ def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contribut
     # NOTE: use {title}-{artists_name}-{album_name} as song identifier
     title = data['title']
     album_name = data['album_name']
-    artist_name_list = gen_artist_name_list(data['artists_name'], artist_splitter, artist_splitter_ignorance)
+    artist_name_list = gen_artist_name_list(
+        data['artists_name'], artist_splitter, artist_splitter_ignorance)
     artists_name = ','.join(artist_name_list)
     duration = data['duration']
     album_artist_name = data['album_artist_name']
@@ -229,7 +233,8 @@ def add_song(fpath, g_songs, g_artists, g_albums, g_file_song, g_album_contribut
 
     # 生成 album artist model
     if split_album_artist_name:
-        album_artist_name_list = gen_artist_name_list(album_artist_name, artist_splitter, artist_splitter_ignorance)
+        album_artist_name_list = gen_artist_name_list(
+            album_artist_name, artist_splitter, artist_splitter_ignorance)
     else:
         album_artist_name_list = [album_artist_name]
 

--- a/feeluown/local/db.py
+++ b/feeluown/local/db.py
@@ -169,6 +169,7 @@ def gen_artist_name_list(artists_name, splitter, splitter_ignorance):
     # artists_name: 'Years & Years & Jess Glynne'
     # splitter: [',', '&']
     # splitter_ignorance: ['Years & Years']
+    # return: ['Years & Years', 'Jess Glynne']
     if splitter_ignorance is None:
         splitter_ignorance = []
     if splitter_ignorance:

--- a/feeluown/local/provider.py
+++ b/feeluown/local/provider.py
@@ -169,9 +169,13 @@ class LocalProvider(AbstractProvider, ProviderV2):
         else:
             result = []
         result_songs = []
-        for each, score in result:
-            # if score > 80, keyword is almost included in song key
-            if score > 80:
+        if False:
+            for each, score in result:
+                # if score > 80, keyword is almost included in song key
+                if score > 80:
+                    result_songs.append(repr_song_map[each])
+        else:
+            for each in result:
                 result_songs.append(repr_song_map[each])
         return SimpleSearchResult(
             q=keyword,

--- a/feeluown/local/provider.py
+++ b/feeluown/local/provider.py
@@ -169,7 +169,7 @@ class LocalProvider(AbstractProvider, ProviderV2):
         else:
             result = []
         result_songs = [repr_song_map[each] for each in result]
-        
+
         return SimpleSearchResult(
             q=keyword,
             songs=[to_brief_song(song) for song in result_songs]

--- a/feeluown/local/provider.py
+++ b/feeluown/local/provider.py
@@ -168,15 +168,8 @@ class LocalProvider(AbstractProvider, ProviderV2):
             result = difflib.get_close_matches(keyword, choices, n=limit, cutoff=0)
         else:
             result = []
-        result_songs = []
-        if False:
-            for each, score in result:
-                # if score > 80, keyword is almost included in song key
-                if score > 80:
-                    result_songs.append(repr_song_map[each])
-        else:
-            for each in result:
-                result_songs.append(repr_song_map[each])
+        result_songs = [repr_song_map[each] for each in result]
+        
         return SimpleSearchResult(
             q=keyword,
             songs=[to_brief_song(song) for song in result_songs]


### PR DESCRIPTION
1. 简单修复本地音乐搜索功能完全失效的问题
2. 支持配置是否对本地音乐的专辑艺术家信息进行分隔
3. 支持配置对本地音乐的艺术家信息分隔符与不拆分艺术家的列表(参考poweramp)