### PR TITLE
[bugfix](gui): fix crash in drag and drop

### DIFF
--- a/feeluown/gui/widgets/playlists.py
+++ b/feeluown/gui/widgets/playlists.py
@@ -96,7 +96,7 @@ class PlaylistsView(TextlistView):
         try:
             # FIXME: this may block the app.
             app = self.parent().parent()._app   # type: ignore[attr-defined]
-            app.library.playlist_add_song(playlist, song)
+            is_success = app.library.playlist_add_song(playlist, song)
         except:  # noqa, to avoid crash.
             logger.exception('add song to playlist failed')
             is_success = False


### PR DESCRIPTION
A successful drag and drop to playlist causes `is_success' unbound and eventually crash the whole application. 105aa5a9 introduces this, this PR fixes it.