### PR TITLE
player:   can't render video properly with libmpv(0.38) on Linux

### DIFF
--- a/feeluown/player/mpvplayer.py
+++ b/feeluown/player/mpvplayer.py
@@ -3,6 +3,7 @@ import logging
 import time
 import math
 import os
+import sys
 
 from feeluown.mpv import (  # type: ignore
     MPV,
@@ -45,12 +46,11 @@ class MpvPlayer(AbstractPlayer):
             mpvkwargs['wid'] = winid
         self._version = _mpv_client_api_version()
 
-        # old version libmpv can use opengl-cb
-        if self._version < (1, 107):
-            mpvkwargs['vo'] = 'opengl-cb'
-            self.use_opengl_cb = True
-        else:
-            self.use_opengl_cb = False
+        # From libmpv 0.38, libmpv is not the default vo.
+        # Note if vo is not set to libmpv, the video is rendered in mpv's
+        # native window instead of feeluown's mpvwidget (tested on KDE+wayland).
+        if sys.platform == 'linux':
+            mpvkwargs['vo'] = 'libmpv'
 
         # set log_handler if you want to debug
         # mpvkwargs['log_handler'] = self.__log_handler

--- a/feeluown/player/mpvplayer.py
+++ b/feeluown/player/mpvplayer.py
@@ -3,7 +3,6 @@ import logging
 import time
 import math
 import os
-import sys
 
 from feeluown.mpv import (  # type: ignore
     MPV,
@@ -49,8 +48,9 @@ class MpvPlayer(AbstractPlayer):
         # From libmpv 0.38, libmpv is not the default vo.
         # Note if vo is not set to libmpv, the video is rendered in mpv's
         # native window instead of feeluown's mpvwidget (tested on KDE+wayland).
-        if sys.platform == 'linux':
-            mpvkwargs['vo'] = 'libmpv'
+        # On macOS, this option is optional. I believe the option is also required
+        # on Windows.
+        mpvkwargs['vo'] = 'libmpv'
 
         # set log_handler if you want to debug
         # mpvkwargs['log_handler'] = self.__log_handler


### PR DESCRIPTION
from libmpv API changelog

> --- mpv 0.38.0 ---
> 2.3    - partially revert the changes from API version 1.27, remove libmpv as
         the default VO and move it to the bottom of the auto-probing order.
         This restores the prior behavior on all platforms other than macOS,
         but still auto selects libmpv/cocoa-cb on macOS if it was built with
         support for cocoa-cb.

so we should set libmpv as vo explicitly. 