### PR TITLE
local: fix duration format

### DIFF
--- a/feeluown/local/db.py
+++ b/feeluown/local/db.py
@@ -143,7 +143,7 @@ def read_audio_metadata(fpath, can_convert_chinese=False, lang='auto') -> Option
         metadata_dict['duration'] = 0
     else:
         # milesecond
-        metadata_dict['duration'] = metadata.info.length * 1000
+        metadata_dict['duration'] = int(metadata.info.length * 1000)
 
     # Convert simplified to traditional, or reverse.
     if can_convert_chinese:


### PR DESCRIPTION
It should be an `int` according to `SongModel`'s spec, but not converted accordingly. Breaks pydantic validation:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for SongModel
duration
  Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=226533.87755102038, input_type=float]
```