### PR TITLE
player: the player skipped a song unexpectedly

### DIFF
--- a/feeluown/gui/image.py
+++ b/feeluown/gui/image.py
@@ -47,7 +47,6 @@ class ImgManager(object):
             return provider.handle_with_path(img_url[11:])
         fpath = self.cache.get(img_name)
         if fpath is not None:
-            logger.debug('read image:%s from cache', img_name)
             with open(fpath, 'rb') as f:
                 content = f.read()
             self.cache.update(img_name)

--- a/feeluown/player/mpvplayer.py
+++ b/feeluown/player/mpvplayer.py
@@ -287,10 +287,7 @@ class MpvPlayer(AbstractPlayer):
         self.video_format_changed.emit(vformat)
 
     def _stop_mpv(self):
-        # Remove current media.
-        self._mpv.play("")
-        # Clear the playlist so that no other media will be played.
-        self._mpv.playlist_clear()
+        self._mpv.stop()
 
     def _on_position_changed(self, position):
         self._position = max(0, position or 0)

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -488,6 +488,7 @@ class Playlist:
         """
         next_song = self._get_next_song_no_lock()
         if next_song is None:
+            logger.debug('No next song in playlist, emit eof_reached.')
             self.eof_reached.emit()
             return None
         return self.set_existing_song_as_current_song(next_song)


### PR DESCRIPTION
Before, feeluown stops the MPV by playing a `''` file. The action causes the MPV to emit an EndFile event in the new version of libmpv. In the old version of libmpv, it does not emit any event. This change causes the bug. 
```
[v] bdmv/bluray: Opening
[v] file: Opening
[error] file: Cannot open file '': No such file or directory
[error] stream: Failed to open .
[v] cplayer: Opening failed or was aborted:
[v] cplayer: finished playback, loading failed (reason 4)
[v] stream_callback: Opening http://xxxx
```

Now, call `stop` method directly to stop the MPV instead of `play('')`