### PR TITLE
refactor(mcp): drop URI playlist tools and enforce model-json flow

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,5 +1,12 @@
 版本变更历史
 ----------------------
+5.1.1.dev0 (unreleased)
+""""""""""""""""""""""""""
+- 兼容性变更
+
+  - MCP Server 移除 URI 形式的播放队列接口：`player_play_media_by_uri`、`playlist_add_uri`、`playlist_play_uri`。
+  - 统一使用 JSON model 接口：`playlist_add_model_json`、`playlist_play_model_json`（可直接复用 `provider_search` / `provider_song_get` 的模型输出）。
+
 5.1 (2026-02-28)
 """"""""""""""""""""""
 - 功能增强

--- a/feeluown/__init__.py
+++ b/feeluown/__init__.py
@@ -6,7 +6,7 @@ import logging.config
 from .consts import LOG_FILE
 
 
-__version__ = '5.1'
+__version__ = '5.1.1.dev0'
 
 
 dict_config = {

--- a/feeluown/mcpserver.py
+++ b/feeluown/mcpserver.py
@@ -4,9 +4,6 @@ from mcp.server.fastmcp import FastMCP
 from feeluown.app import App, get_app
 from feeluown.library import (
     ModelType,
-    ResolveFailed,
-    ResolverNotFound,
-    resolve,
     reverse,
     SearchType,
     BriefAlbumModel,
@@ -110,15 +107,6 @@ def _player_nowplaying_metadata() -> dict[str, Any] | None:
 def _playlist_list() -> list[dict[str, Any]]:
     app = _require_app()
     return serialize("python", app.playlist.list())
-
-
-def _player_play_media_by_uri(uri: str) -> bool:
-    app = _require_app()
-    for model in app.playlist.list():
-        if reverse(model) == uri:
-            app.playlist.play_model(model)
-            return True
-    return False
 
 
 def _model_from_json_payload(model_payload: dict[str, Any]):
@@ -291,14 +279,6 @@ def library_providers() -> list[dict[str, Any]]:
 
 
 @mcp.tool()
-def player_play_media_by_uri(uri: str) -> bool:
-    """
-    Play a track by URI if it exists in the current playlist queue.
-    """
-    return _player_play_media_by_uri(uri)
-
-
-@mcp.tool()
 def player_toggle() -> None:
     _require_app().player.toggle()
 
@@ -349,18 +329,14 @@ def playlist_clear() -> None:
 
 
 @mcp.tool()
-def playlist_add_uri(uri: str) -> bool:
-    app = _require_app()
-    try:
-        model = resolve(uri)
-    except (ResolveFailed, ResolverNotFound):
-        return False
-    app.playlist.add(model)
-    return True
-
-
-@mcp.tool()
 def playlist_add_model_json(model: dict[str, Any]) -> bool:
+    """
+    Deserialize a song/video model JSON payload and append it to the playlist.
+
+    The payload can be passed directly from provider tool outputs, such as
+    entries in ``provider_search(...)[i]["result"]["songs"]`` /
+    ``provider_search(...)[i]["result"]["videos"]``.
+    """
     app = _require_app()
     try:
         parsed_model = _model_from_json_payload(model)
@@ -371,19 +347,13 @@ def playlist_add_model_json(model: dict[str, Any]) -> bool:
 
 
 @mcp.tool()
-def playlist_play_uri(uri: str) -> bool:
-    app = _require_app()
-    try:
-        model = resolve(uri)
-    except (ResolveFailed, ResolverNotFound):
-        return False
-    app.playlist.add(model)
-    app.playlist.play_model(model)
-    return True
-
-
-@mcp.tool()
 def playlist_play_model_json(model: dict[str, Any]) -> bool:
+    """
+    Deserialize a song/video model JSON payload and play it immediately.
+
+    The payload shape is the same as ``playlist_add_model_json`` and can be
+    passed directly from provider tool outputs.
+    """
     app = _require_app()
     try:
         parsed_model = _model_from_json_payload(model)
@@ -415,6 +385,13 @@ def provider_search(
 ) -> list[dict[str, Any]] | None:
     """
     Search provider resources. Returns a list of results per search type.
+
+    Each returned item has the shape:
+    ``{"type": "...", "source": "...", "result": <serialized payload>}``.
+
+    For song/video results, serialized models inside ``result`` can be used
+    directly as the ``model`` argument of ``playlist_add_model_json`` or
+    ``playlist_play_model_json``.
     """
     provider = _provider_from_id(provider_id)
     if provider is None:

--- a/tests/mcp/test_mcpserver.py
+++ b/tests/mcp/test_mcpserver.py
@@ -6,7 +6,7 @@ import pytest
 
 import feeluown.mcpserver as mcpserver
 from feeluown.player import PlaybackMode, State
-from feeluown.library import ResolveFailed, SearchType, Collection, CollectionType
+from feeluown.library import SearchType, Collection, CollectionType
 
 
 @pytest.fixture
@@ -298,14 +298,6 @@ def test_player_status(mocker, app):
     assert payload["nowplaying"]["uri"] == "fuo://fake/songs/1"
 
 
-def test_playlist_add_uri_success(mocker, app):
-    mocker.patch("feeluown.mcpserver.get_app", return_value=app)
-    mocker.patch("feeluown.mcpserver.resolve", return_value=MagicMock())
-
-    assert mcpserver.playlist_add_uri("fuo://fake/songs/1") is True
-    assert app.playlist.add.called
-
-
 def test_playlist_add_model_json_success(mocker, app):
     mocker.patch("feeluown.mcpserver.get_app", return_value=app)
     payload = {
@@ -343,23 +335,6 @@ def test_playlist_add_model_json_unsupported_model(mocker, app):
 
     assert mcpserver.playlist_add_model_json(payload) is False
     app.playlist.add.assert_not_called()
-
-
-def test_playlist_add_uri_fail(mocker, app):
-    mocker.patch("feeluown.mcpserver.get_app", return_value=app)
-    mocker.patch("feeluown.mcpserver.resolve", side_effect=ResolveFailed("bad"))
-
-    assert mcpserver.playlist_add_uri("bad-uri") is False
-    assert not app.playlist.add.called
-
-
-def test_playlist_play_uri(mocker, app):
-    mocker.patch("feeluown.mcpserver.get_app", return_value=app)
-    mocker.patch("feeluown.mcpserver.resolve", return_value=MagicMock())
-
-    assert mcpserver.playlist_play_uri("fuo://fake/songs/1") is True
-    assert app.playlist.add.called
-    assert app.playlist.play_model.called
 
 
 def test_playlist_play_model_json_success(mocker, app):


### PR DESCRIPTION
## Summary
- remove URI-based MCP playlist/player tools to prevent ambiguous usage (`player_play_media_by_uri`, `playlist_add_uri`, `playlist_play_uri`)
- keep and document model-json playlist tools as the single path (`playlist_add_model_json`, `playlist_play_model_json`)
- bump project version to `5.1.1.dev0` and add changelog entry describing this MCP breaking change

## Test Plan
- `uv run pytest tests/mcp/test_mcpserver.py -q`
- `uv run make test`
