### PR TITLE
gui: render song exploring page correctly

### DIFF
--- a/feeluown/gui/pages/song_explore.py
+++ b/feeluown/gui/pages/song_explore.py
@@ -6,7 +6,7 @@ from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtWidgets import QWidget, QHBoxLayout, QLabel, QVBoxLayout, \
     QSizePolicy, QScrollArea, QFrame
 
-from feeluown.excs import ProviderNotFound
+from feeluown.excs import ProviderNotFound, ModelCannotUpgrade
 from feeluown.library import (
     SupportsSongHotComments, SupportsSongSimilar, SupportsSongWebUrl,
     NotSupported, SupportsSongLyric
@@ -55,7 +55,7 @@ async def render(req, **kwargs):  # pylint: disable=too-many-locals,too-many-bra
 
     try:
         upgraded_song = await aio.run_fn(app.library.song_upgrade, song)
-    except NotSupported:
+    except (NotSupported, ModelCannotUpgrade):
         upgraded_song = None
     if upgraded_song is not None:
         song = upgraded_song
@@ -72,7 +72,7 @@ async def render(req, **kwargs):  # pylint: disable=too-many-locals,too-many-bra
     if album is not None:
         try:
             upgraded_album = await aio.run_fn(app.library.album_upgrade, song.album)
-        except NotSupported:
+        except (NotSupported, ModelCannotUpgrade):
             upgraded_album = None
     else:
         upgraded_album = None

--- a/tests/gui/pages/test_pages.py
+++ b/tests/gui/pages/test_pages.py
@@ -56,6 +56,26 @@ async def test_render_song_v2(guiapp, ekaf_provider):
 
 
 @pytest.mark.asyncio
+async def test_render_song_v2_with_non_exists_album(guiapp, ekaf_provider):
+    """
+    When the album does not exist, the rendering process should succeed.
+    This test case tests that every exceptions, which raised by library, should
+    be correctly catched.
+    """
+    song = SongModel(source=ekaf_provider.identifier,
+                     identifier='0',
+                     title='',
+                     album=BriefAlbumModel(source=ekaf_provider.identifier,
+                                           identifier='not_exist'),
+                     artists=[],
+                     duration=0)
+    ctx = {'model': song, 'app': guiapp}
+    req = Request('', '', {}, {}, ctx)
+    # No error should occur.
+    await render_song_explore(req)
+
+
+@pytest.mark.asyncio
 async def test_render_playlist_v2(guiapp, ekaf_provider):
     playlist = PlaylistModel(
         source=ekaf_provider.identifier,


### PR DESCRIPTION
When the song's album does not exist, the page rendering may fail. The exception ModelCannotUpgrade is not catched.