### PR TITLE
fix: single song loop no redownloads

### DIFF
--- a/feeluown/player/mpvplayer.py
+++ b/feeluown/player/mpvplayer.py
@@ -166,19 +166,19 @@ class MpvPlayer(AbstractPlayer):
             self._current_metadata = metadata
         self.metadata_changed.emit(self.current_metadata)
 
-    def set_loop(self, loop_mode):
+    def setInfiniteLoop(self, inf_loop):
         """
-        Set playback as loop mode
+        Set playback as Infinite Loop
 
-        :param loop_mode:
+        :param inf_loop:
                     - False: No loop
                     - True: Loop as infinite
         """
-        if loop_mode is False:
-            loop_mode = "no"
-        elif loop_mode is True:
-            loop_mode = "inf"
-        _mpv_set_property_string(self._mpv.handle, b'loop', bytes(loop_mode, 'utf-8'))
+        if inf_loop is False:
+            inf_loop = "no"
+        elif inf_loop is True:
+            inf_loop = "inf"
+        _mpv_set_property_string(self._mpv.handle, b'loop', bytes(inf_loop, 'utf-8'))
 
     def set_play_range(self, start=None, end=None):
         if self._version >= (1, 28):

--- a/feeluown/player/mpvplayer.py
+++ b/feeluown/player/mpvplayer.py
@@ -166,19 +166,10 @@ class MpvPlayer(AbstractPlayer):
             self._current_metadata = metadata
         self.metadata_changed.emit(self.current_metadata)
 
-    def setInfiniteLoop(self, inf_loop):
-        """
-        Set playback as Infinite Loop
-
-        :param inf_loop:
-                    - False: No loop
-                    - True: Loop as infinite
-        """
-        if inf_loop is False:
-            inf_loop = "no"
-        elif inf_loop is True:
-            inf_loop = "inf"
-        _mpv_set_property_string(self._mpv.handle, b'loop', bytes(inf_loop, 'utf-8'))
+    def set_infinite_loop(self, on: bool):
+        """Enable or disable infinite loop playback."""
+        loop = "inf" if on is True else "no"
+        _mpv_set_property_string(self._mpv.handle, b'loop', bytes(loop, 'utf-8'))
 
     def set_play_range(self, start=None, end=None):
         if self._version >= (1, 28):

--- a/feeluown/player/mpvplayer.py
+++ b/feeluown/player/mpvplayer.py
@@ -166,6 +166,20 @@ class MpvPlayer(AbstractPlayer):
             self._current_metadata = metadata
         self.metadata_changed.emit(self.current_metadata)
 
+    def set_loop(self, loop_mode):
+        """
+        Set playback as loop mode
+
+        :param loop_mode:
+                    - False: No loop
+                    - True: Loop as infinite
+        """
+        if loop_mode is False:
+            loop_mode = "no"
+        elif loop_mode is True:
+            loop_mode = "inf"
+        _mpv_set_property_string(self._mpv.handle, b'loop', bytes(loop_mode, 'utf-8'))
+
     def set_play_range(self, start=None, end=None):
         if self._version >= (1, 28):
             start_default, end_default = 'none', 'none'

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -449,6 +449,10 @@ class Playlist:
             self._leave_shuffle_mode()
 
         self._playback_mode = playback_mode
+        if playback_mode == PlaybackMode.one_loop:
+            self._app.player.set_loop(True)
+        else:
+            self._app.player.set_loop(False)
         self.playback_mode_changed.emit(self.playback_mode)
 
     def _enter_shuffle_mode(self):
@@ -594,11 +598,7 @@ class Playlist:
 
     def _on_media_finished(self):
         # Play next model when current media is finished.
-        if self.playback_mode == PlaybackMode.one_loop:
-            self._app.player.set_loop(True)
-        else:
-            self._app.player.set_loop(False)
-            self.next()
+        self.next()
 
     def _on_song_changed(self, song):
         self._app.task_mgr.run_afn_preemptive(self._fetch_current_song_mv, song)

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -595,9 +595,9 @@ class Playlist:
     def _on_media_finished(self):
         # Play next model when current media is finished.
         if self.playback_mode == PlaybackMode.one_loop:
-            with self._queue_lock:
-                return self.set_existing_song_as_current_song(self.current_song)
+            self._app.player.set_loop(True)
         else:
+            self._app.player.set_loop(False)
             self.next()
 
     def _on_song_changed(self, song):

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -450,9 +450,9 @@ class Playlist:
 
         self._playback_mode = playback_mode
         if playback_mode == PlaybackMode.one_loop:
-            self._app.player.set_loop(True)
+            self._app.player.setInfiniteLoop(True)
         else:
-            self._app.player.set_loop(False)
+            self._app.player.setInfiniteLoop(False)
         self.playback_mode_changed.emit(self.playback_mode)
 
     def _enter_shuffle_mode(self):

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -449,10 +449,7 @@ class Playlist:
             self._leave_shuffle_mode()
 
         self._playback_mode = playback_mode
-        if playback_mode == PlaybackMode.one_loop:
-            self._app.player.setInfiniteLoop(True)
-        else:
-            self._app.player.setInfiniteLoop(False)
+        self._app.player.set_infinite_loop(playback_mode is PlaybackMode.one_loop)
         self.playback_mode_changed.emit(self.playback_mode)
 
     def _enter_shuffle_mode(self):

--- a/tests/player/test_oneloop.py
+++ b/tests/player/test_oneloop.py
@@ -1,9 +1,0 @@
-from unittest.mock import MagicMock
-from feeluown.player.playlist import PlaybackMode, Playlist
-
-
-def test_oneloop():
-    app = MagicMock()
-    playlist = Playlist(app)
-    playlist.playback_mode = PlaybackMode.one_loop
-    app.player.set_loop.assert_called_with(True)

--- a/tests/player/test_oneloop.py
+++ b/tests/player/test_oneloop.py
@@ -1,0 +1,9 @@
+from unittest.mock import MagicMock
+from feeluown.player.playlist import PlaybackMode, Playlist
+
+
+def test_oneloop():
+    app = MagicMock()
+    playlist = Playlist(app)
+    playlist.playback_mode = PlaybackMode.one_loop
+    app.player.set_loop.assert_called_with(True)

--- a/tests/player/test_playlist.py
+++ b/tests/player/test_playlist.py
@@ -445,3 +445,14 @@ def test_playlist_next_song(pl):
     assert pl.next_song == pl.list()[0]
     pl.playback_mode = PlaybackMode.sequential
     assert pl.next_song is None
+
+
+def test_switch_to_one_loop(pl):
+    pl.playback_mode = PlaybackMode.one_loop
+    pl._app.player.set_loop.assert_called_with(True)
+
+
+def test_switch_from_one_loop(pl):
+    pl.playback_mode = PlaybackMode.one_loop
+    pl.playback_mode = PlaybackMode.loop
+    pl._app.player.set_loop.assert_called_with(False)

--- a/tests/player/test_playlist.py
+++ b/tests/player/test_playlist.py
@@ -449,10 +449,10 @@ def test_playlist_next_song(pl):
 
 def test_switch_to_one_loop(pl):
     pl.playback_mode = PlaybackMode.one_loop
-    pl._app.player.setInfiniteLoop.assert_called_with(True)
+    pl._app.player.set_infinite_loop.assert_called_with(True)
 
 
 def test_switch_from_one_loop(pl):
     pl.playback_mode = PlaybackMode.one_loop
     pl.playback_mode = PlaybackMode.loop
-    pl._app.player.setInfiniteLoop.assert_called_with(False)
+    pl._app.player.set_infinite_loop.assert_called_with(False)

--- a/tests/player/test_playlist.py
+++ b/tests/player/test_playlist.py
@@ -449,10 +449,10 @@ def test_playlist_next_song(pl):
 
 def test_switch_to_one_loop(pl):
     pl.playback_mode = PlaybackMode.one_loop
-    pl._app.player.set_loop.assert_called_with(True)
+    pl._app.player.setInfiniteLoop.assert_called_with(True)
 
 
 def test_switch_from_one_loop(pl):
     pl.playback_mode = PlaybackMode.one_loop
     pl.playback_mode = PlaybackMode.loop
-    pl._app.player.set_loop.assert_called_with(False)
+    pl._app.player.setInfiniteLoop.assert_called_with(False)


### PR DESCRIPTION
### Problem
As described in issue #855 

### Behaviour
When set playback mode to single song loop and the current song finishes, it fetches from the provider again.

### Expected Behaviour
This can be completely avoided by using mpv param `--loop=inf`. This will prevent FUO from fetching from providers again.

closes #855 