### PR TITLE
library: use yt-dlp as a global standby-provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           pip install --upgrade pip
           pip install pyqt5
           pip install "pytest<7.2"
-          pip install -e .[dev,cookies,webserver]
+          pip install -e .[dev,cookies,webserver,ytdl]
 
       - name: Install Python(macOS) Dependencies
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -22,7 +22,7 @@ jobs:
         pip install pyqt5
         pip install pyinstaller
         pip install pyinstaller-versionfile
-        pip install -e .[win32,battery,cookies]
+        pip install -e .[win32,battery,cookies,ytdl]
     - name: Download mpv-1.dll
       run: |
         choco install curl

--- a/docs/source/fuorc.rst
+++ b/docs/source/fuorc.rst
@@ -3,17 +3,20 @@
 
 类似 Vim 的 ``.vimrc`` 、Emacs 的 ``init.el`` ，feeluown 也有自己的配置文件 ``.fuorc`` 。
 
-fuorc 文件是一个 Python 脚本，它位于 ``~/.fuorc`` 目录下，我们可以在其中使用任意 Python 语法。
-feeluown 启动时，第一步就是加载并解析该配置文件。通常，我们可以在配置文件中作以下事情：
+fuorc 文件是一个 Python 脚本，它位于 ``~/.fuorc`` ，我们可以在其中使用任意 Python 语法。
+feeluown 启动时，第一步就是加载并解析该配置文件，结合 Python 的灵活性，意味着你可以对
+feeluown 的行为进行完完全全的控制。通常，你可以在配置文件中作以下事情：
 
-1. 配置部分选项
-2. 定制一些小功能
+1. 配置选项
+2. 功能定制
+
+
+一个🌰
+-----------------
 
 一个 fuorc 文件示例::
 
-
   import os
-
 
   # 自定义配置
   config.THEME = 'dark'
@@ -39,49 +42,43 @@ feeluown 启动时，第一步就是加载并解析该配置文件。通常，�
   #
   # vim: ft=python
 
+配置选项
+-------------
 
-原理简述
---------------
+通用配置项如下
 
-feeluown 使用 Python 的 exec 方法来加载（执行）配置文件。执行时，
-会暴露 config 对象和部分函数到这个作用域中。
-
-函数
-~~~~~~~~
-
-目前暴露到该作用域的函数有
-
-.. autofunction:: feeluown.fuoexec.add_hook
-
-.. autofunction:: feeluown.fuoexec.rm_hook
-
-.. autofunction:: feeluown.fuoexec.source
-
-config 对象
-~~~~~~~~~~~~~
-
-``config`` 是 :class:`feeluown.config.Config` 的实例，常见使用场景有两种::
-
-  >>> theme = config.THEME  # 获取配置项的值
-  >>> config.THEME = 'dark'  # 设置配置项的值
-
-目前支持的配置项如下
-
-**通用配置项**
-
-====================       =========  ============    =========
+=======================    =========  ============    =========
 名称                         类型        默认值           描述
-====================       =========  ============    =========
-DEBUG                       ``bool``   ``False``      是否为调试模式
-MODE                        ``str``    ``0x0000``     CLI or GUI 模式
+=======================    =========  ============    =========
+RPC_PORT                    ``int``    ``23333``      RPC 服务端口
+PUBSUB_PORT                 ``int``    ``23334``      PUBSUB 服务端口
+ALLOW_LAN_CONNECT           ``bool``   ``False``      是否可以从局域网连接 RPC 服务
 THEME                       ``str``    ``auto``       auto/light/dark
 COLLECTIONS_DIR             ``str``    ``''``         本地收藏所在目录
 LOG_TO_FILE                 ``bool``   ``True``       将日志输出到文件中
 AUDIO_SELECT_POLICY         ``str``    ``hq<>``       :class:`feeluown.media.Quality.SortPolicy`
 VIDEO_SELECT_POLICY         ``str``    ``hd<>``       :class:`feeluown.media.Quality.SortPolicy`
-====================       =========  ============    =========
+NOTIFY_ON_TRACK_CHANGED     ``bool``   ``False``      切换歌曲时显示桌面通知
+NOTIFY_DURATION             ``int``    ``3000``       桌面通知保留时长(ms)
+PROVIDERS_STANDBY           ``list``   ``None``       候选歌曲提供方（默认：所有提供方）
+=======================    =========  ============    =========
 
-**MPV 播放器配置项** (使用 MPV 做为播放引擎时生效)
+实验特性的配置项
+
+=============================    =========  ============    =========
+名称                              类型        默认值           描述
+=============================    =========  ============    =========
+ENABLE_WEB_SERVER                ``bool``    ``False``      开启 WEB 服务
+WEB_PORT                         ``int``     ``23332``      WEB 服务端口
+ENABLE_NEW_HOMEPAGE              ``bool``    ``False``      开启新版主页
+ENABLE_MV_AS_STANDBY             ``bool``    ``True``       使用 MV 作为歌曲资源
+PLAYBACK_CROSSFADE               ``bool``    ``False``      开启淡入淡出
+PLAYBACK_CROSSFADE_DURATION      ``int``     ``500``        淡入淡出持续时间
+ENABLE_YTDL_AS_MEDIA_PROVIDER    ``int``     ``False``      使用 YTDL 作为媒体资源提供方
+YTDL_RULES                       ``list``    ``None``       YTDL 的命中规则
+=============================    =========  ============    =========
+
+MPV 播放器配置项 (使用 MPV 做为播放引擎时生效)
 
 ====================       =========  ============    =========
 名称                         类型        默认值           描述
@@ -89,5 +86,32 @@ VIDEO_SELECT_POLICY         ``str``    ``hd<>``       :class:`feeluown.media.Qua
 MPV_AUDIO_DEVICE            ``str``    ``auto``       MPV 播放设备
 ====================       =========  ============    =========
 
+你可以查看下述函数的源代码来查看完整列表。
 
-.. autoclass:: feeluown.config.Config
+.. autofunction:: feeluown.app.config.create_config
+
+
+功能定制
+--------------
+
+feeluown 使用 Python 的 exec 方法来加载（执行）配置文件。执行时，
+会暴露 ``config`` 对象和部分函数（如 ``add_hook``, ``rm_hook`` 等）到这个作用域中。
+通过 ``add_hook`` （这个函数有个别名是 ``when`` ），你可以对程序大部分事件进行监听。
+
+常见的事件有
+
+1. ``app.player.metadata_changed`` 歌曲元信息变化时（通常发生于歌曲切换时）
+2. ``app.initialized`` 应用初始化完毕（未启动）
+3. ``app.started`` 应用已经启动
+4. ``app.ui.songs_table.about_to_show_menu`` 右键显示歌曲菜单
+
+你可以参考示例 `cosven-fuorc <https://github.com/cosven/rcfiles/blob/master/fuorc>`_
+
+函数
+~~~~~~~~
+
+函数的文档可以参考
+
+.. autofunction:: feeluown.fuoexec.add_hook
+.. autofunction:: feeluown.fuoexec.rm_hook
+.. autofunction:: feeluown.fuoexec.source

--- a/feeluown/app/app.py
+++ b/feeluown/app/app.py
@@ -54,7 +54,7 @@ class App:
 
         # Library.
         self.library = Library(config.PROVIDERS_STANDBY)
-        if config.ENABLE_YTDL_AS_STANDBY:
+        if config.ENABLE_YTDL_AS_MEDIA_PROVIDER:
             try:
                 self.library.setup_ytdl(rules=config.YTDL_RULES)
             except ImportError as e:

--- a/feeluown/app/app.py
+++ b/feeluown/app/app.py
@@ -54,6 +54,14 @@ class App:
 
         # Library.
         self.library = Library(config.PROVIDERS_STANDBY)
+        if config.ENABLE_YTDL_AS_STANDBY:
+            try:
+                self.library.setup_ytdl(rules=config.YTDL_RULES)
+            except ImportError as e:
+                logger.warning(f"can't enable ytdl as standby due to {e}")
+            else:
+                logger.info(f"enable ytdl as standby succeed"
+                            f" with rules:{config.YTDL_RULES}")
         # TODO: initialization should be moved into initialize
         Resolver.library = self.library
         # Player.

--- a/feeluown/app/config.py
+++ b/feeluown/app/config.py
@@ -28,6 +28,13 @@ def create_config() -> Config:
     config.deffield('VIDEO_SELECT_POLICY', default='hd<>')
     config.deffield('ALLOW_LAN_CONNECT', type_=bool, default=False, desc='是否可以从局域网连接服务器')
     config.deffield('PROVIDERS_STANDBY', type_=list, default=None, desc='')
+    config.deffield('ENABLE_YTDL_AS_STANDBY', type_=bool, default=True,
+                    desc='YTDL 作为备用资源')
+    # For example::
+    #    [{'name': 'match_by_source',
+    #      'source': 'xxx',
+    #      'http_proxy': 'http://127.0.0.1:7890'},]
+    config.deffield('YTDL_RULES', type_=list, default=None, desc='')
     # TODO(cosven): maybe
     # 1. when it is set to 2, find standby from other providers first.
     # 2. when it is set to 3, play it's MV model instead of using MV's media.

--- a/feeluown/app/config.py
+++ b/feeluown/app/config.py
@@ -28,7 +28,7 @@ def create_config() -> Config:
     config.deffield('VIDEO_SELECT_POLICY', default='hd<>')
     config.deffield('ALLOW_LAN_CONNECT', type_=bool, default=False, desc='是否可以从局域网连接服务器')
     config.deffield('PROVIDERS_STANDBY', type_=list, default=None, desc='')
-    config.deffield('ENABLE_YTDL_AS_STANDBY', type_=bool, default=True,
+    config.deffield('ENABLE_YTDL_AS_MEDIA_PROVIDER', type_=bool, default=True,
                     desc='YTDL 作为备用资源')
     # For example::
     #    [{'name': 'match_by_source',

--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -2,7 +2,7 @@
 import logging
 import warnings
 from functools import partial
-from typing import Optional, TypeVar, List
+from typing import Optional, TypeVar, List, TYPE_CHECKING
 
 from feeluown.media import Media
 from feeluown.utils.aio import run_fn, as_completed
@@ -20,8 +20,11 @@ from .model_state import ModelState
 from .provider_protocol import (
     check_flag as check_flag_impl,
     SupportsSongLyric, SupportsSongMV, SupportsSongMultiQuality,
-    SupportsVideoMultiQuality,
+    SupportsVideoMultiQuality, SupportsSongWebUrl,
 )
+
+if TYPE_CHECKING:
+    from .ytdl import Ytdl
 
 
 logger = logging.getLogger(__name__)
@@ -75,9 +78,15 @@ class Library:
         """
         self._providers_standby = providers_standby
         self._providers = set()
+        self.ytdl: Optional['Ytdl'] = None
 
         self.provider_added = Signal()  # emit(AbstractProvider)
         self.provider_removed = Signal()  # emit(AbstractProvider)
+
+    def setup_ytdl(self, *args, **kwargs):
+        from .ytdl import Ytdl
+
+        self.ytdl = Ytdl(*args, **kwargs)
 
     def register(self, provider):
         """register provider
@@ -271,9 +280,20 @@ class Library:
             raise MediaNotFound(f'provider({song.source}) not found')
         media = None
         if isinstance(provider, SupportsSongMultiQuality):
-            media, _ = provider.song_select_media(song, policy)
+            try:
+                media, _ = provider.song_select_media(song, policy)
+            except MediaNotFound as e:
+                if e.reason is MediaNotFound.Reason.check_children:
+                    raise
+                else:
+                    media = None
         if not media:
-            raise MediaNotFound('provider returns empty media')
+            if self.ytdl is not None and isinstance(provider, SupportsSongWebUrl):
+                song_web_url = provider.song_get_web_url(song)
+                logger.info(f'use ytdl to get media for {song_web_url}')
+                media = self.ytdl.select_audio(song_web_url, policy, source=song.source)
+            if not media:
+                raise MediaNotFound('provider returns empty media')
         return media
 
     def song_prepare_mv_media(self, song: BriefSongModel, policy) -> Media:

--- a/feeluown/library/provider_protocol.py
+++ b/feeluown/library/provider_protocol.py
@@ -217,6 +217,12 @@ class SupportsVideoGet(Protocol):
         raise NotImplementedError
 
 
+@runtime_checkable
+class SupportsVideoWebUrl(Protocol):
+    def video_get_web_url(self, video: BriefVideoModel) -> str:
+        raise NotImplementedError
+
+
 @eq(ModelType.video, PF.multi_quality)
 @runtime_checkable
 class SupportsVideoMultiQuality(Protocol):

--- a/feeluown/library/ytdl.py
+++ b/feeluown/library/ytdl.py
@@ -3,39 +3,48 @@ from typing import Optional, List, Any
 
 from yt_dlp import YoutubeDL
 
-from feeluown.media import Media
+from feeluown.media import Media, VideoAudioManifest
 
 logger = logging.getLogger(__name__)
 
 
 class Ytdl:
+
     def __init__(self, rules: Optional[List[Any]] = None):
         self._default_audio_ytdl_opts = {
             'logger': logger,
             # The following two options may be only valid for select_audio API.
             # Remove these two options if needed.
             'format': 'm4a/bestaudio/best',
-            'postprocessors': [{  # Extract audio using ffmpeg
-                'key': 'FFmpegExtractAudio',
-                'preferredcodec': 'm4a',
-            }]
+        }
+        self._default_video_ytdl_opts = {
+            'logger': logger,
         }
         # For example::
-        #    [{'name': 'match_source',
-        #      'pattern': 'xxx',
-        #      'http_proxy': 'http://127.0.0.1:7890'},]
+        #    [
+        #        {'name': 'match_source',
+        #         'pattern': 'xxx',
+        #         'http_proxy': 'http://127.0.0.1:7890'},
+        #    ]
         # TODO: valid rules
         self._rules = rules or []
 
-    def select_audio(self, url, _: Optional[str] = None, source='') -> Optional[Media]:
+    def match_rule(self, _, source=''):
+        """
+        Currently, only 'match_source' is supported. Maybe support 'match_url'
+        in the future.
+        """
         matched_rule = None
         if isinstance(self._rules, list) and self._rules:
             for rule in self._rules:
                 if rule['name'] == 'match_source' and source == rule['pattern']:
                     matched_rule = rule
+        return matched_rule
+
+    def select_audio(self, url, _: Optional[str] = None, source='') -> Optional[Media]:
+        matched_rule = self.match_rule(url, source)
         if matched_rule is None:
             return
-
         http_proxy = matched_rule.get('http_proxy')
         ytdl_opts = {}
         ytdl_opts.update(self._default_audio_ytdl_opts)
@@ -47,20 +56,68 @@ class Ytdl:
                 if media_url:
                     # NOTE(cosven): do not set http headers, otherwise it can't play.
                     # Tested with 'https://music.youtube.com/watch?v=vKwowKeEv5w'
-                    return Media(media_url,
-                                 format=info['ext'],
-                                 bitrate=int(info['abr']),
-                                 http_proxy=http_proxy)
+                    return Media(
+                        media_url,
+                        format=info['ext'],
+                        bitrate=int(info['abr']),
+                        http_proxy=http_proxy
+                    )
             return None
+
+    def select_video(self, url, _: Optional[str] = None, source='') -> Optional[Media]:
+        matched_rule = self.match_rule(url, source)
+        if matched_rule is None:
+            return
+        http_proxy = matched_rule.get('http_proxy')
+        ytdl_opts = {}
+        ytdl_opts.update(self._default_video_ytdl_opts)
+        ytdl_opts['proxy'] = http_proxy
+
+        audio_candidates = []  # [(url, abr)]  abr: average bitrate
+        video_candidates = []  # [(url, width)]
+        with YoutubeDL(ytdl_opts) as inner:
+            info = inner.extract_info(url, download=False)
+            if info:
+                for f in info['formats']:
+                    if f.get('acodec', 'none') not in ('none', None):
+                        audio_candidates.append((f['url'], f['abr']))
+                    if (
+                        f.get('vcodec', 'none') not in ('none', None)
+                        and f.get('protocol', '') in ('https', 'http')
+                    ):
+                        video_candidates.append((f['url'], f['width']))
+            if not (audio_candidates and video_candidates):
+                return
+            audio_candidates = sorted(
+                audio_candidates, key=lambda c: c[1] or 0, reverse=True
+            )
+            video_candidates = sorted(
+                video_candidates, key=lambda c: c[1] or 0, reverse=True
+            )
+            # always use the best audio(with highest bitrate)
+            audio_url = audio_candidates[0][0]
+            # TODO: use policy on video because high-quality video may be slow
+            video_url = video_candidates[0][0]
+            return Media(VideoAudioManifest(video_url, audio_url), http_proxy=http_proxy)
 
 
 if __name__ == '__main__':
     # A E2E test case for YTDL, this should print a playable url.
-    rules = [{'name': 'match_source',
-              'pattern': 'ytmusic',
-              'http_proxy': 'http://127.0.0.1:7890'},]
+    rules = [
+        {
+            'name': 'match_source',
+            'pattern': 'ytmusic',
+            'http_proxy': 'http://127.0.0.1:7890'
+        },
+    ]
 
     ytdl = Ytdl(rules)
     url = 'https://music.youtube.com/watch?v=vKwowKeEv5w'
-    media = ytdl.select_audio(url, None, 'ytmusic')
-    print(media.url)
+
+    # media = ytdl.select_audio(url, None, 'ytmusic')
+    # print(media.url)
+    # print()
+
+    media = ytdl.select_video(url, None, 'ytmusic')
+    print(media.manifest.video_url)
+    print(media.manifest.audio_url)

--- a/feeluown/library/ytdl.py
+++ b/feeluown/library/ytdl.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Optional, List, Any
+
+from yt_dlp import YoutubeDL
+
+from feeluown.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class Ytdl:
+    def __init__(self, rules: Optional[List[Any]] = None):
+        self._default_audio_ytdl_opts = {
+            'logger': logger,
+            # The following two options may be only valid for select_audio API.
+            # Remove these two options if needed.
+            'format': 'm4a/bestaudio/best',
+            'postprocessors': [{  # Extract audio using ffmpeg
+                'key': 'FFmpegExtractAudio',
+                'preferredcodec': 'm4a',
+            }]
+        }
+        # For example::
+        #    [{'name': 'match_source',
+        #      'pattern': 'xxx',
+        #      'http_proxy': 'http://127.0.0.1:7890'},]
+        # TODO: valid rules
+        self._rules = rules or []
+
+    def select_audio(self, url, _: Optional[str] = None, source='') -> Optional[Media]:
+        matched_rule = None
+        if isinstance(self._rules, list) and self._rules:
+            for rule in self._rules:
+                if rule['name'] == 'match_source' and source == rule['pattern']:
+                    matched_rule = rule
+        if matched_rule is None:
+            return
+
+        http_proxy = matched_rule.get('http_proxy')
+        ytdl_opts = {}
+        ytdl_opts.update(self._default_audio_ytdl_opts)
+        ytdl_opts['proxy'] = http_proxy
+        with YoutubeDL(ytdl_opts) as inner:
+            info = inner.extract_info(url, download=False)
+            if info:
+                media_url = info['url']
+                if media_url:
+                    # NOTE(cosven): do not set http headers, otherwise it can't play.
+                    # Tested with 'https://music.youtube.com/watch?v=vKwowKeEv5w'
+                    return Media(media_url,
+                                 format=info['ext'],
+                                 bitrate=int(info['abr']),
+                                 http_proxy=http_proxy)
+            return None
+
+
+if __name__ == '__main__':
+    # A E2E test case for YTDL, this should print a playable url.
+    rules = [{'name': 'match_source',
+              'pattern': 'ytmusic',
+              'http_proxy': 'http://127.0.0.1:7890'},]
+
+    ytdl = Ytdl(rules)
+    url = 'https://music.youtube.com/watch?v=vKwowKeEv5w'
+    media = ytdl.select_audio(url, None, 'ytmusic')
+    print(media.url)

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -652,7 +652,7 @@ class Playlist:
 
     async def _prepare_media(self, song):
         task_spec = self._app.task_mgr.get_or_create('prepare-media')
-        task_spec.disable_default_cb()
+        # task_spec.disable_default_cb()
         if self.watch_mode is True:
             mv_media = await task_spec.bind_coro(self._prepare_mv_media(song))
             if mv_media:

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,9 @@ setup(
             'secretstorage',
             'pycryptodome',
         ],
+        'ytdl': [
+            'yt-dlp',
+        ],
         'dev': [
             # lint
             'flake8',


### PR DESCRIPTION
To use this feature, you should 
1. instance yt-dlp `pip install yt-dlp`
2. setup config in `~/.fuorc`, for example

```python
config.YTDL_RULES = [{'name': 'match_source',
                      'pattern': 'ytmusic',
                      'http_proxy': 'http://127.0.0.1:7890'},]
```

