### PR TITLE
library: remove model protocol usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ flake8:
 # flake8 is mainly used for constrainting coding style
 # pylint is mainly used for finding obvious bugs
 # mypy is mainly used for better readable code
-lint: flake8 pylint mypy
+lint: flake8 pylint
 
 unittest: pytest
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ flake8:
 # flake8 is mainly used for constrainting coding style
 # pylint is mainly used for finding obvious bugs
 # mypy is mainly used for better readable code
-lint: flake8 pylint
+lint: flake8 pylint mypy
 
 unittest: pytest
 

--- a/feeluown/collection.py
+++ b/feeluown/collection.py
@@ -124,9 +124,9 @@ class Collection:
 
         doc = tomlkit.document()
         if title:
-            doc.add('title', title)
-        doc.add('created', datetime.now())
-        doc.add('updated', datetime.now())
+            doc.add('title', title)         # type: ignore[arg-type]
+        doc.add('created', datetime.now())  # type: ignore[arg-type]
+        doc.add('updated', datetime.now())  # type: ignore[arg-type]
         with open(fpath, 'w', encoding='utf-8') as f:
             f.write(TOML_DELIMLF)
             f.write(tomlkit.dumps(doc))

--- a/feeluown/gui/components/btns.py
+++ b/feeluown/gui/components/btns.py
@@ -1,20 +1,23 @@
 import logging
+from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import QEvent
 from PyQt5.QtWidgets import QPushButton, QWidget, QHBoxLayout
 
-from feeluown.app import App
 from feeluown.player import State
 from feeluown.excs import ProviderIOError
 from feeluown.utils.aio import run_fn
 from feeluown.gui.widgets.textbtn import TextButton
 from feeluown.gui.helpers import resize_font
 
+if TYPE_CHECKING:
+    from feeluown.app.gui_app import GuiApp
+
 logger = logging.getLogger(__name__)
 
 
 class LyricButton(TextButton):
-    def __init__(self, app: App, **kwargs):
+    def __init__(self, app: 'GuiApp', **kwargs):
         kwargs.setdefault('height', 16)
         super().__init__('词', **kwargs)
         self._app = app
@@ -45,7 +48,7 @@ class LyricButton(TextButton):
 
 
 class WatchButton(TextButton):
-    def __init__(self, app: App, *args, **kwargs):
+    def __init__(self, app: 'GuiApp', *args, **kwargs):
         super().__init__('♨', *args, **kwargs)
         self._app = app
 
@@ -75,7 +78,7 @@ class WatchButton(TextButton):
 
 
 class LikeButton(QPushButton):
-    def __init__(self, app: App, size=(15, 15), parent=None):
+    def __init__(self, app: 'GuiApp', size=(15, 15), parent=None):
         super().__init__(parent=parent)
         self._app = app
         self.setCheckable(True)
@@ -113,7 +116,7 @@ class LikeButton(QPushButton):
 
 
 class SongMVTextButton(TextButton):
-    def __init__(self, app: App, song=None, text='MV', **kwargs):
+    def __init__(self, app: 'GuiApp', song=None, text='MV', **kwargs):
         super().__init__(text, **kwargs)
         self._app = app
         self._song = None
@@ -152,7 +155,7 @@ class SongMVTextButton(TextButton):
 
 
 class MVButton(SongMVTextButton):
-    def __init__(self, app: App, parent=None, **kwargs):
+    def __init__(self, app: 'GuiApp', parent=None, **kwargs):
         super().__init__(app, song=None, parent=parent, **kwargs)
 
         self.setObjectName('mv_btn')
@@ -169,7 +172,7 @@ class MVButton(SongMVTextButton):
 
 
 class MediaButtons(QWidget):
-    def __init__(self, app: App, spacing=8, button_width=30, parent=None):
+    def __init__(self, app: 'GuiApp', spacing=8, button_width=30, parent=None):
         super().__init__(parent=parent)
 
         self._app = app

--- a/feeluown/gui/components/collections.py
+++ b/feeluown/gui/components/collections.py
@@ -30,9 +30,11 @@ class CollectionListView(TextlistView):
         self._app.coll_mgr.scan_finished.connect(self.on_scan_finished)
 
     def on_scan_finished(self):
-        self.model().clear()
+        model = self.model()
+        assert isinstance(model, TextlistModel)
+        model.clear()
         for coll in self._app.coll_mgr.listall():
-            self.model().add(coll)
+            model.add(coll)
 
     def _on_clicked(self, index):
         collection = index.data(role=Qt.UserRole)

--- a/feeluown/gui/components/menu.py
+++ b/feeluown/gui/components/menu.py
@@ -1,11 +1,13 @@
 import logging
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
-from feeluown.app import App
 from feeluown.excs import ProviderIOError
 from feeluown.utils.aio import run_fn, run_afn
 from feeluown.player import SongRadio
 from feeluown.library import SongModel, VideoModel
+
+if TYPE_CHECKING:
+    from feeluown.app.gui_app import GuiApp
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +17,7 @@ MV_BTN_TEXT = '播放 MV'
 
 class SongMenuInitializer:
 
-    def __init__(self, app: App, song):
+    def __init__(self, app: 'GuiApp', song):
         """
         :type app: feeluown.app.App
         """

--- a/feeluown/gui/components/menu.py
+++ b/feeluown/gui/components/menu.py
@@ -5,7 +5,7 @@ from feeluown.app import App
 from feeluown.excs import ProviderIOError
 from feeluown.utils.aio import run_fn, run_afn
 from feeluown.player import SongRadio
-from feeluown.library import SongProtocol, VideoModel
+from feeluown.library import SongModel, VideoModel
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class SongMenuInitializer:
             app.browser.goto(model=song, path='/explore')
 
         async def goto_song_album(song):
-            usong: SongProtocol = await run_fn(self._app.library.song_upgrade, song)
+            usong: SongModel = await run_fn(self._app.library.song_upgrade, song)
             if usong.album is not None:
                 self._app.browser.goto(model=usong.album)
             else:

--- a/feeluown/gui/drawers.py
+++ b/feeluown/gui/drawers.py
@@ -46,6 +46,7 @@ class PixmapDrawer:
     def maybe_update_pixmap(self):
         if self._widget.width() != self._widget_last_width:
             self._widget_last_width = self._widget.width()
+            assert self._img is not None
             new_img = self._img.scaledToWidth(self._widget_last_width,
                                               Qt.SmoothTransformation)
             self._pixmap = QPixmap(new_img)

--- a/feeluown/gui/pages/search.py
+++ b/feeluown/gui/pages/search.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QFrame, QVBoxLayout
+from PyQt5.QtWidgets import QAbstractItemView, QFrame, QVBoxLayout
 
 from feeluown.library import SearchType
 from feeluown.gui.page_containers.table import TableContainer, Renderer
@@ -58,9 +58,11 @@ async def render(req, **kwargs):  # pylint: disable=too-many-locals,too-many-bra
             # HACK: set fixed row for tables.
             # pylint: disable=protected-access
             for table in table_container._tables:
+                assert isinstance(table, QAbstractItemView)
                 delegate = table.itemDelegate()
                 if isinstance(delegate, ImgCardListDelegate):
-                    table._fixed_row_count = 2
+                    # FIXME: set fixed_row_count in better way.
+                    table._fixed_row_count = 2  # type: ignore[attr-defined]
                     delegate.update_settings("card_min_width", 100)
                 elif isinstance(table, SongsTableView):
                     table._fixed_row_count = 8

--- a/feeluown/gui/provider_ui.py
+++ b/feeluown/gui/provider_ui.py
@@ -103,7 +103,7 @@ class ProviderUiManager:
 
         self._store: Dict[str, AbstractProviderUi] = {}  # {name: provider_ui}
 
-        self._items = {}  # name:model mapping
+        self._items: Dict[str, ProviderUiItem] = {}  # name:model mapping
         self.model = ProvidersModel(self._app.library, self._app)
 
     def register(self, provider_ui: AbstractProviderUi):

--- a/feeluown/gui/uimain/floating_box.py
+++ b/feeluown/gui/uimain/floating_box.py
@@ -135,7 +135,7 @@ class AnimatedCoverLabel(CoverLabelV2):
         super().__init__(app, *args, **kwargs)
 
         self._padding = padding
-        self._angle = 0
+        self._angle: float = 0
         self._timer = QTimer()
         self._timer.timeout.connect(self.on_timeout)
         self._timer.start(16)
@@ -163,12 +163,13 @@ class AnimatedCoverLabel(CoverLabelV2):
         painter.setBrush(QBrush(color))
         painter.drawRoundedRect(self.rect(), radius, radius)
 
-        if self._pixmap is not None:
-            size = self._pixmap.size()
+        pixmap =  self.drawer.get_pixmap()
+        if pixmap is not None:
+            size = pixmap.size()
             y = (size.height() - self.height()) // 2
             rect = QRect(self._padding, y+self._padding,
                          self.width()-self._padding*2, self.height()-self._padding*2)
-            brush = QBrush(self._pixmap)
+            brush = QBrush(pixmap)
             painter.setBrush(brush)
             painter.drawRoundedRect(rect, radius, radius)
 

--- a/feeluown/gui/uimain/floating_box.py
+++ b/feeluown/gui/uimain/floating_box.py
@@ -163,7 +163,7 @@ class AnimatedCoverLabel(CoverLabelV2):
         painter.setBrush(QBrush(color))
         painter.drawRoundedRect(self.rect(), radius, radius)
 
-        pixmap =  self.drawer.get_pixmap()
+        pixmap = self.drawer.get_pixmap()
         if pixmap is not None:
             size = pixmap.size()
             y = (size.height() - self.height()) // 2

--- a/feeluown/gui/uimain/page_view.py
+++ b/feeluown/gui/uimain/page_view.py
@@ -198,9 +198,9 @@ class RightPanel(QFrame):
             self._draw_pixmap_overlay(painter, draw_width, draw_height, scrolled)
             curve = QEasingCurve(QEasingCurve.OutCubic)
             if max_scroll_height == 0:
-                alpha_ratio = 1
+                alpha_ratio = 1.0
             else:
-                alpha_ratio = min(scrolled / max_scroll_height, 1)
+                alpha_ratio = min(scrolled / max_scroll_height, 1.0)
             alpha = int(250 * curve.valueForProgress(alpha_ratio))
             painter.save()
             color = self.palette().color(QPalette.Window)

--- a/feeluown/gui/widgets/cover_label.py
+++ b/feeluown/gui/widgets/cover_label.py
@@ -59,10 +59,10 @@ class CoverLabel(QLabel):
 
     def sizeHint(self):
         super_size = super().sizeHint()
-        if self.drawer.get_pixmap() is None:
+        pixmap = self.drawer.get_pixmap()
+        if pixmap is None:
             return super_size
-        h = (self.width() * self.drawer.get_pixmap().height()) \
-            // self.drawer.get_pixmap().width()
+        h = (self.width() * pixmap.height()) // pixmap.width()
         # cover label height hint can be as large as possible, since the
         # parent width has been set maximumHeigh
         w = self.width()

--- a/feeluown/library/__init__.py
+++ b/feeluown/library/__init__.py
@@ -3,7 +3,7 @@ from .library import Library
 from .provider import AbstractProvider, ProviderV2, Provider
 from .flags import Flags as ProviderFlags
 from .model_state import ModelState
-from .model_protocol import (
+from .model_protocol import (  # deprecated
     BriefSongProtocol,
     BriefVideoProtocol,
     BriefArtistProtocol,

--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -2,7 +2,7 @@
 import logging
 import warnings
 from functools import partial
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, List
 
 from feeluown.media import Media
 from feeluown.utils.aio import run_fn, as_completed
@@ -123,7 +123,7 @@ class Library:
                 return provider
         return None
 
-    def list(self):
+    def list(self) -> List[Provider]:
         """列出所有资源提供方"""
         return list(self._providers)
 
@@ -303,6 +303,7 @@ class Library:
         provider = self.get(song.source)
         if isinstance(provider, SupportsSongMV):
             return provider.song_get_mv(song)
+        return None
 
     def song_get_lyric(self, song: BriefSongModel) -> Optional[LyricModel]:
         """Get the lyric model of a song.
@@ -313,6 +314,7 @@ class Library:
         provider = self.get(song.source)
         if isinstance(provider, SupportsSongLyric):
             return provider.song_get_lyric(song)
+        return None
 
     # --------
     # Album

--- a/feeluown/library/models.py
+++ b/feeluown/library/models.py
@@ -334,7 +334,7 @@ class CommentModel(BaseNormalModel):
     root_comment_id: Optional[str] = None
 
 
-class ArtistModel(BaseNormalModel):
+class ArtistModel(BriefArtistModel, BaseNormalModel):
     meta: Any = ModelMeta.create(ModelType.artist, is_normal=True)
     name: str
     pic_url: str
@@ -380,7 +380,7 @@ class LyricModel(BaseNormalModel):
     trans_content: str = ''
 
 
-class VideoModel(BaseNormalModel):
+class VideoModel(BriefVideoModel, BaseNormalModel):
     meta: Any = ModelMeta.create(ModelType.video, is_normal=True)
     title: str
     artists: List[BriefArtistModel]
@@ -393,7 +393,7 @@ class VideoModel(BaseNormalModel):
         self.duration_ms = get_duration_ms(self.duration)
 
 
-class PlaylistModel(BaseBriefModel):
+class PlaylistModel(BriefPlaylistModel, BaseNormalModel):
     meta: Any = ModelMeta.create(ModelType.playlist, is_normal=True)
     # Since modelv1 playlist does not have creator field, it is set to optional.
     creator: Optional[BriefUserModel] = None

--- a/feeluown/library/models.py
+++ b/feeluown/library/models.py
@@ -101,6 +101,15 @@ def fmt_artists(artists: List['BriefArtistModel']) -> str:
     return fmt_artists_names([artist.name for artist in artists])
 
 
+def get_duration_ms(duration):
+    if duration is not None:
+        seconds = duration / 1000
+        m, s = seconds / 60, seconds % 60
+    else:
+        m, s = 0, 0
+    return '{:02}:{:02}'.format(int(m), int(s))
+
+
 # When a model is fully supported (with v2 design), it means
 # the library has implemented all features(functions) for this model.
 # You can do anything with model v2 without model v1.
@@ -262,7 +271,7 @@ class BriefUserModel(BaseBriefModel):
     name: str = ''
 
 
-class SongModel(BaseNormalModel):
+class SongModel(BriefSongModel, BaseNormalModel):
     """
     ..versionadded: 3.8.11
         The `pic_url` field.
@@ -289,28 +298,17 @@ class SongModel(BaseNormalModel):
     # to fetch a image url of the song.
     pic_url: str = ''
 
+    def model_post_init(self, _):
+        super().model_post_init(_)
+        self.artists_name = fmt_artists(self.artists)
+        self.album_name = self.album.name if self.album else ''
+        self.duration_ms = get_duration_ms(self.duration)
+
     def __str__(self):
         return f'{self.source}:{self.title}•{self.artists_name}'
 
-    @property
-    def artists_name(self):
-        return fmt_artists(self.artists)
 
-    @property
-    def album_name(self):
-        return self.album.name if self.album else ''
-
-    @property
-    def duration_ms(self):
-        if self.duration is not None:
-            seconds = self.duration / 1000
-            m, s = seconds / 60, seconds % 60
-        else:
-            m, s = 0, 0
-        return '{:02}:{:02}'.format(int(m), int(s))
-
-
-class UserModel(BaseNormalModel):
+class UserModel(BriefUserModel, BaseNormalModel):
     meta: Any = ModelMeta.create(ModelType.user, is_normal=True)
     name: str = ''
     avatar_url: str = ''
@@ -345,7 +343,7 @@ class ArtistModel(BaseNormalModel):
     description: str
 
 
-class AlbumModel(BaseNormalModel):
+class AlbumModel(BriefAlbumModel, BaseNormalModel):
     """
     .. versionadded:: 3.8.12
         The `song_count` field.
@@ -371,9 +369,9 @@ class AlbumModel(BaseNormalModel):
     description: str
     released: str = ''  # format: 2000-12-27.
 
-    @property
-    def artists_name(self):
-        return fmt_artists(self.artists)
+    def model_post_init(self, _):
+        super().model_post_init(_)
+        self.artists_name = fmt_artists(self.artists)
 
 
 class LyricModel(BaseNormalModel):
@@ -389,18 +387,10 @@ class VideoModel(BaseNormalModel):
     duration: int
     cover: str
 
-    @property
-    def artists_name(self):
-        return fmt_artists(self.artists)
-
-    @property
-    def duration_ms(self):
-        if self.duration is not None:
-            seconds = self.duration / 1000
-            m, s = seconds / 60, seconds % 60
-        else:
-            m, s = 0, 0
-        return '{:02}:{:02}'.format(int(m), int(s))
+    def model_post_init(self, _):
+        super().model_post_init(_)
+        self.artists_name = fmt_artists(self.artists)
+        self.duration_ms = get_duration_ms(self.duration)
 
 
 class PlaylistModel(BaseBriefModel):

--- a/feeluown/library/models.py
+++ b/feeluown/library/models.py
@@ -63,7 +63,7 @@ try:
 except ImportError:
     # pydantic<2.0
     from pydantic import validator
-    identifier_validator = validator('identifier', pre=True)
+    identifier_validator = validator('identifier', pre=True)  # type: ignore
     pydantic_version = 1
 
 from feeluown.utils.utils import elfhash

--- a/feeluown/library/provider.py
+++ b/feeluown/library/provider.py
@@ -27,6 +27,7 @@ class Provider:
     class meta:
         identifier: str = ''
         name: str = ''
+        flags: dict = {}
 
     def __init__(self):
         self._user = None
@@ -65,36 +66,7 @@ class Provider:
         pass
 
     def use_model_v2(self, model_type: ModelType) -> bool:
-        """Check whether model v2 is used for the specified model_type.
-
-        For feeluown developer, there are three things you should know.
-
-        1. Both v2 model and v1 model implement BriefXProtocol, which means
-           model.{attirbute}_display works for both models. For exmample,
-           SongModel(v2), BriefSongModel(v2) and SongModel(v1) all implement
-           BriefSongProtocol. So no matter which version the `song` is, it is
-           always safe to access `song.title_display`.
-
-        2. When model v2 is used, it means the way of accessing model's attributes
-           becomes different. So you should always check which version
-           the model is before accessing some attributes.
-
-           For model v1, you can access all model's attributes by {model}.{attribute},
-           and IO(network) operations may be performed implicitly. For example,
-           the code `song.url` *may* trigger a network request to fetch the
-           url when `song.url` is currently None. Tips: you can check the
-           `BaseModel.__getattribute__` implementation in `feeluown.library` package
-           for more details.
-
-           For model v2, everything are explicit. Basic attributes of model can be
-           accessed by {model}.{attribute} and there will be no IO operations.
-           Other attributes can only be accessed with methods of library. For example,
-           you can access song url/media info by `library.song_prepare_media`.
-
-        3. When deserializing model from a text line, the model version is important.
-           If provider does not declare it uses model v2, feeluown just use model v1
-           to do deserialization to keep backward compatibility.
-        """
+        """Check whether model v2 is used for the specified model_type."""
         return Flags.model_v2 in self.meta.flags.get(model_type, Flags.none)
 
     def model_get(self, model_type, model_id):

--- a/feeluown/library/provider_protocol.py
+++ b/feeluown/library/provider_protocol.py
@@ -4,13 +4,10 @@ from feeluown.media import Quality, Media
 from feeluown.excs import NoUserLoggedIn
 from .models import (
     BriefCommentModel, SongModel, VideoModel, AlbumModel, ArtistModel,
-    PlaylistModel, UserModel, ModelType,
+    PlaylistModel, UserModel, ModelType, BriefArtistModel, BriefSongModel,
+    LyricModel, BriefVideoModel,
 )
-from .model_protocol import (
-    BriefArtistProtocol, BriefSongProtocol, SongProtocol,
-    BriefVideoProtocol, VideoProtocol,
-    LyricProtocol,
-)
+
 from .flags import Flags as PF
 
 
@@ -62,7 +59,7 @@ class SupportsSongGet(Protocol):
 @runtime_checkable
 class SupportsSongSimilar(Protocol):
     @abstractmethod
-    def song_list_similar(self, song: BriefSongProtocol) -> List[BriefSongProtocol]:
+    def song_list_similar(self, song: BriefSongModel) -> List[BriefSongModel]:
         """List similar songs
         """
         raise NotImplementedError
@@ -72,7 +69,7 @@ class SupportsSongSimilar(Protocol):
 @runtime_checkable
 class SupportsSongMultiQuality(Protocol):
     @abstractmethod
-    def song_list_quality(self, song: BriefSongProtocol) -> List[Quality.Audio]:
+    def song_list_quality(self, song: BriefSongModel) -> List[Quality.Audio]:
         """List all possible qualities
 
         Please ensure all the qualities are valid. `song_get_media(song, quality)`
@@ -82,7 +79,7 @@ class SupportsSongMultiQuality(Protocol):
 
     @abstractmethod
     def song_select_media(
-        self, song: BriefSongProtocol, policy=None
+        self, song: BriefSongModel, policy=None
     ) -> Tuple[Media, Quality.Audio]:
         """Select a media by the quality sorting policy
 
@@ -92,7 +89,7 @@ class SupportsSongMultiQuality(Protocol):
 
     @abstractmethod
     def song_get_media(
-        self, song: BriefVideoProtocol, quality: Quality.Audio
+        self, song: BriefVideoModel, quality: Quality.Audio
     ) -> Optional[Media]:
         """Get song's media by a specified quality
 
@@ -104,21 +101,21 @@ class SupportsSongMultiQuality(Protocol):
 @eq(ModelType.song, PF.hot_comments)
 @runtime_checkable
 class SupportsSongHotComments(Protocol):
-    def song_list_hot_comments(self, song: BriefSongProtocol) -> List[BriefCommentModel]:
+    def song_list_hot_comments(self, song: BriefSongModel) -> List[BriefCommentModel]:
         raise NotImplementedError
 
 
 @eq(ModelType.song, PF.web_url)
 @runtime_checkable
 class SupportsSongWebUrl(Protocol):
-    def song_get_web_url(self, song: BriefSongProtocol) -> str:
+    def song_get_web_url(self, song: BriefSongModel) -> str:
         raise NotImplementedError
 
 
 @eq(ModelType.song, PF.lyric)
 @runtime_checkable
 class SupportsSongLyric(Protocol):
-    def song_get_lyric(self, song: BriefSongProtocol) -> Optional[LyricProtocol]:
+    def song_get_lyric(self, song: BriefSongModel) -> Optional[LyricModel]:
         """Get music video of the song
         """
         raise NotImplementedError
@@ -127,7 +124,7 @@ class SupportsSongLyric(Protocol):
 @eq(ModelType.song, PF.mv)
 @runtime_checkable
 class SupportsSongMV(Protocol):
-    def song_get_mv(self, song: BriefSongProtocol) -> Optional[VideoProtocol]:
+    def song_get_mv(self, song: BriefSongModel) -> Optional[VideoModel]:
         """Get music video of the song
 
         """
@@ -154,7 +151,7 @@ class SupportsAlbumGet(Protocol):
 @runtime_checkable
 class SupportsAlbumSongsReader(Protocol):
     @abstractmethod
-    def album_create_songs_rd(self, album) -> List[SongProtocol]:
+    def album_create_songs_rd(self, album) -> List[SongModel]:
         raise NotImplementedError
 
 
@@ -178,7 +175,7 @@ class SupportsArtistGet(Protocol):
 @runtime_checkable
 class SupportsArtistSongsReader(Protocol):
     @abstractmethod
-    def artist_create_songs_rd(self, artist: BriefArtistProtocol):
+    def artist_create_songs_rd(self, artist: BriefArtistModel):
         """Create songs reader of the artist
         """
         raise NotImplementedError
@@ -188,7 +185,7 @@ class SupportsArtistSongsReader(Protocol):
 @runtime_checkable
 class SupportsArtistAlbumsReader(Protocol):
     @abstractmethod
-    def artist_create_albums_rd(self, artist: BriefArtistProtocol):
+    def artist_create_albums_rd(self, artist: BriefArtistModel):
         """Create albums reader of the artist
         """
         raise NotImplementedError
@@ -197,7 +194,7 @@ class SupportsArtistAlbumsReader(Protocol):
 @runtime_checkable
 class SupportsArtistContributedAlbumsReader(Protocol):
     @abstractmethod
-    def artist_create_contributed_albums_rd(self, artist: BriefArtistProtocol):
+    def artist_create_contributed_albums_rd(self, artist: BriefArtistModel):
         """Create contributed albums reader of the artist
         """
         raise NotImplementedError
@@ -223,16 +220,16 @@ class SupportsVideoGet(Protocol):
 @runtime_checkable
 class SupportsVideoMultiQuality(Protocol):
     @abstractmethod
-    def video_list_quality(self, video: BriefVideoProtocol) -> List[Quality.Video]:
+    def video_list_quality(self, video: BriefVideoModel) -> List[Quality.Video]:
         raise NotImplementedError
 
     @abstractmethod
     def video_select_media(
-            self, video: BriefVideoProtocol, policy=None) -> Tuple[Media, Quality.Video]:
+            self, video: BriefVideoModel, policy=None) -> Tuple[Media, Quality.Video]:
         raise NotImplementedError
 
     @abstractmethod
-    def video_get_media(self, video: BriefVideoProtocol, quality) -> Optional[Media]:
+    def video_get_media(self, video: BriefVideoModel, quality) -> Optional[Media]:
         raise NotImplementedError
 
 

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -12,7 +12,7 @@ from feeluown.utils.dispatch import Signal
 from feeluown.utils.utils import DedupList
 from feeluown.player import Metadata, MetadataFields
 from feeluown.library import (
-    MediaNotFound, SongProtocol, ModelType, NotSupported, ResourceNotFound,
+    MediaNotFound, SongModel, ModelType, NotSupported, ResourceNotFound,
 )
 from feeluown.media import Media
 from feeluown.library import reverse
@@ -425,7 +425,7 @@ class Playlist:
         return self.set_current_song(self.previous_song)
 
     @property
-    def current_song(self) -> Optional[SongProtocol]:
+    def current_song(self) -> Optional[SongModel]:
         """Current song
 
         return None if there is no current song
@@ -433,7 +433,7 @@ class Playlist:
         return self._current_song
 
     @current_song.setter
-    def current_song(self, song: Optional[SongProtocol]):
+    def current_song(self, song: Optional[SongModel]):
         self.set_current_song(song)
 
     def set_current_song(self, song) -> Optional[asyncio.Task]:

--- a/feeluown/server/handlers/base.py
+++ b/feeluown/server/handlers/base.py
@@ -1,6 +1,10 @@
-from typing import Dict, Type, TypeVar, Optional
+from typing import Dict, Type, TypeVar, Optional, TYPE_CHECKING
 
 from feeluown.server.session import SessionLike
+
+if TYPE_CHECKING:
+    from feeluown.app.server_app import ServerApp
+
 
 T = TypeVar('T', bound='HandlerMeta')
 cmd_handler_mapping: Dict[str, 'HandlerMeta'] = {}
@@ -22,7 +26,7 @@ class HandlerMeta(type):
 class AbstractHandler(metaclass=HandlerMeta):
     support_aio_handle = False
 
-    def __init__(self, app, session: Optional[SessionLike] = None):
+    def __init__(self, app: 'ServerApp', session: Optional[SessionLike] = None):
         """
         暂时不确定 session 应该设计为什么样的结构。当前主要是为了将它看作一个
         subscriber。大部分 handler 不需要使用到 session 对像，目前只有 SubHandler

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,5 +34,3 @@ addopts = -q
           --doctest-modules
 [mypy-mpv]
 ignore_errors = True
-[mypy-feeluown.models.*]
-ignore_errors = True

--- a/tests/library/test_model_v2.py
+++ b/tests/library/test_model_v2.py
@@ -23,6 +23,10 @@ def test_create_song_model_basic():
     # check song's attribute value
     assert song.artists_name == 'Audrey'
 
+    # song model cache get/set
+    song.cache_set('count', 1)
+    assert song.cache_get('count') == (1, True)
+
 
 def test_create_model_with_extra_field():
     with pytest.raises(pydantic.ValidationError):


### PR DESCRIPTION
 - [x] NormalModel inherits BriefXModel
 - [x] do not use model_protocol in feeluown (some plugins still use it)
 - [x] add type hint for related API
 - [x] enable mypy check