### PR TITLE
tests: fix test_collection.py for Python 3.12

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -12,7 +12,7 @@ def test_collection_load(tmp_path, song, mocker):
     path.write_text(text)
     coll = Collection(str(path))
     coll.load()
-    mock_resolve.called_once_with(text)
+    mock_resolve.assert_called_once_with(text)
     assert coll.models[0] is song
 
 


### PR DESCRIPTION
Python 3.12 treats the typo as an error now:

```
=================================== FAILURES ===================================
_____________________________ test_collection_load _____________________________

tmp_path = PosixPath('/tmp/pytest-of-builduser/pytest-0/test_collection_load0')
song = SongModel(meta=<feeluown.library.models.ModelMeta object at 0x7acaf2177c50>, identifier='0', source='fake', state=<Mod...on=600000, children=[], genre='', date='', track='1/1', disc='1/1', pic_url='', media_flags=<MediaFlags.not_sure: 128>)
mocker = <pytest_mock.plugin.MockerFixture object at 0x7acad8c98b60>

    def test_collection_load(tmp_path, song, mocker):                                                                                                                                                                                                                                              mock_resolve = mocker.patch('feeluown.collection.resolve',
                                    return_value=song)
        path = tmp_path / 'test.fuo'
        path.touch()
        text = 'fuo://fake/songs/1  # hello - Tom'                                                                                                                                                                                                                                                 path.write_text(text)
        coll = Collection(str(path))
        coll.load()
>       mock_resolve.called_once_with(text)

tests/test_collection.py:15:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <MagicMock name='resolve' id='135011639070880'>
name = 'called_once_with'

    def __getattr__(self, name):
        if name in {'_mock_methods', '_mock_unsafe'}:
            raise AttributeError(name)
        elif self._mock_methods is not None:
            if name not in self._mock_methods or name in _all_magics:
                raise AttributeError("Mock object has no attribute %r" % name)                                                                                                                                                                                                                     elif _is_magic(name):
            raise AttributeError(name)
        if not self._mock_unsafe and (not self._mock_methods or name not in self._mock_methods):
            if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')) or name in _ATTRIB_DENY_LIST:
>               raise AttributeError(
                    f"{name!r} is not a valid assertion. Use a spec "
                    f"for the mock if {name!r} is meant to be an attribute.")                                                                                                                                                                                                              E               AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?

/usr/lib/python3.12/unittest/mock.py:663: AttributeError
```