### PR TITLE
library: add pic_url field for SongModel

### DIFF
--- a/feeluown/library/__init__.py
+++ b/feeluown/library/__init__.py
@@ -23,5 +23,5 @@ from .models import ModelFlags, BaseModel, ModelType, \
     get_modelcls_by_type, \
     V2SupportedModelTypes
 from .excs import NotSupported, NoUserLoggedIn, ModelNotFound, \
-    ProviderAlreadyExists, ResourceNotFound, MediaNotFound
+    ProviderAlreadyExists, ResourceNotFound, MediaNotFound, ModelCannotUpgrade
 from .provider_protocol import *

--- a/feeluown/library/excs.py
+++ b/feeluown/library/excs.py
@@ -9,4 +9,5 @@ from feeluown.excs import (  # noqa
     NotSupported,
     NoUserLoggedIn,
     MediaNotFound,
+    ModelCannotUpgrade,
 )  # noqa

--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -690,7 +690,7 @@ class Library:
     def _model_upgrade(self, model):
         """
         :raises NotSupported: provider does't impl SupportGetProtocol for the model type
-        :raises CannotUpgrade: the model can't be upgraded
+        :raises ModelCannotUpgrade: the model can't be upgraded
         """
         # Upgrade model in v1 way if it is a v1 model.
         if MF.v2 not in model.meta.flags:

--- a/feeluown/library/models.py
+++ b/feeluown/library/models.py
@@ -258,6 +258,10 @@ class BriefUserModel(BaseBriefModel):
 
 
 class SongModel(BaseNormalModel):
+    """
+    ..versionadded: 3.8.11
+        The `pic_url` field.
+    """
     meta: Any = ModelMeta.create(ModelType.song, is_normal=True)
     title: str
     album: Optional[BriefAlbumModel]
@@ -268,6 +272,12 @@ class SongModel(BaseNormalModel):
     date: str = ''  # For example: 2020-12-11 00:00:00, 2020-12-11T00:00:00Z
     track: str = '1/1'  # The number of the track on the album.
     disc: str = '1/1'
+    # Before the field pic_url is added, user needs to fetch a AlbumModel
+    # to get the image url of the song, which means that there needs another
+    # IO request. However, for almost every music providers, the pic url of the song
+    # can be fetched in get_song_detail API. So one IO request can be saved
+    # to fetch a image url of the song.
+    pic_url: str = ''
 
     @property
     def artists_name(self):

--- a/feeluown/models/models.py
+++ b/feeluown/models/models.py
@@ -207,7 +207,7 @@ class SongModel(BaseModel, MultiQualityMixin):
         model_type = ModelType.song.value
         fields = ['album', 'artists', 'lyric', 'comments', 'title', 'url',
                   'duration', 'mv', 'media',
-                  'disc', 'genre', 'date', 'track', ]
+                  'disc', 'genre', 'date', 'track', 'pic_url']
         fields_display = ['title', 'artists_name', 'album_name', 'duration_ms']
 
         support_multi_quality = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from feeluown import models
 from feeluown.library import (
     AbstractProvider, ProviderV2, ModelType, ProviderFlags as PF,
     AlbumModel, ArtistModel, BriefVideoModel, BriefSongModel,
-    Library,
+    Library, SongModel, BriefAlbumModel, BriefArtistModel
 )
 from feeluown.media import Quality, Media, MediaType
 from feeluown.utils.reader import create_reader
@@ -48,6 +48,10 @@ class EkafProvider(AbstractProvider, ProviderV2):
     @property
     def name(self):
         return 'EKAF'
+
+    def song_get(self, identifier):
+        if identifier == _ekaf_song0.identifier:
+            return _ekaf_song0
 
     def song_list_quality(self, song):
         return []
@@ -110,6 +114,10 @@ _song2 = FakeSongModel(identifier=2, url='2.mp3')
 _song3 = FakeSongModel(identifier=3)
 _ekaf_brief_song0 = BriefSongModel(source=EkafSource,
                                    identifier='0')
+_ekaf_brief_album0 = BriefAlbumModel(source=EkafSource,
+                                     identifier='0')
+_ekaf_brief_artist0 = BriefArtistModel(source=EkafSource,
+                                       identifier='0')
 _ekaf_album0 = AlbumModel(source=EkafSource,
                           identifier='0', name='0', cover='',
                           description='', songs=[], artists=[])
@@ -118,6 +126,9 @@ _ekaf_artist0 = ArtistModel(source=EkafSource,
                             description='', hot_songs=[], aliases=[])
 _ekaf_brief_mv0 = BriefVideoModel(source=EkafSource,
                                   identifier='0', title='')
+_ekaf_song0 = SongModel(source=EkafSource,
+                        identifier='0', title='0', album=_ekaf_brief_album0,
+                        artists=[_ekaf_brief_artist0], duration=0)
 
 
 @pytest.fixture
@@ -133,6 +144,11 @@ def album():
 @pytest.fixture
 def ekaf_brief_song0():
     return _ekaf_brief_song0
+
+
+@pytest.fixture
+def ekaf_song0():
+    return _ekaf_song0
 
 
 @pytest.fixture

--- a/tests/gui/test_helpers.py
+++ b/tests/gui/test_helpers.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+import pytest
+
+from feeluown.models import reverse
+from feeluown.library import ModelCannotUpgrade
+from feeluown.gui.helpers import fetch_cover_wrapper
+
+
+async def img_mgr_get_return_x():
+    return b'x'
+
+
+@pytest.mark.asyncio
+async def test_fetch_cover_wrapper(app_mock, library,
+                                   ekaf_brief_song0, ekaf_album0, ekaf_song0,
+                                   song):
+    app_mock.library = library
+    app_mock.img_mgr.get_from_cache.return_value = None
+    mock_img_mgr_get = app_mock.img_mgr.get
+    song_pic_uri = reverse(ekaf_song0, '/pic_url')
+    album_cover_uri = reverse(ekaf_album0, '/cover')
+
+    # case 1: when song is a v2 model and it has pic_url, it should directly used.
+    url = 'http://xxx.com/cover.jpg'
+    ekaf_song0.pic_url = url
+    cb = mock.MagicMock()
+    mock_img_mgr_get.return_value = img_mgr_get_return_x()
+    coro = fetch_cover_wrapper(app_mock)
+    await coro(ekaf_brief_song0, cb)
+    mock_img_mgr_get.assert_called_once_with(url, song_pic_uri)
+    cb.assert_called_once_with(b'x')
+
+    # case 2: song.pic_url is empty and its album has valid cover,
+    # the cover should be used.
+    ekaf_song0.pic_url = ''
+    ekaf_album0.cover = 'http://xxx.com/cover.jpg'
+    cb = mock.MagicMock()
+    app_mock.img_mgr.get.return_value = img_mgr_get_return_x()
+    coro = fetch_cover_wrapper(app_mock)
+    await coro(ekaf_brief_song0, cb)
+    mock_img_mgr_get.assert_called_with(url, album_cover_uri)
+    cb.assert_called_once_with(b'x')
+
+    # case 3: song is a v1 model, and it's album has valid cover.
+    app_mock.img_mgr.get.return_value = img_mgr_get_return_x()
+    song.album.cover = 'http://xxx.com/cover.jpg'
+    cb = mock.MagicMock()
+    coro = fetch_cover_wrapper(app_mock)
+    await coro(song, cb)
+    cb.assert_called_once_with(b'x')
+
+    # case 4: song has no valid album
+    song.album.cover = ''
+    cb = mock.MagicMock()
+    coro = fetch_cover_wrapper(app_mock)
+    await coro(song, cb)
+    cb.assert_called_once_with(None)
+
+    # case 5: song can not be upgraded
+    mock_upgrad_song = mock.MagicMock()
+    app_mock.library.song_upgrade = mock_upgrad_song
+    mock_upgrad_song.side_effect = ModelCannotUpgrade
+    cb = mock.MagicMock()
+    coro = fetch_cover_wrapper(app_mock)
+    await coro(ekaf_brief_song0, cb)
+    cb.assert_called_once_with(None)

--- a/tests/player/test_playlist.py
+++ b/tests/player/test_playlist.py
@@ -312,6 +312,7 @@ def test_playlist_next_should_call_set_current_song(app_mock, mocker, song):
 async def test_playlist_prepare_metadata_for_song(app_mock, pl, ekaf_brief_song0):
     class Album:
         cover = Media('fuo://')
+        released = '2018-01-01'
     album = Album()
     f = asyncio.Future()
     f.set_result(album)


### PR DESCRIPTION
Before the field pic_url is added, user needs to fetch a AlbumModel
to get the image url of the song, which means that there needs another
IO request. However, for almost every music providers, the pic url of the song
can be fetched in get_song_detail API. So one IO request can be saved
to fetch a image url of the song.