### PR TITLE
Improve settings dialog layout

### DIFF
--- a/feeluown/gui/ui.py
+++ b/feeluown/gui/ui.py
@@ -94,8 +94,12 @@ class Ui:
 
         self._app.resize(960, 600)
 
-    def _open_settings_dialog(self):
+    def create_settings_dialog(self):
         dialog = SettingsDialog(self._app, self._app)
+        return dialog
+
+    def _open_settings_dialog(self):
+        dialog = self.create_settings_dialog()
         dialog.exec()
 
     def toggle_player_bar(self):

--- a/feeluown/gui/uimain/toolbar.py
+++ b/feeluown/gui/uimain/toolbar.py
@@ -9,9 +9,7 @@ from feeluown.gui.widgets import (
     SearchSwitchButton,
     SettingsButton,
 )
-from feeluown.gui.components import NetworkStatusButton
 from feeluown.gui.widgets.magicbox import MagicBox
-from feeluown.gui.widgets.statusline import StatusLine, StatusLineItem
 from feeluown.i18n import t
 
 if TYPE_CHECKING:
@@ -44,11 +42,6 @@ class BottomPanel(QWidget):
         self._stacked_widget.addWidget(self.magicbox)
         self._stack_switch.hide()
 
-        self.status_line = StatusLine(self._app)
-        self.network_status_button = NetworkStatusButton(length=ButtonSize[0])
-        self.status_line.add_item(
-            StatusLineItem("network-status", self.network_status_button)
-        )
         self.settings_btn = SettingsButton(length=ButtonSize[0])
 
         # initialize widgets
@@ -73,7 +66,6 @@ class BottomPanel(QWidget):
         self._layout.addWidget(self._stacked_widget)
         self._layout.addWidget(self._stack_switch)
         self._layout.addSpacing(40)
-        self._layout.addWidget(self.status_line)
         self._layout.addWidget(self.settings_btn)
 
         # assume the magicbox height is about 30

--- a/feeluown/gui/widgets/settings.py
+++ b/feeluown/gui/widgets/settings.py
@@ -12,7 +12,7 @@ from PyQt6.QtWidgets import (
 from feeluown.i18n import t
 from feeluown.gui.widgets.magicbox import KeySourceIn
 from feeluown.gui.widgets.header import MidHeader
-from feeluown.gui.components import LyricButton, WatchButton
+from feeluown.gui.components import LyricButton, NetworkStatusButton, WatchButton
 
 
 class _ProviderCheckBox(QCheckBox):
@@ -73,6 +73,16 @@ class PlayerSettings(QWidget):
         self._layout.addStretch(0)
 
 
+class NetworkSettings(QWidget):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.network_status_button = NetworkStatusButton()
+        self._layout = QHBoxLayout(self)
+        self._layout.addWidget(self.network_status_button)
+        self._layout.addStretch(0)
+
+
 class AISettings(QWidget):
     def __init__(self, app, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -85,7 +95,7 @@ class AISettings(QWidget):
         self._layout.addWidget(self._prompt_editor)
         self._layout.addWidget(self._save_btn)
         self._prompt_editor.setPlainText(self._app.config.AI_RADIO_PROMPT)
-        self._prompt_editor.setMaximumHeight(200)
+        self._prompt_editor.setMaximumHeight(96)
 
         self._save_btn.clicked.connect(self.save_prompt)
 
@@ -116,6 +126,10 @@ class SettingsDialog(QDialog):
         self._layout.addWidget(toolbar)
         self._layout.addWidget(MidHeader(t("ai-radio-prompt")))
         self._layout.addWidget(AISettings(self._app))
+        self._layout.addWidget(MidHeader(t("network")))
+        network_settings = NetworkSettings()
+        self.network_status_button = network_settings.network_status_button
+        self._layout.addWidget(network_settings)
         self._layout.addWidget(MidHeader(t("player")))
         self._layout.addWidget(PlayerSettings(self._app))
         self._layout.addStretch(0)

--- a/feeluown/i18n/assets/en-US/app.ftl
+++ b/feeluown/i18n/assets/en-US/app.ftl
@@ -324,6 +324,7 @@ app-config = App Configuration
 save-config = Save
 search-providers = Search { -provider(capitalization: "uppercase") }s
 ai-radio-prompt = AI Radio (Prompt)
+network = Network
 player = Player
 # feeluown.gui.widgets.login
 # ----------------------------------------

--- a/feeluown/i18n/assets/ja-JP/app.ftl
+++ b/feeluown/i18n/assets/ja-JP/app.ftl
@@ -299,6 +299,7 @@ app-config = アプリ設定
 save-config = 保存
 search-providers = 検索ソース
 ai-radio-prompt = AI ラジオ（プロンプト）
+network = ネットワーク
 player = プレイヤー
 
 # feeluown.gui.widgets.login

--- a/feeluown/i18n/assets/zh-CN/app.ftl
+++ b/feeluown/i18n/assets/zh-CN/app.ftl
@@ -299,6 +299,7 @@ app-config = 应用配置
 save-config = 保存
 search-providers = 搜索来源
 ai-radio-prompt = AI 电台 (提示词)
+network = 网络
 player = 播放器
 
 # feeluown.gui.widgets.login

--- a/tests/app/test_gui_app.py
+++ b/tests/app/test_gui_app.py
@@ -15,7 +15,7 @@ def test_gui_app_initialize(qtbot, mocker, args, config, noharm):
     app.initialize()
 
 
-def test_gui_app_initialize_updates_network_status_button_tooltip(
+def test_gui_app_settings_dialog_network_status_button_detects_proxy(
     qtbot, mocker, args, config, noharm
 ):
     mocker.patch('feeluown.app.app.TaskManager')
@@ -30,6 +30,9 @@ def test_gui_app_initialize_updates_network_status_button_tooltip(
     mocker.patch.object(app, 'about_to_exit')
     app.initialize()
 
-    assert app.ui.bottom_panel.network_status_button.toolTip() == t(
+    dialog = app.ui.create_settings_dialog()
+    qtbot.addWidget(dialog)
+
+    assert dialog.network_status_button.toolTip() == t(
         "proxy-detected", proxyInfo="http=http://127.0.0.1:7890"
     ) + "\n\n" + t("proxy-click-to-refresh")

--- a/tests/gui/widgets/test_settings.py
+++ b/tests/gui/widgets/test_settings.py
@@ -1,0 +1,31 @@
+from feeluown.gui.components.network_status import NetworkStatusButton
+from feeluown.gui.widgets.settings import AISettings, SettingsDialog
+
+
+def test_settings_dialog_has_network_status_button(qtbot, app_mock):
+    app_mock.browser.local_storage.get.return_value = None
+    app_mock.library.list.return_value = []
+    app_mock.config.AI_RADIO_PROMPT = ""
+
+    dialog = SettingsDialog(app_mock)
+    qtbot.addWidget(dialog)
+
+    assert isinstance(dialog.network_status_button, NetworkStatusButton)
+
+
+def test_bottom_panel_does_not_show_network_status_button(qtbot, app_mock):
+    from feeluown.gui.uimain.toolbar import BottomPanel
+
+    panel = BottomPanel(app_mock)
+    qtbot.addWidget(panel)
+
+    assert not hasattr(panel, "network_status_button")
+
+
+def test_ai_settings_prompt_editor_is_compact(qtbot, app_mock):
+    app_mock.config.AI_RADIO_PROMPT = ""
+
+    settings = AISettings(app_mock)
+    qtbot.addWidget(settings)
+
+    assert settings._prompt_editor.maximumHeight() == 96


### PR DESCRIPTION
## Summary

- Move the network status button from the bottom toolbar into a Network section in settings.
- Keep proxy detection, sanitized tooltip text, and click-to-refresh behavior unchanged.
- Reduce the AI Radio prompt editor height so the settings dialog is more compact.

## Test Plan

- [x] `uv run make test`
