### PR TITLE
chore: jsonrpc is not needed

### DIFF
--- a/feeluown/server/handlers/handle.py
+++ b/feeluown/server/handlers/handle.py
@@ -72,4 +72,4 @@ from .set_ import SetHandler  # noqa
 try:
     from .jsonrpc_ import JsonRPCHandler  # noqa
 except ImportError as e:
-    logger.warning(f'jsonrpc handler is not available: {e}')
+    logger.info(f'jsonrpc handler is not available: {e}')


### PR DESCRIPTION
jsonrpc is optional, so do not log a warning when it is not installed

```sh
~ > fuo status
jsonrpc handler is not available: No module named 'jsonrpc'
   repeat:  true
   random:  false
   volume:  100
    state:  paused
 duration:  217.6408843537415
 position:  207.466666666659
     song:  fuo://qqmusic/songs/1923055	# 可惜我是水瓶座 (L… - 杨千嬅
  lyric-s:  够绝情我都赶我自己出去
```