### PR TITLE
[fix](reader): fix play-all may fail due to 'ValueError: generator already executing'

### DIFF
--- a/feeluown/utils/reader.py
+++ b/feeluown/utils/reader.py
@@ -221,6 +221,7 @@ class RandomSequentialReader(Reader[T]):
         self._ranges: List[Tuple[int, int]] = []  # list of tuple
         self._objects: List[Optional[T]] = [None] * count
         self._read_func = read_func
+        self._lock = Lock()
 
         assert max_per_read > 0, 'max_per_read must big than 0'
         self._max_per_read = max_per_read

--- a/feeluown/utils/reader.py
+++ b/feeluown/utils/reader.py
@@ -12,6 +12,7 @@ from typing import (
     Sequence,
     AsyncIterable,
 )
+from threading import Lock
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +163,7 @@ class SequentialReader(Reader[T]):
         self._count = count
         self.offset = offset
         self._objects: List[T] = []
+        self._lock = Lock()
 
     @property
     def count(self):
@@ -189,7 +191,8 @@ class SequentialReader(Reader[T]):
     def _read_next(self) -> T:
         if self._count is None or self.offset < self.count:
             try:
-                obj = next(self._g)
+                with self._lock:
+                    obj = next(self._g)
             except StopIteration:
                 if self._count is None:
                     self._count = self.offset + 1
@@ -269,7 +272,12 @@ class RandomSequentialReader(Reader[T]):
         return cast(List[T], self._objects[start:end])
 
     def _read_range(self, start, end):
-        # TODO: make this method thread safe
+        # Though this method is thread safe now, _read_range_unsafe may read
+        # the same range multiple times.
+        with self._lock:
+            self._read_range_unsafe(start, end)
+
+    def _read_range_unsafe(self, start, end):
         assert start <= end, 'start should less than end'
         logger.debug('trigger read_func(%d, %d)', start, end)
         objs = list(self._read_func(start, end))


### PR DESCRIPTION
'播放全部' may fail due to
```
[2024-11-16 21:49:48,867 feeluown.task:85] [ERROR]: Task play-all failed
Traceback (most recent call last):
  File "/Users/xxx/code/feeluown/feeluown/task.py", line 81, in _cb
    future.result()
  File "/Users/xxx/code/feeluown/.venv/lib/python3.11/site-packages/qasync/__init__.py", line 150, in run
    r = callback(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xxx/code/feeluown/feeluown/utils/reader.py", line 173, in readall
    list(self)
  File "/Users/xxx/code/feeluown/feeluown/utils/reader.py", line 98, in __next__
    return self._read_next()
           ^^^^^^^^^^^^^^^^^
  File "/Users/xxx/code/feeluown/feeluown/utils/reader.py", line 192, in _read_next
    obj = next(self._g)
          ^^^^^^^^^^^^^
ValueError: generator already executing
[2024-11-16 21:49:48,871 qasync._QEventLoop:739] [ERROR]: Task exception was never retrieved
future: <Task finished name='Task-88455' coro=<TableContainer.play_all() done, defined at /Users/xxx/code/feeluown/feeluown/gui/page_containers/table
.py:420> exception=ValueError('generator already executing')>
Traceback (most recent call last):
  File "/Users/xxx/code/feeluown/feeluown/gui/page_containers/table.py", line 432, in play_all
    songs = await task_spec.bind_blocking_io(reader.readall)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: generator already executing
```