### PR TITLE
server: fix crash when any webserver dependency is not installed

### DIFF
--- a/feeluown/app/server_app.py
+++ b/feeluown/app/server_app.py
@@ -52,7 +52,11 @@ class ServerApp(App):
                 self.config.PUBSUB_PORT,
             ))
         if self.config.ENABLE_WEB_SERVER:
-            from feeluown.webserver import run_web_server
-            asyncio.create_task(
-                run_web_server(self.get_listen_addr(), self.config.WEB_PORT))
+            try:
+                from feeluown.webserver import run_web_server
+            except ImportError as e:
+                logger.error(f"can't enable webserver, err: {e}")
+            else:
+                asyncio.create_task(
+                    run_web_server(self.get_listen_addr(), self.config.WEB_PORT))
         asyncio.create_task(run_nowplaying_server(self))


### PR DESCRIPTION
Before, when a user enables webserver and does not install sanic, the app just crashes.
Now, log a error message instead.
![telegram-cloud-photo-size-5-6150136853269953860-y](https://github.com/user-attachments/assets/58bd9975-22e3-45af-b135-328a1f53970f)
