### PR TITLE
*: resolve logger warnings

### DIFF
--- a/feeluown/library/uri.py
+++ b/feeluown/library/uri.py
@@ -314,7 +314,7 @@ def reverse(model, path='', as_line=False):
             video = model
             fields = [video.title_display]
         else:
-            logger.warn('The display fields are dropped during reverse')
+            logger.warning('The display fields are dropped during reverse')
             fields = []
 
         # strip emtpy suffix

--- a/feeluown/player/mpvplayer.py
+++ b/feeluown/player/mpvplayer.py
@@ -260,7 +260,7 @@ class MpvPlayer(AbstractPlayer):
             self._position = position
             self.seeked.emit(position)
         else:
-            logger.warn("can't set position when current media is empty")
+            logger.warning("can't set position when current media is empty")
 
     @AbstractPlayer.volume.setter  # type: ignore
     def volume(self, value):


### PR DESCRIPTION
## PR Summary
This small PR migrates from the deprecated `logger.warn` to the recommended `logger.warning` method to solve:
```python
DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
```