### PR TITLE
[misc](library): disable ytdl by default

### DIFF
--- a/feeluown/app/app.py
+++ b/feeluown/app/app.py
@@ -60,6 +60,7 @@ class App:
             except ImportError as e:
                 logger.warning(f"can't enable ytdl as standby due to {e}")
             else:
+                logger.warning('ytdl-as-standby is deprecated since v4.1.9')
                 logger.info(f"enable ytdl as standby succeed"
                             f" with rules:{config.YTDL_RULES}")
         # TODO: initialization should be moved into initialize

--- a/feeluown/app/config.py
+++ b/feeluown/app/config.py
@@ -44,8 +44,13 @@ def create_config() -> Config:
     config.deffield('VIDEO_SELECT_POLICY', default='hd<>')
     config.deffield('ALLOW_LAN_CONNECT', type_=bool, default=False, desc='是否可以从局域网连接服务器')
     config.deffield('PROVIDERS_STANDBY', type_=list, default=None, desc='')
+
+    # YTDL related fields are deprecated since v4.1.9. Disable them by default.
     config.deffield(
-        'ENABLE_YTDL_AS_MEDIA_PROVIDER', type_=bool, default=True, desc='YTDL 作为备用资源'
+        'ENABLE_YTDL_AS_MEDIA_PROVIDER',
+        type_=bool,
+        default=False,
+        desc='(Deprecated) YTDL 作为备用资源'
     )
     # For example::
     #    [
@@ -58,7 +63,8 @@ def create_config() -> Config:
     #            },
     #        },
     #    ]
-    config.deffield('YTDL_RULES', type_=list, default=None, desc='')
+    config.deffield('YTDL_RULES', type_=list, default=None, desc='(Deprecated)')
+
     # TODO(cosven): maybe
     # 1. when it is set to 2, find standby from other providers first.
     # 2. when it is set to 3, play it's MV model instead of using MV's media.


### PR DESCRIPTION
经过一段时间的使用，发现之前 ytdl 这个东西属过度设计（想太多）。

ytdl 实际上只对 feeluown-ytmusic 有用，并且它的配置也很复杂，不如直接把这坨逻辑移到 ytmusic 中去实现。所以先默认关闭这个功能。