### PR TITLE
gui: webengine can't be initialized on macOS

### DIFF
--- a/feeluown/app/gui_app.py
+++ b/feeluown/app/gui_app.py
@@ -31,7 +31,7 @@ class GuiApp(App, QWidget):
         # macOS: must initialize QApplication before constructing a pixmap object.
         # Arch Linux: it may core if QApplication is initialized here.
         if sys.platform == 'darwin':
-            GuiApp.__q_app = QApplication([])
+            GuiApp.__q_app = QApplication(['FeelUOwn'])
         # Set desktopFileName so that the window icon is properly shown under wayland.
         # I don't know if this setting brings other benefits or not.
         # https://github.com/pyfa-org/Pyfa/issues/1607#issuecomment-392099878


### PR DESCRIPTION
Argument list is empty, the program name is not passed to QCoreApplication. base::CommandLine cannot be properly initialized.