### PR TITLE
server: add jsonrpc support for fuo server (23333)

### DIFF
--- a/feeluown/argparser.py
+++ b/feeluown/argparser.py
@@ -63,6 +63,7 @@ def add_common_cmds(subparsers: argparse._SubParsersAction):
     remove_parser = add_parser('remove', help='从播放列表移除歌曲')
     add_parser_ = add_parser('add', help='添加歌曲到播放列表')
     exec_parser = add_parser('exec')
+    jsonrpc_parser = add_parser('jsonrpc')
     add_parser('pause', help='暂停播放')
     add_parser('resume', help='回复播放')
     add_parser('toggle', help='')
@@ -88,6 +89,7 @@ def add_common_cmds(subparsers: argparse._SubParsersAction):
         choices=['song', 'album', 'artist', 'video', 'playlist']
     )
     exec_parser.add_argument('code', nargs='?', help='Python 代码')
+    jsonrpc_parser.add_argument('body')
 
 
 def add_cli_cmds(subparsers: argparse._SubParsersAction):

--- a/feeluown/cli/cli.py
+++ b/feeluown/cli/cli.py
@@ -178,13 +178,17 @@ class ExecHandler(BaseHandler):
 
     def before_request(self):
         code = self.args.code
-        if code is None:
+        self._req.cmd_args = (code, )
+
+
+class JsonRPCHandler(BaseHandler):
+    cmds = ('jsonrpc', )
+
+    def before_request(self):
+        body = self.args.body
+        if body is None:
             body = sys.stdin.read()
-            self._req.has_heredoc = True
-            self._req.heredoc_word = 'EOF'
-            self._req.set_heredoc_body(body)
-        else:
-            self._req.cmd_args = (code, )
+        self._req.cmd_args = (body, )
 
 
 class OnceClient:

--- a/feeluown/server/handlers/handle.py
+++ b/feeluown/server/handlers/handle.py
@@ -69,3 +69,4 @@ from .show import ShowHandler  # noqa
 from .exec_ import ExecHandler  # noqa
 from .sub import SubHandler  # noqa
 from .set_ import SetHandler  # noqa
+from .jsonrpc_ import JsonRPCHandler  # noqa

--- a/feeluown/webserver/server.py
+++ b/feeluown/webserver/server.py
@@ -10,7 +10,7 @@ from feeluown.server.pubsub import Gateway as PubsubGateway
 from feeluown.server.handlers.cmd import Cmd
 from feeluown.server.handlers.status import StatusHandler
 from feeluown.server.handlers.player import PlayerHandler
-from .jsonrpc_ import initialize, handle
+from feeluown.server.handlers.jsonrpc_ import handle
 
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,6 @@ async def signal(request, ws: Websocket):
 
 
 async def run_web_server(host, port):
-    initialize()
     sanic_app.config.MOTD = False
     server = await sanic_app.create_server(host, port, return_asyncio_server=True)
     await server.startup()


### PR DESCRIPTION
Before, only the web server(23332) supports jsonrpc.
Now, the fuo server(23333) also supports it.

**Background**
FeelUOwn webserver uses `sanic` as its web framework. However, the `sanic` package has many sub-dependencies. It's hard to run `sanic` on mobile devices such as Android.