### PR TITLE
fuoexec:  allow reload fuorc to debug easily

### DIFF
--- a/feeluown/fuoexec/signal_manager.py
+++ b/feeluown/fuoexec/signal_manager.py
@@ -41,7 +41,8 @@ class SignalConnector:
             self._slot_list.append((slot, kwargs))
 
     def connect_slot_symbol(self, slot_symbol: str, **kwargs):
-        self._slot_symbol_list.append((slot_symbol, kwargs))
+        if (slot_symbol, kwargs) not in self._slot_symbol_list:
+            self._slot_symbol_list.append((slot_symbol, kwargs))
 
     def disconnect_slot_symbol(self, slot_symbol):
         for i, (symbol, _) in enumerate(self._slot_symbol_list):


### PR DESCRIPTION
Assume we have the following code in fuorc
```
when('app.ui.songs_table.about_to_show_menu', ask_ai_background, use_symbol=True)
```
Before, if user execute `fuo exec < ~/.fuorc` multiple times, when the signal is emitted, the slot will be invoked multiple times.
