### PR TITLE
player: fix next_song when the following songs are bad

### DIFF
--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -381,13 +381,16 @@ class Playlist:
             next_song = self._get_good_song(random_=True)
         else:
             current_index = self._songs.index(self.current_song)
-            if current_index == len(self._songs) - 1:
-                if self.playback_mode in (PlaybackMode.loop, PlaybackMode.one_loop):
-                    next_song = self._get_good_song()
-                elif self.playback_mode == PlaybackMode.sequential:
-                    next_song = None
+            is_last_song = current_index == len(self._songs) - 1
+            if is_last_song and self.playback_mode == PlaybackMode.sequential:
+                next_song = None
             else:
-                next_song = self._get_good_song(base=current_index+1, loop=False)
+                if is_last_song:
+                    base_index = 0
+                else:
+                    base_index = current_index + 1
+                loop = self.playback_mode != PlaybackMode.sequential
+                next_song = self._get_good_song(base=base_index, loop=loop)
         return next_song
 
     @property

--- a/tests/player/test_playlist.py
+++ b/tests/player/test_playlist.py
@@ -366,3 +366,10 @@ async def test_playlist_prepare_metadata_for_song(
     # app_mock.library.album_upgrade.return_value = album
     # When cover is a media object, prepare_metadata should also succeed.
     await pl._metadata_mgr.prepare_for_song(ekaf_brief_song0)
+
+
+def test_playlist_next_song(pl):
+    pl.mark_as_bad(pl.list()[1])
+    assert pl.next_song == pl.list()[0]
+    pl.playback_mode = PlaybackMode.sequential
+    assert pl.next_song is None


### PR DESCRIPTION
Before, next_song returns no song when the following songs are bad. For example, the playlist has [valid_song1, valid_song2, bad_song1, bad_song2] and the current song is valid_song2. At the this time, next_song return None before. After this PR, next_song returns valid_song1.