### PR TITLE
gui: window becomes large unexpectedly

### DIFF
--- a/feeluown/gui/widgets/messageline.py
+++ b/feeluown/gui/widgets/messageline.py
@@ -2,7 +2,7 @@ from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtGui import QPalette
 from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout
 
-from feeluown.gui.helpers import BgTransparentMixin
+from feeluown.gui.helpers import BgTransparentMixin, elided_text
 
 
 class MessageLine(QWidget, BgTransparentMixin):
@@ -36,6 +36,6 @@ class MessageLine(QWidget, BgTransparentMixin):
         self._layout.setSpacing(0)
 
     def show_msg(self, msg, timeout=1300, **kwargs):
-        self._label.setText(msg)
+        self._label.setText(elided_text(msg, self.width(), self.font()))
         self.show()
         self._timer.start(timeout)


### PR DESCRIPTION
Before, the message line widget show text in one line. When the line is too long, and the width becomes big.