### PR TITLE
feat(gui): support provider image media for cover loading

### DIFF
--- a/feeluown/gui/page_containers/table.py
+++ b/feeluown/gui/page_containers/table.py
@@ -92,10 +92,11 @@ class Renderer:
         self.container.current_extra = extra
 
     async def show_cover(self, cover, cover_uid, as_background=False):
-        cover = Media(cover, MediaType.image)
-        url = cover.url
+        cover_media = (
+            cover if isinstance(cover, Media) else Media(cover, MediaType.image)
+        )
         app = self._app
-        content = await app.img_mgr.get(url, cover_uid)
+        content = await app.img_mgr.get(cover_media, cover_uid)
         img = QImage()
         img.loadFromData(content)
         pixmap = QPixmap(img)

--- a/feeluown/gui/widgets/cover_label.py
+++ b/feeluown/gui/widgets/cover_label.py
@@ -82,8 +82,8 @@ class CoverLabelV2(CoverLabel):
 
         self._app = app
 
-    async def show_cover(self, url, cover_uid):
-        content = await self._app.img_mgr.get(url, cover_uid)
+    async def show_cover(self, cover, cover_uid):
+        content = await self._app.img_mgr.get(cover, cover_uid)
         img = QImage()
         img.loadFromData(content)
         self.show_img(img)

--- a/feeluown/library/provider_protocol.py
+++ b/feeluown/library/provider_protocol.py
@@ -4,9 +4,19 @@ from feeluown.media import Quality, Media
 from feeluown.excs import NoUserLoggedIn
 from feeluown.utils.dispatch import Signal
 from .models import (
-    BriefCommentModel, SongModel, VideoModel, AlbumModel, ArtistModel,
-    PlaylistModel, UserModel, ModelType, BriefArtistModel, BriefSongModel,
-    LyricModel, BriefVideoModel, BriefPlaylistModel,
+    BriefCommentModel,
+    SongModel,
+    VideoModel,
+    AlbumModel,
+    ArtistModel,
+    PlaylistModel,
+    UserModel,
+    ModelType,
+    BriefArtistModel,
+    BriefSongModel,
+    LyricModel,
+    BriefVideoModel,
+    BriefPlaylistModel,
 )
 from .collection import Collection
 
@@ -35,15 +45,18 @@ def check_flag(provider, model_type: ModelType, flag: PF) -> bool:
 
 def eq(model_type: ModelType, flag: PF):
     """Decorate a protocol class and associate it with a provider flag"""
+
     def wrapper(cls):
         _FlagProtocolMapping[(model_type, flag)] = cls
         return cls
+
     return wrapper
 
 
 #
 # Protocols for Song related functions.
 #
+
 
 @eq(ModelType.song, PF.get)
 @runtime_checkable
@@ -62,8 +75,7 @@ class SupportsSongGet(Protocol):
 class SupportsSongSimilar(Protocol):
     @abstractmethod
     def song_list_similar(self, song: BriefSongModel) -> List[BriefSongModel]:
-        """List similar songs
-        """
+        """List similar songs"""
         raise NotImplementedError
 
 
@@ -118,8 +130,7 @@ class SupportsSongWebUrl(Protocol):
 @runtime_checkable
 class SupportsSongLyric(Protocol):
     def song_get_lyric(self, song: BriefSongModel) -> Optional[LyricModel]:
-        """Get music video of the song
-        """
+        """Get music video of the song"""
         raise NotImplementedError
 
 
@@ -127,15 +138,14 @@ class SupportsSongLyric(Protocol):
 @runtime_checkable
 class SupportsSongMV(Protocol):
     def song_get_mv(self, song: BriefSongModel) -> Optional[VideoModel]:
-        """Get music video of the song
-
-        """
+        """Get music video of the song"""
         raise NotImplementedError
 
 
 #
 # Protocols for Album related functions.
 #
+
 
 @eq(ModelType.album, PF.get)
 @runtime_checkable
@@ -161,6 +171,7 @@ class SupportsAlbumSongsReader(Protocol):
 # Protocols for Album related functions.
 #
 
+
 @eq(ModelType.artist, PF.get)
 @runtime_checkable
 class SupportsArtistGet(Protocol):
@@ -178,8 +189,7 @@ class SupportsArtistGet(Protocol):
 class SupportsArtistSongsReader(Protocol):
     @abstractmethod
     def artist_create_songs_rd(self, artist: BriefArtistModel):
-        """Create songs reader of the artist
-        """
+        """Create songs reader of the artist"""
         raise NotImplementedError
 
 
@@ -188,8 +198,7 @@ class SupportsArtistSongsReader(Protocol):
 class SupportsArtistAlbumsReader(Protocol):
     @abstractmethod
     def artist_create_albums_rd(self, artist: BriefArtistModel):
-        """Create albums reader of the artist
-        """
+        """Create albums reader of the artist"""
         raise NotImplementedError
 
 
@@ -197,14 +206,14 @@ class SupportsArtistAlbumsReader(Protocol):
 class SupportsArtistContributedAlbumsReader(Protocol):
     @abstractmethod
     def artist_create_contributed_albums_rd(self, artist: BriefArtistModel):
-        """Create contributed albums reader of the artist
-        """
+        """Create contributed albums reader of the artist"""
         raise NotImplementedError
 
 
 #
 # Protocols for Video related functions.
 #
+
 
 @eq(ModelType.video, PF.get)
 @runtime_checkable
@@ -233,7 +242,8 @@ class SupportsVideoMultiQuality(Protocol):
 
     @abstractmethod
     def video_select_media(
-            self, video: BriefVideoModel, policy=None) -> Tuple[Media, Quality.Video]:
+        self, video: BriefVideoModel, policy=None
+    ) -> Tuple[Media, Quality.Video]:
         raise NotImplementedError
 
     @abstractmethod
@@ -244,6 +254,7 @@ class SupportsVideoMultiQuality(Protocol):
 #
 # Protocols for Album related functions.
 #
+
 
 @eq(ModelType.playlist, PF.get)
 @runtime_checkable
@@ -420,6 +431,7 @@ class SupportsCurrentUserFavVideosReader(Protocol):
 @runtime_checkable
 class SupportsCurrentUserDislikeSongsReader(Protocol):
     """Support reading the song dislike list."""
+
     @abstractmethod
     def current_user_dislike_create_songs_rd(self) -> List[BriefSongModel]:
         pass
@@ -428,6 +440,7 @@ class SupportsCurrentUserDislikeSongsReader(Protocol):
 @runtime_checkable
 class SupportsCurrentUserDislikeAddSong(Protocol):
     """Support adding a song to the song dislike list."""
+
     @abstractmethod
     def current_user_dislike_add_song(self, song: BriefSongModel) -> bool:
         """
@@ -438,6 +451,7 @@ class SupportsCurrentUserDislikeAddSong(Protocol):
 @runtime_checkable
 class SupportsCurrentUserDislikeRemoveSong(Protocol):
     """Support removing a song from the song dislike list."""
+
     @abstractmethod
     def current_user_dislike_remove_song(self, song: BriefSongModel) -> bool:
         """
@@ -459,6 +473,13 @@ class SupportsToplist(Protocol):
         PlaylistModel. They should think about a way to solve this. For example,
         turn the identifier into `toplist_{id}` and do some hack in playlist_get API.
         """
+
+
+@runtime_checkable
+class SupportsImgUrlToMedia(Protocol):
+    @abstractmethod
+    def img_url_to_media(self, pic_url: str) -> Media:
+        """Convert a picture url to image media with optional network options."""
 
 
 #

--- a/tests/gui/test_helpers.py
+++ b/tests/gui/test_helpers.py
@@ -5,53 +5,75 @@ import pytest
 from feeluown.library import reverse
 from feeluown.library import ModelNotFound
 from feeluown.gui.helpers import fetch_cover_wrapper
+from feeluown.media import Media, MediaType
 
 
 async def img_mgr_get_return_x():
-    return b'x'
+    return b"x"
 
 
 @pytest.mark.asyncio
-async def test_fetch_cover_wrapper(app_mock, library,
-                                   ekaf_brief_song0, ekaf_album0, ekaf_song0,
-                                   song):
+async def test_fetch_cover_wrapper(
+    app_mock, library, ekaf_brief_song0, ekaf_album0, ekaf_song0, song
+):
     app_mock.library = library
     app_mock.img_mgr.get_from_cache.return_value = None
     mock_img_mgr_get = app_mock.img_mgr.get
-    song_pic_uri = reverse(ekaf_song0, '/pic_url')
-    album_cover_uri = reverse(ekaf_album0, '/cover')
+    song_pic_uri = reverse(ekaf_song0, "/pic_url")
+    album_cover_uri = reverse(ekaf_album0, "/cover")
+    ekaf_provider = library.get(ekaf_song0.source)
+
+    def to_cover_media(url):
+        return Media(
+            url,
+            MediaType.image,
+            http_proxy="http://127.0.0.1:7890",
+        )
+
+    ekaf_provider.img_url_to_media = to_cover_media
 
     # case 1: when song is a v2 model and it has pic_url, it should directly used.
-    url = 'http://xxx.com/cover.jpg'
+    url = "http://xxx.com/cover.jpg"
     ekaf_song0.pic_url = url
     cb = mock.MagicMock()
     mock_img_mgr_get.return_value = img_mgr_get_return_x()
     coro = fetch_cover_wrapper(app_mock)
     await coro(ekaf_brief_song0, cb)
-    mock_img_mgr_get.assert_called_once_with(url, song_pic_uri)
-    cb.assert_called_once_with(b'x')
+    call = mock_img_mgr_get.call_args
+    media, uid = call.args
+    assert isinstance(media, Media)
+    assert media.type_ == MediaType.image
+    assert media.url == url
+    assert media.http_proxy == "http://127.0.0.1:7890"
+    assert uid == song_pic_uri
+    cb.assert_called_once_with(b"x")
 
     # case 2: song.pic_url is empty and its album has valid cover,
     # the cover should be used.
-    ekaf_song0.pic_url = ''
-    ekaf_album0.cover = 'http://xxx.com/cover.jpg'
+    ekaf_song0.pic_url = ""
+    ekaf_album0.cover = "http://xxx.com/cover.jpg"
     cb = mock.MagicMock()
     app_mock.img_mgr.get.return_value = img_mgr_get_return_x()
     coro = fetch_cover_wrapper(app_mock)
     await coro(ekaf_brief_song0, cb)
-    mock_img_mgr_get.assert_called_with(url, album_cover_uri)
-    cb.assert_called_once_with(b'x')
+    call = mock_img_mgr_get.call_args
+    media, uid = call.args
+    assert isinstance(media, Media)
+    assert media.url == url
+    assert media.http_proxy == "http://127.0.0.1:7890"
+    assert uid == album_cover_uri
+    cb.assert_called_once_with(b"x")
 
     # case 3: song is a v1 model, and it's album has valid cover.
     app_mock.img_mgr.get.return_value = img_mgr_get_return_x()
-    song.album.cover = 'http://xxx.com/cover.jpg'
+    song.album.cover = "http://xxx.com/cover.jpg"
     cb = mock.MagicMock()
     coro = fetch_cover_wrapper(app_mock)
     await coro(song, cb)
-    cb.assert_called_once_with(b'x')
+    cb.assert_called_once_with(b"x")
 
     # case 4: song has no valid album
-    song.album.cover = ''
+    song.album.cover = ""
     cb = mock.MagicMock()
     coro = fetch_cover_wrapper(app_mock)
     await coro(song, cb)

--- a/tests/gui/test_image.py
+++ b/tests/gui/test_image.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from feeluown.gui.image import ImgManager
+from feeluown.media import Media, MediaType
+
+
+@pytest.mark.asyncio
+async def test_img_mgr_get_uses_media_network_options(tmp_path):
+    app_mock = MagicMock()
+    app_mock.request.get.return_value = SimpleNamespace(content=b"img-bytes")
+    img_mgr = ImgManager(app_mock)
+    img_mgr.cache.get = MagicMock(return_value=None)
+    img_mgr.cache.create = MagicMock(return_value=str(tmp_path / "img.cache"))
+    img_mgr.save = MagicMock()
+
+    media = Media(
+        "https://img.example.com/a.jpg",
+        MediaType.image,
+        http_headers={"User-Agent": "fuo-test"},
+        http_proxy="http://127.0.0.1:7890",
+    )
+    content = await img_mgr.get(media, "img-uid")
+
+    assert content == b"img-bytes"
+    app_mock.request.get.assert_called_once_with(
+        "https://img.example.com/a.jpg",
+        headers={"User-Agent": "fuo-test"},
+        proxies={
+            "http": "http://127.0.0.1:7890",
+            "https": "http://127.0.0.1:7890",
+        },
+    )


### PR DESCRIPTION
## Summary
- add a new provider protocol `SupportsImgUrlToMedia` to map image url to `Media`
- add `Library.model_get_cover_media` and use it in cover fetching helpers
- update image loading to consume `Media` network options (`http_proxy` and headers)
- keep legacy string-url cover paths compatible while moving to media-based flow
- add tests for protocol hook usage and image request proxy/header propagation

## Testing
- [x] `uv run ruff check feeluown/library/provider_protocol.py feeluown/library/library.py feeluown/gui/helpers.py feeluown/gui/image.py feeluown/gui/page_containers/table.py feeluown/gui/widgets/cover_label.py tests/gui/test_helpers.py tests/gui/test_image.py tests/library/test_library.py`
- [x] `uv run pytest tests/gui/test_helpers.py tests/gui/test_image.py tests/library/test_library.py`
- [x] E2E with ytmusic provider + proxy (`http://127.0.0.1:7890`) confirms cover download succeeds through `ImgManager`
