### PR TITLE
player: add timeout when fetching song metadata

### DIFF
--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -292,6 +292,9 @@ class Library:
                 song_web_url = provider.song_get_web_url(song)
                 logger.info(f'use ytdl to get media for {song_web_url}')
                 media = self.ytdl.select_audio(song_web_url, policy, source=song.source)
+                found = media is not None
+                logger.debug(f'ytdl select audio for {song_web_url} finished, '
+                             f'found: {found}')
             if not media:
                 raise MediaNotFound('provider returns empty media')
         return media
@@ -425,7 +428,6 @@ class Library:
         :param video: either a v1 MvModel or a v2 (Brief)VideoModel.
         """
         provider = self.get(video.source)
-
         try:
             if isinstance(provider, SupportsVideoMultiQuality):
                 media, _ = provider.video_select_media(video, policy)
@@ -440,6 +442,11 @@ class Library:
                 media = self.ytdl.select_video(video_web_url,
                                                policy,
                                                source=video.source)
+                found = media is not None
+                logger.debug(f'ytdl select video for {video_web_url} finished, '
+                             f'found: {found}')
+            else:
+                media = None
             if not media:
                 raise
         return media

--- a/feeluown/utils/aio.py
+++ b/feeluown/utils/aio.py
@@ -36,6 +36,9 @@ wait = asyncio.wait
 #: gather is an alias of `asyncio.gather`.
 gather = asyncio.gather
 
+#: wait_for is an alias of `asyncio.wait_for`
+wait_for = asyncio.wait_for
+
 
 def run_in_executor(executor, func, *args):
     """alias for loop.run_in_executor"""

--- a/tests/player/test_playlist.py
+++ b/tests/player/test_playlist.py
@@ -355,13 +355,15 @@ def test_playlist_next_should_call_set_current_song(app_mock, mocker, song):
 
 
 @pytest.mark.asyncio
-async def test_playlist_prepare_metadata_for_song(app_mock, pl, ekaf_brief_song0):
+async def test_playlist_prepare_metadata_for_song(
+        app_mock, library, pl, ekaf_brief_song0, mocker):
     class Album:
         cover = Media('fuo://')
         released = '2018-01-01'
+
+    app_mock.library = library
     album = Album()
-    f = asyncio.Future()
-    f.set_result(album)
-    app_mock.library.album_upgrade.return_value = album
+    mocker.patch.object(library, 'album_upgrade', return_value=album)
+    # app_mock.library.album_upgrade.return_value = album
     # When cover is a media object, prepare_metadata should also succeed.
     await pl._prepare_metadata_for_song(ekaf_brief_song0)


### PR DESCRIPTION
Currently, the player play the media after metadata is fetched.
However, some provider (ytmusic)  cost much time in fetching metadata. 
So add a timeout to workaround this problem.