### PR TITLE
i18n(feat): plugins can register their own translation

### DIFF
--- a/feeluown/i18n/__init__.py
+++ b/feeluown/i18n/__init__.py
@@ -57,9 +57,10 @@ def t(
 ) -> str:
     """
     :param msg_id: Message ID inside fluent translation files.
-                   Supports plugin translation format.
     :param locale: Optional BCP-47 language code
-    :param domain: Plugin id, e.g. "fuo-netease"
+    :param domain: Plugin id, e.g. "fuo-netease".
+                   If None, will go through l10n_bundle. (CORE)
+                   If is passed, will go through plugin_l10n_bundle. (Plugin)
     :param kwargs: Any object that implements the `__str__`
 
     If `locale` was left `None`, this will use the _DEFAULT_LOCALE.
@@ -93,21 +94,22 @@ def t(
     return bundle.format_value(msg_id, kwargs)
 
 
-def register_plugin_locales(domain: str, locales_dir: str | Path,
-                            resource_id: list[str]):
+def register_plugin_i18n(domain: str, locales_dir: str | Path,
+                         resource_ids: list[str]):
     """
-    Registration for plugin locales dir
+    Registration for plugin i18n
 
     :param domain: Plugin id, e.g. "fuo-netease"
     :param locales_dir: Parent path of the locale files
-    :param resource_id: Locale file names as list
+    :param resource_ids: Locale file names as list
     """
-    _PLUGIN_LOCALES[domain] = (Path(locales_dir), resource_id)
+    _PLUGIN_LOCALES[domain] = (Path(locales_dir), resource_ids)
     logger.info(f"Registered i18n for plugin: {domain}")
 
 
 def l10n_bundle(locale: str | None = None) -> FluentLocalization:
     """
+    Get bundle for CORE
     You could call this method multiple times
 
     **NOTE:** `locale.getlocale` from standard library is unreliable.
@@ -121,7 +123,14 @@ def l10n_bundle(locale: str | None = None) -> FluentLocalization:
         else:
             locale = OVERRIDE_LOCALE
 
-    return load_l10n_resource(locales=[locale])
+    with resources.as_file(
+            resources.files(feeluown.i18n) / "assets",
+    ) as current_dir:
+        supported = [lang for lang in os.listdir(current_dir)]
+        roots = [str(current_dir / "{locale}")]
+
+    return _create_or_get_bundle(namespace="CORE", roots=roots, locales=[locale],
+                                 resource_ids=DEFAULT_RESOURCE_IDS, supported=supported)
 
 
 def plugin_l10n_bundle(domain: str, locale: str | None = None) -> FluentLocalization:
@@ -142,46 +151,25 @@ def plugin_l10n_bundle(domain: str, locale: str | None = None) -> FluentLocaliza
 
     localedir, resource_ids = _PLUGIN_LOCALES[domain]
     supported = [d.name for d in localedir.iterdir() if d.is_dir()]
+    roots = [localedir / "{locale}"]
 
-    return load_l10n_resource(locales=[locale],
-                              resource_id=resource_ids,
-                              roots=[localedir / "{locale}"],
-                              supported=supported,
-                              is_plugin=True
-                              )
+    return _create_or_get_bundle(namespace=domain, roots=roots, locales=[locale],
+                                 resource_ids=resource_ids, supported=supported)
 
 
-def load_l10n_resource(
-    locales: list[str],
-    skip_fallback: bool = False,
-    resource_id: list[str] = None,
-    roots: list[Path] = None,
-    supported: list[str] = None,
-    is_plugin: bool = False
+def _create_or_get_bundle(
+        namespace: str,
+        roots: str | list[str],
+        locales: list[str | None],
+        resource_ids: list[str] = None,
+        supported: list[str] = None,
+        skip_fallback: bool = False
 ) -> FluentLocalization:
-    if resource_id is None:
-        resource_id = DEFAULT_RESOURCE_IDS
-
-    # For core
-    if roots is None and is_plugin is False:
-        with resources.as_file(
-            resources.files(feeluown.i18n) / "assets",
-        ) as current_dir:
-            supported = [lang for lang in os.listdir(current_dir)]
-            roots = [current_dir / "{locale}"]
-            return _create_bundle(locales, skip_fallback, resource_id, roots,
-                                  supported, is_plugin)
-
-    # For Plugins
-    return _create_bundle(locales, skip_fallback, resource_id, roots,
-                          supported, is_plugin)
-
-
-def _create_bundle(locales, skip_fallback, resource_id, roots, supported, is_plugin):
     """
     General logic for creating bundle
+
+    :param namespace: "CORE" or Plugin domain id, e.g. "fuo-netease"
     """
-    res_loader = FluentResourceLoader(roots=[str(r) for r in roots])
 
     matched_locales = []
     for locale in locales:
@@ -196,12 +184,8 @@ def _create_bundle(locales, skip_fallback, resource_id, roots, supported, is_plu
     if not skip_fallback:
         locales_to_load += ["en-US", "zh-CN"]
 
-    if is_plugin:
-        cache_key = (tuple(locales_to_load), tuple(resource_id),
-                     tuple(str(r) for r in roots))
-    else:
-        cache_key = (tuple(locales_to_load), tuple(resource_id),
-                     tuple("CORE"))
+    cache_key = (tuple(locales_to_load), tuple(resource_ids),
+                 tuple(namespace))
 
     with _L10N_BUNDLE_LOCK[cache_key]:
         if cache_key in _L10N_BUNDLE:
@@ -211,10 +195,11 @@ def _create_bundle(locales, skip_fallback, resource_id, roots, supported, is_plu
 
         # resources are loaded immediately,
         # so current_dir can be cleaned safely.
+        res_loader = FluentResourceLoader(roots=roots)
         bundle = FluentLocalization(
             # add en-US, zh-CN for fallback
             locales=locales_to_load,
-            resource_ids=resource_id,
+            resource_ids=resource_ids,
             resource_loader=res_loader,
         )
 
@@ -256,44 +241,54 @@ DEFAULT_RESOURCE_IDS = ["app.ftl", "argparser.ftl", "config.ftl"]
 
 
 if __name__ == "__main__":
-    for res_id in DEFAULT_RESOURCE_IDS:
-        resource_ids = [res_id]
-        print(f"""{res_id}:
------------------------------""")
-        l10n_zh = next(
-            load_l10n_resource(
-                locales=["zh-CN"],
-                skip_fallback=True,
-                resource_id=resource_ids,
-            )._bundles()
-        )
-        total_term_len = len(l10n_zh._terms)
-        total_msg_len = len(l10n_zh._messages)
-        for locale in os.listdir(Path(__file__).parent / "assets"):
-            if locale == "zh-CN":
-                continue
+    with resources.as_file(
+            resources.files(feeluown.i18n) / "assets",
+    ) as current_dir:
+        supported = [lang for lang in os.listdir(current_dir)]
+        roots = [str(current_dir / "{locale}")]
 
-            try:
-                bundle: FluentBundle = next(
-                    load_l10n_resource(
-                        locales=[locale],
-                        skip_fallback=True,
-                        resource_id=resource_ids,
-                    )._bundles()
-                )
-            except StopIteration:
-                continue
-            print(f"{locale}")
+        for res_id in DEFAULT_RESOURCE_IDS:
+            resource_ids = [res_id]
+            print(f"""{res_id}:
+    -----------------------------""")
+            l10n_zh = next(
+                _create_or_get_bundle(
+                    namespace="CORE",
+                    roots=roots,
+                    locales=["zh-CN"],
+                    skip_fallback=True,
+                    resource_ids=resource_ids,
+                )._bundles()
+            )
+            total_term_len = len(l10n_zh._terms)
+            total_msg_len = len(l10n_zh._messages)
+            for locale in os.listdir(Path(__file__).parent / "assets"):
+                if locale == "zh-CN":
+                    continue
 
-            if total_term_len:
-                print(
-                    f"Terms: {len(bundle._terms)}/{total_term_len}"
-                    f" ({100 * len(bundle._terms) / total_term_len:.1f}%)"
-                )
-            if total_msg_len:
-                print(
-                    f"Messages: {len(bundle._messages)}/{total_msg_len}"
-                    f" ({100 * len(bundle._messages) / total_msg_len:.1f}%)"
-                )
+                try:
+                    bundle: FluentBundle = next(
+                        _create_or_get_bundle(
+                            namespace="CORE",
+                            roots=roots,
+                            locales=[locale],
+                            skip_fallback=True,
+                            resource_ids=resource_ids,
+                        )._bundles()
+                    )
+                except StopIteration:
+                    continue
+                print(f"{locale}")
 
-            print()
+                if total_term_len:
+                    print(
+                        f"Terms: {len(bundle._terms)}/{total_term_len}"
+                        f" ({100 * len(bundle._terms) / total_term_len:.1f}%)"
+                    )
+                if total_msg_len:
+                    print(
+                        f"Messages: {len(bundle._messages)}/{total_msg_len}"
+                        f" ({100 * len(bundle._messages) / total_msg_len:.1f}%)"
+                    )
+
+                print()


### PR DESCRIPTION
In the setting window(App Configration), the provider names are not localized, always showing Chinese name regardless of the UI language.
Added translation keys for current providers and updated SearchProvidersFilter to use localized names.

# Behaviour
<img width="570" height="434" alt="Screenshot 2026-03-19 192434" src="https://github.com/user-attachments/assets/a80ca8dd-59ae-4c32-a538-b09effe2a56e" />

# Expected Behaviour
<img width="570" height="434" alt="Screenshot 2026-03-19 200801" src="https://github.com/user-attachments/assets/e14c5c2e-f001-45fb-8ed3-6d67885c8883" />

