### PR TITLE
[enhance](plugin) scan plugins(without enabling them) at the very first

### DIFF
--- a/feeluown/app/app.py
+++ b/feeluown/app/app.py
@@ -124,7 +124,7 @@ class App:
                 except ResolverNotFound:
                     pass
                 except ResolveFailed as e:
-                    logger.warning('resolve failed, {e}')
+                    logger.warning(f'resolve failed, {e}')
                 else:
                     recently_played_models.append(model)
             recently_played.init_from_models(recently_played_models)

--- a/feeluown/entry_points/run_app.py
+++ b/feeluown/entry_points/run_app.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 
 from feeluown.app import AppMode, create_app, create_config
+from feeluown.plugin import plugins_mgr
 from feeluown.utils.utils import is_port_inuse, win32_is_port_binded
 from feeluown.fuoexec import fuoexec_load_rcfile, fuoexec_init
 from feeluown.utils import aio
@@ -36,6 +37,10 @@ def before_start_app(args):
     Prepare things that app depends on and initialize things which don't depend on app.
     """
     config = create_config()
+
+    # Light scan plugins, they may define some configurations.
+    plugins_mgr.light_scan()
+    plugins_mgr.init_plugins_config(config)
 
     # Load rcfile.
     #

--- a/feeluown/plugin.py
+++ b/feeluown/plugin.py
@@ -177,6 +177,9 @@ class PluginsManager:
 
     def _scan_dirs(self):
         """扫描插件目录中的插件"""
+        if not os.path.exists(USER_PLUGINS_DIR):
+            return
+
         module_name_list = []
         for fname in os.listdir(USER_PLUGINS_DIR):
             if os.path.isdir(os.path.join(USER_PLUGINS_DIR, fname)):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -39,6 +39,6 @@ def config():
 @pytest.fixture
 def noharm(mocker):
     mocker.patch('feeluown.app.app.Player')
-    mocker.patch.object(PluginsManager, 'scan')
+    mocker.patch.object(PluginsManager, 'enable_plugins')
     # CollectionUiManager write library.fuo file during initialization.
     mocker.patch.object(CollectionUiManager, 'initialize')

--- a/tests/entry_points/test_run_app.py
+++ b/tests/entry_points/test_run_app.py
@@ -31,7 +31,7 @@ def noharm(mocker):
     """
     mocker.patch('feeluown.entry_points.run_app.ensure_dirs')
     mocker.patch.object(App, 'dump_state')
-    mocker.patch.object(PluginsManager, 'scan')
+    mocker.patch.object(PluginsManager, 'enable_plugins')
     # CollectionUiManager write library.fuo file during initialization.
     mocker.patch.object(CollectionUiManager, 'initialize')
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -36,8 +36,8 @@ def foo_plugin(foo_module):
 
 
 @pytest.fixture
-def plugin_mgr(app_mock):
-    return PluginsManager(app_mock)
+def plugin_mgr():
+    return PluginsManager()
 
 
 def test_plugin_init_config(foo_plugin):
@@ -47,10 +47,12 @@ def test_plugin_init_config(foo_plugin):
     assert config.foo.VERBOSE == 0
 
 
-def test_plugin_manager_load_module(plugin_mgr, foo_module, mocker):
+def test_plugin_manager_enable_plugin(plugin_mgr, foo_module, app_mock, mocker):
     mock_init_config = mocker.patch.object(Plugin, 'init_config')
     mock_enable = mocker.patch.object(Plugin, 'enable')
-    plugin_mgr.load_module(foo_module)
+    plugin_mgr.load_plugin_from_module(foo_module)
+    plugin_mgr.init_plugins_config(Config())
+    plugin_mgr.enable_plugins(app_mock)
     # The `init_config` and `enable` function should be called.
     assert mock_init_config.called
     assert mock_enable.called


### PR DESCRIPTION
Before, it is hard for users to define config for plugins. Now, it's really simple. 
For example, if users want to set http_proxy for youtube music, just write the following line in the fuorc
```
config.ytmusic.HTTP_PROXY='http://127.0.0.1:7890'
``` 