### PR TITLE
nowplaying: fix race condition, add tests and comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,16 @@ jobs:
           pip install "pytest<7.2"
           pip install -e .[dev]
 
+      - name: Install Python(macOS) Dependencies
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          pip install -e .[macos]
+
+      - name: Install Python(windows) Dependencies
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          pip install -e .[win32]
+
       - name: Test if no syntax error
         run: feeluown -h
 

--- a/feeluown/nowplaying/__init__.py
+++ b/feeluown/nowplaying/__init__.py
@@ -12,21 +12,30 @@ async def run_nowplaying_server(app):
         logger.warning(f"run nowplaying server failed: '{e}'")
 
 
+def get_service_cls():
+    """
+    Only public for testing.
+    """
+    # pylint: disable=import-outside-toplevel
+    from .nowplaying import NowPlayingService
+
+    if sys.platform == 'darwin':
+        from .macos import MacosMixin
+
+        class Service(MacosMixin, NowPlayingService):
+            pass
+    else:
+        Service = NowPlayingService
+    return Service
+
+
 async def run_nowplaying_server_internal(app):
     # pylint: disable=import-outside-toplevel
     if sys.platform == 'linux':
         from .linux import run_mpris2_server
         run_mpris2_server(app)
     elif sys.platform in ('win32', 'darwin'):
-        from .nowplaying import NowPlayingService
-        if sys.platform == 'darwin':
-            from .macos import MacosMixin
-
-            class Service(MacosMixin, NowPlayingService):
-                pass
-        else:
-            Service = NowPlayingService
-        service = Service(app)
+        service = get_service_cls()(app)
         await service.start()
     else:
         logger.warning('nowplaying is not supported on %s', sys.platform)

--- a/feeluown/nowplaying/macos.py
+++ b/feeluown/nowplaying/macos.py
@@ -10,8 +10,8 @@ from feeluown.utils import aio
 
 class MacosMixin:
 
-    def update_song_props(self, meta):
-        super().update_song_props(meta)
+    def update_song_metadata(self, meta):
+        super().update_song_metadata(meta)
 
         artwork = meta.get('artwork', '')
         artwork_uid = meta.get('uri', artwork)

--- a/feeluown/nowplaying/nowplaying.py
+++ b/feeluown/nowplaying/nowplaying.py
@@ -30,10 +30,11 @@ class NowPlayingService(aionp.NowPlayingInterface):
         self._app = app
 
         self._app.player.seeked.connect(self.update_position)
-        self._app.player.duration_changed.connect(self.update_duration)
+        self._app.player.media_loaded.connect(self.on_player_media_loaded, aioqueue=True)
+        self._app.player.duration_changed.connect(self.update_duration, aioqueue=True)
         self._app.player.state_changed.connect(self.update_playback_status)
-        self._app.player.metadata_changed.connect(self.update_song_props)
-        self._app.player.media_changed.connect(self.on_player_media_changed)
+        self._app.player.metadata_changed.connect(self.update_song_metadata, aioqueue=True)
+        self._app.player.media_changed.connect(self.on_player_media_changed, aioqueue=True)
         self._app.playlist.playback_mode_changed.connect(self.update_playback_mode)
         self._app.started.connect(
             lambda: self.update_playback_mode(self._app.playlist.playback_mode))
@@ -56,7 +57,7 @@ class NowPlayingService(aionp.NowPlayingInterface):
         self.set_playback_property(PlayProp.LoopStatus, mode_value[0])
         self.set_playback_property(PlayProp.Shuffle, mode_value[1])
 
-    def update_song_props(self, meta: dict):
+    def update_song_metadata(self, meta: dict):
         metadata = aionp.PlaybackProperties.MetadataBean()
         metadata.artist = meta.get('artists', ['Unknown'])
         metadata.album = meta.get('album', '')
@@ -117,6 +118,11 @@ class NowPlayingService(aionp.NowPlayingInterface):
             raise ValueError('unknown key')
 
     def on_player_media_changed(self, _):
+        # Update position when media is changed, so that some nowplaying servers
+        # can update its UI immediately.
+        self.set_playback_property(PlayProp.Position, 0)
+
+    def on_player_media_loaded(self):
         # As seeked signal is not emitted when media is changed,
         # update position explicitly.
         self.set_playback_property(PlayProp.Position, 0)

--- a/feeluown/nowplaying/nowplaying.py
+++ b/feeluown/nowplaying/nowplaying.py
@@ -13,7 +13,10 @@ StatePlaybackStatusMapping = {
     State.paused: aionp.PlaybackStatus.Paused,
     State.playing: aionp.PlaybackStatus.Playing,
 }
-PlaybackStatusStateMapping = {v: k for k, v in StatePlaybackStatusMapping.items()}
+PlaybackStatusStateMapping = {
+    v: k
+    for k, v in StatePlaybackStatusMapping.items()
+}
 
 
 def to_aionp_time(t):
@@ -30,14 +33,19 @@ class NowPlayingService(aionp.NowPlayingInterface):
         self._app = app
 
         self._app.player.seeked.connect(self.update_position)
-        self._app.player.media_loaded.connect(self.on_player_media_loaded, aioqueue=True)
-        self._app.player.duration_changed.connect(self.update_duration, aioqueue=True)
+        self._app.player.media_loaded.connect(self.on_player_media_loaded,
+                                              aioqueue=True)
+        self._app.player.duration_changed.connect(self.update_duration,
+                                                  aioqueue=True)
         self._app.player.state_changed.connect(self.update_playback_status)
-        self._app.player.metadata_changed.connect(self.update_song_metadata, aioqueue=True)
-        self._app.player.media_changed.connect(self.on_player_media_changed, aioqueue=True)
-        self._app.playlist.playback_mode_changed.connect(self.update_playback_mode)
-        self._app.started.connect(
-            lambda: self.update_playback_mode(self._app.playlist.playback_mode))
+        self._app.player.metadata_changed.connect(self.update_song_metadata,
+                                                  aioqueue=True)
+        self._app.player.media_changed.connect(self.on_player_media_changed,
+                                               aioqueue=True)
+        self._app.playlist.playback_mode_changed.connect(
+            self.update_playback_mode)
+        self._app.started.connect(lambda: self.update_playback_mode(
+            self._app.playlist.playback_mode))
 
         self.set_playback_property(PlayProp.CanPlay, True)
         self.set_playback_property(PlayProp.CanPause, True)

--- a/feeluown/player/base_player.py
+++ b/feeluown/player/base_player.py
@@ -28,7 +28,11 @@ class State(IntEnum):
 
 
 class AbstractPlayer(metaclass=ABCMeta):
-    """Player abstrace base class"""
+    """Player abstrace base class.
+
+    Note that signals may be emitted from different thread. You should
+    take care of race condition.
+    """
 
     def __init__(self, _=None, **kwargs):
         """
@@ -50,18 +54,16 @@ class AbstractPlayer(metaclass=ABCMeta):
         #: player state changed signal
         self.state_changed = Signal()
 
-        #: current media finished signal
-        self.media_finished = Signal()
-
         #: duration changed signal
         self.duration_changed = Signal()
 
         #: media about to change: (old_media, media)
         self.media_about_to_changed = Signal()
-        #: media changed signal
-        self.media_changed = Signal()
-        self.media_loaded = Signal()
+        self.media_changed = Signal()  # Media source is changed (not loaded yet).
+        self.media_loaded = Signal()  # Start to play the media.
+        # Metadata is changed, and it may be changed during playing.
         self.metadata_changed = Signal()
+        self.media_finished = Signal()  # Finish to play the media.
 
         #: volume changed signal: (int)
         self.volume_changed = Signal()

--- a/feeluown/player/lyric.py
+++ b/feeluown/player/lyric.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
 import re
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 from collections import namedtuple, OrderedDict
 
-from feeluown.library import LyricModel
+from feeluown.library import LyricModel, NotSupported
 from feeluown.utils import aio
 from feeluown.utils.dispatch import Signal
+
+if TYPE_CHECKING:
+    from feeluown.app import App
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +120,7 @@ class LiveLyric:
         player.song_changed.connect(live_lyric.on_song_changed)
         player.position_change.connect(live_lyric.on_position_changed)
     """
-    def __init__(self, app):
+    def __init__(self, app: App):
         """
 
         :type app: feeluown.app.App
@@ -191,6 +195,8 @@ class LiveLyric:
         def cb(future):
             try:
                 lyric = future.result()
+            except NotSupported:
+                lyric = None
             except:  # noqa
                 logger.exception('get lyric failed')
                 lyric = None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import asyncio
 
 
 is_travis_env = os.environ.get('TEST_ENV') == 'travis'
@@ -7,3 +9,17 @@ cannot_play_audio = is_travis_env
 
 # By set QT_QPA_PLATFORM=offscreen, qt widgets can run on various CI.
 cannot_run_qt_test = False
+is_macos = sys.platform == 'darwin'
+
+
+async def aio_waitfor_simple_tasks():
+    """
+    Many async test cases need to assert some internal tasks must be done,
+    but we have no way to confirm if it is done. In most cases, call asyncio.sleep
+    to let asyncio schedule the task is enough.
+
+    Here, simple means that the task can be done as long as it is scheduled.
+
+    HELP: find a more robust way to do this.
+    """
+    await asyncio.sleep(0.001)

--- a/tests/test_nowplaying.py
+++ b/tests/test_nowplaying.py
@@ -1,0 +1,13 @@
+import pytest
+
+from feeluown.nowplaying import get_service_cls
+from .helpers import is_macos, aio_waitfor_simple_tasks
+
+
+@pytest.mark.skipif(not is_macos, reason='only test on macos')
+@pytest.mark.asyncio
+async def test_macos_update_song_pic(app_mock):
+    service = get_service_cls()(app_mock)
+    service.update_song_metadata({})
+    await aio_waitfor_simple_tasks()
+    assert app_mock.img_mgr.get.called


### PR DESCRIPTION
1. Listen to media_loaded signal and update nowplaying position property.
2. Fix race condition when signals are emitted at the same time in different thread.