### PR TITLE
Fixed issue where the code assumes ~/.FeelUOwn/ exists when copying png files

### DIFF
--- a/feeluown/cli/install.py
+++ b/feeluown/cli/install.py
@@ -75,6 +75,7 @@ def gen_for_win_linux():
     DESKTOP_FILE = 'feeluown.desktop'
     from_icon = ICONS_DIR / 'feeluown.png'
     to_icon = pathlib.Path.home() / '.FeelUOwn' / 'feeluown.png'
+    to_icon.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(from_icon, to_icon)
 
     icon_string = win_linux_icon.format(feeluown_icon=to_icon)


### PR DESCRIPTION
When on a fresh install as a system library (usually via OS packaging), the following will happen:
```
anton@hotlap ~ $ feeluown genicon
Generate icon, then you can see app on desktop.
Traceback (most recent call last):
  File "/usr/bin/feeluown", line 33, in <module>
    sys.exit(load_entry_point('feeluown==3.8.12', 'console_scripts', 'feeluown')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/feeluown/entry_points/run.py", line 27, in run
    return run_cli(args)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/feeluown/entry_points/run_cli.py", line 6, in run_cli
    aio.run(climain(args))
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/feeluown/cli/cli.py", line 221, in climain
    generate_icon()
  File "/usr/lib/python3.11/site-packages/feeluown/cli/install.py", line 126, in generate_icon
    gen_for_win_linux()
  File "/usr/lib/python3.11/site-packages/feeluown/cli/install.py", line 78, in gen_for_win_linux
    shutil.copy(from_icon, to_icon)
  File "/usr/lib/python3.11/shutil.py", line 419, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.11/shutil.py", line 258, in copyfile
    with open(dst, 'wb') as fdst:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/anton/.FeelUOwn/feeluown.png'
```
The code assumes `~/.FeelUOwn/` exists, which is not true on a fresh machine with a fresh install of feeluown.

This PR should correct this.