### PR TITLE
packaging: decrease the size by about 100MB (on macOS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,15 @@ integration_test:
 test: lint unittest
 
 BUNDLE_FLAGS=
+# On macOS, excluding the following moduels can decrease the package size by 130MB,
+# mainly due to the QtWebEngine module.
+BUNDLE_FLAGS += --exclude PyQt5.QtQml
+BUNDLE_FLAGS += --exclude PyQt5.QtDBus
+BUNDLE_FLAGS += --exclude PyQt5.QtPdf
+BUNDLE_FLAGS += --exclude PyQt5.QtQuick
+BUNDLE_FLAGS += --exclude PyQt5.QtNetwork
+BUNDLE_FLAGS += --exclude PyQt5.QtWebEngineCore
+BUNDLE_FLAGS += --exclude PyQt5.QtWebEngineWidgets
 
 ifeq ($(OS),Windows_NT)
 	BUNDLE_FLAGS += --name FeelUOwn


### PR DESCRIPTION
add the following lines in makefile can also decrease the pacakge size by about 30MB
```
+       # remove some useless dlls to decrease the package size
+       rm -rf dist/FeelUOwn/_internal/PyQt5/Qt5/bin/Qt5Network.dll
+       rm -rf dist/FeelUOwn/_internal/PyQt5/Qt5/bin/Qt5Quick.dll
+       rm -rf dist/FeelUOwn/_internal/PyQt5/Qt5/bin/Qt5Qml.dll
+       rm -rf dist/FeelUOwn/_internal/PyQt5/Qt5/bin/Qt5QmlModels.dll
+       rm -rf dist/FeelUOwn/_internal/PyQt5/Qt5/bin/Qt5WebSockets.dll
+       rm -rf dist/FeelUOwn/_internal/PyQt5/Qt5/bin/Qt5DBus.dll
+       rm -rf dist/FeelUOwn/_internal/PyQt5/Qt5/bin/opengl32sw.dll
```