### PR TITLE
gui: fix several bugs of video-show

### DIFF
--- a/feeluown/gui/uimain/nowplaying_overlay.py
+++ b/feeluown/gui/uimain/nowplaying_overlay.py
@@ -98,8 +98,8 @@ class PlayerPanel(QWidget):
             self.artwork_view.set_body(video_widget)
         else:
             with video_widget.change_parent():
-                video_widget.show()
                 self.artwork_view.set_body(video_widget)
+                video_widget.show()
         self.ctl_btns.hide()
         self.progress.hide()
         video_widget.ctl_bar.clear_adhoc_btns()

--- a/feeluown/gui/uimain/nowplaying_overlay.py
+++ b/feeluown/gui/uimain/nowplaying_overlay.py
@@ -98,6 +98,9 @@ class PlayerPanel(QWidget):
             self.artwork_view.set_body(video_widget)
         else:
             with video_widget.change_parent():
+                # Remember always give video_widget a parent first and
+                # then show it. Otherwise, mpv may use its mpv-gui to show video,
+                # which causes the player crash.
                 self.artwork_view.set_body(video_widget)
                 video_widget.show()
         self.ctl_btns.hide()

--- a/feeluown/gui/widgets/video.py
+++ b/feeluown/gui/widgets/video.py
@@ -59,6 +59,7 @@ class VideoPlayerCtlBar(QWidget):
         """
         btn = Button(text)
         self._adhoc_btn_layout.addWidget(btn)
+        btn.setPalette(self.palette())
         return btn
 
     def clear_adhoc_btns(self):


### PR DESCRIPTION
1.  fix video-show on Linux(tested on wayland) (before, it may use mpv's widget to show videos)
2. fix the video-ctl-button color