### PR TITLE
Update Arch Linux package URL in quickstart.rst

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -73,7 +73,7 @@ Windows
 Arch Linux
 ~~~~~~~~~~
 
-https://archlinux.org/packages/community/any/feeluown/
+https://archlinux.org/packages/extra/any/feeluown/
 
 Gentoo
 ~~~~~~


### PR DESCRIPTION
The old URL returns 404 now.