### PR TITLE
GUI: Cache scaled thumbnail pixmaps

### DIFF
--- a/feeluown/gui/drawers.py
+++ b/feeluown/gui/drawers.py
@@ -22,6 +22,7 @@ from feeluown.gui.helpers import (
     IS_MACOS,
     SOLARIZED_COLORS,
 )
+from feeluown.gui.thumbnail_cache import ThumbnailCache
 
 
 class SizedPixmapDrawer:
@@ -37,23 +38,21 @@ class SizedPixmapDrawer:
         self._img_old_width = rect.width()
         self._radius = radius
         self._device_pixel_ratio = QGuiApplication.instance().devicePixelRatio()
+        self._thumb_cache = ThumbnailCache()
 
-        if img is None:
+        if img is None or img.isNull():
             self._color = random_solarized_color()
             self._img = None
             self._pixmap = None
         else:
             self._img = img
             self._color = None
-            new_img = self._scale_image(img)
-            self._pixmap = QPixmap(new_img)
-            self._pixmap.setDevicePixelRatio(self._device_pixel_ratio)
-
-    def _scale_image(self, img: QImage) -> QImage:
-        return img.scaledToWidth(
-            int(self._img_old_width * self._device_pixel_ratio),
-            Qt.TransformationMode.SmoothTransformation,
-        )
+            self._pixmap = self._thumb_cache.pixmap_for_width(
+                img,
+                self._img_old_width,
+                self._device_pixel_ratio,
+                "drawer",
+            )
 
     def get_radius(self):
         return (
@@ -137,10 +136,12 @@ class PixmapDrawer(SizedPixmapDrawer):
         if self._widget.width() != self._img_old_width:
             self._img_old_width = self._widget.width()
             assert self._img is not None
-            new_img = self._img.scaledToWidth(
-                self._img_old_width, Qt.TransformationMode.SmoothTransformation
+            self._pixmap = self._thumb_cache.pixmap_for_width(
+                self._img,
+                self._img_old_width,
+                self._device_pixel_ratio,
+                "drawer",
             )
-            self._pixmap = QPixmap(new_img)
 
     def _draw_pixmap(self, painter: QPainter):
         self.maybe_update_pixmap()

--- a/feeluown/gui/drawers.py
+++ b/feeluown/gui/drawers.py
@@ -51,7 +51,6 @@ class SizedPixmapDrawer:
                 img,
                 self._img_old_width,
                 self._device_pixel_ratio,
-                "drawer",
             )
 
     def get_radius(self):
@@ -140,7 +139,6 @@ class PixmapDrawer(SizedPixmapDrawer):
                 self._img,
                 self._img_old_width,
                 self._device_pixel_ratio,
-                "drawer",
             )
 
     def _draw_pixmap(self, painter: QPainter):

--- a/feeluown/gui/drawers.py
+++ b/feeluown/gui/drawers.py
@@ -78,9 +78,9 @@ class SizedPixmapDrawer:
 
     def draw(self, painter: QPainter):
         with painter_save(painter):
-            if self._pixmap is None:
+            if self._pixmap is None and self._color is not None:
                 self._draw_random_color(painter)
-            else:
+            elif self._pixmap is not None:
                 self._draw_pixmap(painter)
 
     def _draw_random_color(self, painter: QPainter):

--- a/feeluown/gui/drawers.py
+++ b/feeluown/gui/drawers.py
@@ -22,7 +22,7 @@ from feeluown.gui.helpers import (
     IS_MACOS,
     SOLARIZED_COLORS,
 )
-from feeluown.gui.thumbnail_cache import ThumbnailCache
+from feeluown.gui.thumbnail_cache import ScaledPixmapCache
 
 
 class SizedPixmapDrawer:
@@ -38,7 +38,7 @@ class SizedPixmapDrawer:
         self._img_old_width = rect.width()
         self._radius = radius
         self._device_pixel_ratio = QGuiApplication.instance().devicePixelRatio()
-        self._thumb_cache = ThumbnailCache()
+        self._pixmap_cache = ScaledPixmapCache()
 
         if img is None or img.isNull():
             self._color = random_solarized_color()
@@ -47,7 +47,7 @@ class SizedPixmapDrawer:
         else:
             self._img = img
             self._color = None
-            self._pixmap = self._thumb_cache.pixmap_for_width(
+            self._pixmap = self._pixmap_cache.scaled_to_width(
                 img,
                 self._img_old_width,
                 self._device_pixel_ratio,
@@ -136,7 +136,7 @@ class PixmapDrawer(SizedPixmapDrawer):
         if self._widget.width() != self._img_old_width:
             self._img_old_width = self._widget.width()
             assert self._img is not None
-            self._pixmap = self._thumb_cache.pixmap_for_width(
+            self._pixmap = self._pixmap_cache.scaled_to_width(
                 self._img,
                 self._img_old_width,
                 self._device_pixel_ratio,

--- a/feeluown/gui/thumbnail_cache.py
+++ b/feeluown/gui/thumbnail_cache.py
@@ -2,7 +2,69 @@ from collections import OrderedDict
 from typing import Optional, Tuple
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QImage
+from PyQt6.QtGui import QImage, QPixmap, QPixmapCache
+
+
+class ThumbnailCache:
+    def __init__(self, cache_limit_kb: int = 128 * 1024) -> None:
+        if QPixmapCache.cacheLimit() < cache_limit_kb:
+            QPixmapCache.setCacheLimit(cache_limit_kb)
+
+    def pixmap_for_width(
+        self,
+        img: QImage,
+        width: int,
+        device_pixel_ratio: float,
+        key_prefix: str,
+    ) -> QPixmap | None:
+        if img.isNull() or width <= 0:
+            return None
+        cache_key = f"{key_prefix}:{img.cacheKey()}:{width}@{device_pixel_ratio}"
+        pixmap = QPixmapCache.find(cache_key)
+        if pixmap is not None and not pixmap.isNull():
+            return pixmap
+
+        scaled = img.scaledToWidth(
+            int(width * device_pixel_ratio),
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        pixmap = QPixmap.fromImage(scaled)
+        pixmap.setDevicePixelRatio(device_pixel_ratio)
+        QPixmapCache.insert(cache_key, pixmap)
+        return pixmap
+
+    def pixmap_for_image(
+        self,
+        img: QImage,
+        width: int,
+        height: int,
+        device_pixel_ratio: float,
+        key_prefix: str,
+    ) -> QPixmap | None:
+        if img.isNull() or width <= 0 or height <= 0:
+            return None
+        cache_key = (
+            f"{key_prefix}:{img.cacheKey()}:{width}x{height}@{device_pixel_ratio}"
+        )
+        pixmap = QPixmapCache.find(cache_key)
+        if pixmap is not None and not pixmap.isNull():
+            return pixmap
+
+        if img.width() / img.height() > width / height:
+            scaled = img.scaledToHeight(
+                int(height * device_pixel_ratio),
+                Qt.TransformationMode.SmoothTransformation,
+            )
+        else:
+            scaled = img.scaledToWidth(
+                int(width * device_pixel_ratio),
+                Qt.TransformationMode.SmoothTransformation,
+            )
+
+        pixmap = QPixmap.fromImage(scaled)
+        pixmap.setDevicePixelRatio(device_pixel_ratio)
+        QPixmapCache.insert(cache_key, pixmap)
+        return pixmap
 
 
 def scale_image(img: QImage, max_edge: int) -> QImage:

--- a/feeluown/gui/thumbnail_cache.py
+++ b/feeluown/gui/thumbnail_cache.py
@@ -15,11 +15,10 @@ class ScaledPixmapCache:
         img: QImage,
         width: int,
         device_pixel_ratio: float,
-        key_prefix: str,
     ) -> QPixmap | None:
         if img.isNull() or width <= 0:
             return None
-        cache_key = f"{key_prefix}:{img.cacheKey()}:{width}@{device_pixel_ratio}"
+        cache_key = f"scaled-width:{img.cacheKey()}:{width}@{device_pixel_ratio}"
         pixmap = QPixmapCache.find(cache_key)
         if pixmap is not None and not pixmap.isNull():
             return pixmap
@@ -39,12 +38,11 @@ class ScaledPixmapCache:
         width: int,
         height: int,
         device_pixel_ratio: float,
-        key_prefix: str,
     ) -> QPixmap | None:
         if img.isNull() or width <= 0 or height <= 0:
             return None
         cache_key = (
-            f"{key_prefix}:{img.cacheKey()}:{width}x{height}@{device_pixel_ratio}"
+            f"scaled-fill:{img.cacheKey()}:{width}x{height}@{device_pixel_ratio}"
         )
         pixmap = QPixmapCache.find(cache_key)
         if pixmap is not None and not pixmap.isNull():

--- a/feeluown/gui/thumbnail_cache.py
+++ b/feeluown/gui/thumbnail_cache.py
@@ -5,12 +5,12 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QImage, QPixmap, QPixmapCache
 
 
-class ThumbnailCache:
+class ScaledPixmapCache:
     def __init__(self, cache_limit_kb: int = 128 * 1024) -> None:
         if QPixmapCache.cacheLimit() < cache_limit_kb:
             QPixmapCache.setCacheLimit(cache_limit_kb)
 
-    def pixmap_for_width(
+    def scaled_to_width(
         self,
         img: QImage,
         width: int,
@@ -33,7 +33,7 @@ class ThumbnailCache:
         QPixmapCache.insert(cache_key, pixmap)
         return pixmap
 
-    def pixmap_for_image(
+    def scaled_to_fill(
         self,
         img: QImage,
         width: int,

--- a/feeluown/gui/uimain/page_view.py
+++ b/feeluown/gui/uimain/page_view.py
@@ -82,7 +82,6 @@ class RightPanel(QFrame):
         self._app = app
         self._pixmap = None
         self._pixmap_img = None
-        self._pixmap_dpr = 1.0
         self._pixmap_cache = ScaledPixmapCache()
 
         self._layout = QVBoxLayout(self)
@@ -166,10 +165,8 @@ class RightPanel(QFrame):
         self._pixmap = pixmap
         if pixmap is None:
             self._pixmap_img = None
-            self._pixmap_dpr = 1.0
         else:
             self._pixmap_img = pixmap.toImage()
-            self._pixmap_dpr = pixmap.devicePixelRatio()
         self._adjust_meta_widget_height()
         self.update()
 
@@ -300,7 +297,7 @@ class RightPanel(QFrame):
                 self._pixmap_img,
                 draw_width,
                 draw_height,
-                self._pixmap_dpr,
+                self._pixmap.devicePixelRatio(),
                 "page-bg",
             )
             if scaled_pixmap is None:
@@ -317,7 +314,7 @@ class RightPanel(QFrame):
                 self._pixmap_img,
                 draw_width,
                 draw_height,
-                self._pixmap_dpr,
+                self._pixmap.devicePixelRatio(),
                 "page-bg",
             )
             if scaled_pixmap is None:

--- a/feeluown/gui/uimain/page_view.py
+++ b/feeluown/gui/uimain/page_view.py
@@ -14,7 +14,7 @@ from feeluown.gui.helpers import BgTransparentMixin, BaseScrollAreaForNoScrollIt
 from feeluown.gui.uimain.toolbar import BottomPanel
 from feeluown.gui.page_containers.table import TableContainer
 from feeluown.gui.base_renderer import VFillableBg
-from feeluown.gui.thumbnail_cache import ThumbnailCache
+from feeluown.gui.thumbnail_cache import ScaledPixmapCache
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ class RightPanel(QFrame):
         self._pixmap = None
         self._pixmap_img = None
         self._pixmap_dpr = 1.0
-        self._thumb_cache = ThumbnailCache()
+        self._pixmap_cache = ScaledPixmapCache()
 
         self._layout = QVBoxLayout(self)
         self._stacked_layout = QStackedLayout()
@@ -296,7 +296,7 @@ class RightPanel(QFrame):
         # draw the center part of the pixmap on available rect
         painter.save()
         if pixmap_size.width() / draw_width * draw_height >= pixmap_size.height():
-            scaled_pixmap = self._thumb_cache.pixmap_for_image(
+            scaled_pixmap = self._pixmap_cache.scaled_to_fill(
                 self._pixmap_img,
                 draw_width,
                 draw_height,
@@ -313,7 +313,7 @@ class RightPanel(QFrame):
             painter.translate(-x, -scrolled)
             rect = QRect(0, 0, pixmap_size.width(), draw_height)
         else:
-            scaled_pixmap = self._thumb_cache.pixmap_for_image(
+            scaled_pixmap = self._pixmap_cache.scaled_to_fill(
                 self._pixmap_img,
                 draw_width,
                 draw_height,

--- a/feeluown/gui/uimain/page_view.py
+++ b/feeluown/gui/uimain/page_view.py
@@ -80,8 +80,7 @@ class RightPanel(QFrame):
         super().__init__(parent)
 
         self._app = app
-        self._pixmap = None
-        self._pixmap_img = None
+        self._background_img = None
         self._pixmap_cache = ScaledPixmapCache()
 
         self._layout = QVBoxLayout(self)
@@ -162,11 +161,7 @@ class RightPanel(QFrame):
             logger.warning("can't render this kind of collection")
 
     def show_background_image(self, pixmap):
-        self._pixmap = pixmap
-        if pixmap is None:
-            self._pixmap_img = None
-        else:
-            self._pixmap_img = pixmap.toImage()
+        self._background_img = None if pixmap is None else pixmap.toImage()
         self._adjust_meta_widget_height()
         self.update()
 
@@ -209,9 +204,11 @@ class RightPanel(QFrame):
             painter.restore()
             return
 
-        if self._pixmap is not None:
-            self._draw_pixmap(painter, draw_width, draw_height, scrolled)
-            self._draw_pixmap_overlay(painter, draw_width, draw_height, scrolled)
+        if self._background_img is not None:
+            self._draw_background_image(painter, draw_width, draw_height, scrolled)
+            self._draw_background_image_overlay(
+                painter, draw_width, draw_height, scrolled
+            )
             curve = QEasingCurve(QEasingCurve.Type.OutCubic)
             if max_scroll_height == 0:
                 alpha_ratio = 1.0
@@ -244,7 +241,9 @@ class RightPanel(QFrame):
             painter.restore()
         painter.end()
 
-    def _draw_pixmap_overlay(self, painter, draw_width, draw_height, scrolled):
+    def _draw_background_image_overlay(
+        self, painter, draw_width, draw_height, scrolled
+    ):
         painter.save()
         rect = QRect(0, 0, draw_width, draw_height)
         painter.translate(0, -scrolled)
@@ -283,46 +282,31 @@ class RightPanel(QFrame):
         painter.drawRect(rect)
         painter.restore()
 
-    def _draw_pixmap(self, painter, draw_width, draw_height, scrolled):
-        # scale pixmap
-        assert self._pixmap is not None
-        pixmap_size = self._pixmap.size()
-        if self._pixmap_img is None:
+    def _draw_background_image(self, painter, draw_width, draw_height, scrolled):
+        # Scale once per target size and reuse the resulting pixmap for painting.
+        img = self._background_img
+        assert img is not None
+        image_size = img.size()
+        scaled_pixmap = self._pixmap_cache.scaled_to_fill(
+            img,
+            draw_width,
+            draw_height,
+            img.devicePixelRatio(),
+            "page-bg",
+        )
+        if scaled_pixmap is None:
             return
+        pixmap_size = scaled_pixmap.size()
 
         # draw the center part of the pixmap on available rect
         painter.save()
-        if pixmap_size.width() / draw_width * draw_height >= pixmap_size.height():
-            scaled_pixmap = self._pixmap_cache.scaled_to_fill(
-                self._pixmap_img,
-                draw_width,
-                draw_height,
-                self._pixmap.devicePixelRatio(),
-                "page-bg",
-            )
-            if scaled_pixmap is None:
-                painter.restore()
-                return
-            brush = QBrush(scaled_pixmap)
-            painter.setBrush(brush)
-            pixmap_size = scaled_pixmap.size()
+        brush = QBrush(scaled_pixmap)
+        painter.setBrush(brush)
+        if image_size.width() / draw_width * draw_height >= image_size.height():
             x = (pixmap_size.width() - draw_width) // 2
             painter.translate(-x, -scrolled)
             rect = QRect(0, 0, pixmap_size.width(), draw_height)
         else:
-            scaled_pixmap = self._pixmap_cache.scaled_to_fill(
-                self._pixmap_img,
-                draw_width,
-                draw_height,
-                self._pixmap.devicePixelRatio(),
-                "page-bg",
-            )
-            if scaled_pixmap is None:
-                painter.restore()
-                return
-            pixmap_size = scaled_pixmap.size()
-            brush = QBrush(scaled_pixmap)
-            painter.setBrush(brush)
             # note: in practice, most of the time, we can't show the
             # whole artist pixmap, as a result, the artist head will be cut,
             # which causes bad visual effect. So we render the top-center part
@@ -339,13 +323,16 @@ class RightPanel(QFrame):
 
     def resizeEvent(self, e):
         super().resizeEvent(e)
-        if self._pixmap is not None and e.oldSize().width() != e.size().width():
+        if (
+            self._background_img is not None
+            and e.oldSize().width() != e.size().width()
+        ):
             self._adjust_meta_widget_height()
 
     def _adjust_meta_widget_height(self):
         # HACK: adjust height of table_container's meta_widget to
         # adapt to background image.
-        if self._pixmap is None:
+        if self._background_img is None:
             self.table_container.meta_widget.setMinimumHeight(0)
         else:
             height = (

--- a/feeluown/gui/uimain/page_view.py
+++ b/feeluown/gui/uimain/page_view.py
@@ -14,6 +14,7 @@ from feeluown.gui.helpers import BgTransparentMixin, BaseScrollAreaForNoScrollIt
 from feeluown.gui.uimain.toolbar import BottomPanel
 from feeluown.gui.page_containers.table import TableContainer
 from feeluown.gui.base_renderer import VFillableBg
+from feeluown.gui.thumbnail_cache import ThumbnailCache
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,9 @@ class RightPanel(QFrame):
 
         self._app = app
         self._pixmap = None
+        self._pixmap_img = None
+        self._pixmap_dpr = 1.0
+        self._thumb_cache = ThumbnailCache()
 
         self._layout = QVBoxLayout(self)
         self._stacked_layout = QStackedLayout()
@@ -160,6 +164,12 @@ class RightPanel(QFrame):
 
     def show_background_image(self, pixmap):
         self._pixmap = pixmap
+        if pixmap is None:
+            self._pixmap_img = None
+            self._pixmap_dpr = 1.0
+        else:
+            self._pixmap_img = pixmap.toImage()
+            self._pixmap_dpr = pixmap.devicePixelRatio()
         self._adjust_meta_widget_height()
         self.update()
 
@@ -280,13 +290,22 @@ class RightPanel(QFrame):
         # scale pixmap
         assert self._pixmap is not None
         pixmap_size = self._pixmap.size()
+        if self._pixmap_img is None:
+            return
 
         # draw the center part of the pixmap on available rect
         painter.save()
         if pixmap_size.width() / draw_width * draw_height >= pixmap_size.height():
-            scaled_pixmap = self._pixmap.scaledToHeight(
-                draw_height, mode=Qt.TransformationMode.SmoothTransformation
+            scaled_pixmap = self._thumb_cache.pixmap_for_image(
+                self._pixmap_img,
+                draw_width,
+                draw_height,
+                self._pixmap_dpr,
+                "page-bg",
             )
+            if scaled_pixmap is None:
+                painter.restore()
+                return
             brush = QBrush(scaled_pixmap)
             painter.setBrush(brush)
             pixmap_size = scaled_pixmap.size()
@@ -294,9 +313,16 @@ class RightPanel(QFrame):
             painter.translate(-x, -scrolled)
             rect = QRect(0, 0, pixmap_size.width(), draw_height)
         else:
-            scaled_pixmap = self._pixmap.scaledToWidth(
-                draw_width, mode=Qt.TransformationMode.SmoothTransformation
+            scaled_pixmap = self._thumb_cache.pixmap_for_image(
+                self._pixmap_img,
+                draw_width,
+                draw_height,
+                self._pixmap_dpr,
+                "page-bg",
             )
+            if scaled_pixmap is None:
+                painter.restore()
+                return
             pixmap_size = scaled_pixmap.size()
             brush = QBrush(scaled_pixmap)
             painter.setBrush(brush)

--- a/feeluown/gui/uimain/page_view.py
+++ b/feeluown/gui/uimain/page_view.py
@@ -292,7 +292,6 @@ class RightPanel(QFrame):
             draw_width,
             draw_height,
             img.devicePixelRatio(),
-            "page-bg",
         )
         if scaled_pixmap is None:
             return

--- a/feeluown/gui/widgets/img_card_list.py
+++ b/feeluown/gui/widgets/img_card_list.py
@@ -61,7 +61,7 @@ from feeluown.gui.helpers import (
     random_solarized_color,
 )
 from feeluown.gui.thumbnail_cache import (
-    ThumbnailCache,
+    ScaledPixmapCache,
     ThumbnailImageCache,
     scale_image,
 )
@@ -262,7 +262,7 @@ class ImgCardListDelegate(QAbstractItemDelegate):
         self.w_h_ratio = 1.0
 
         self._device_pixel_ratio = QGuiApplication.instance().devicePixelRatio()
-        self._thumb_cache = ThumbnailCache()
+        self._pixmap_cache = ScaledPixmapCache()
 
         self.card_min_width = card_min_width
         self.card_spacing = card_spacing
@@ -348,7 +348,7 @@ class ImgCardListDelegate(QAbstractItemDelegate):
                 # Fall back to a flat fill when the image is invalid or height is zero.
                 brush = QBrush(border_color)
             else:
-                pixmap = self._thumb_cache.pixmap_for_image(
+                pixmap = self._pixmap_cache.scaled_to_fill(
                     obj,
                     draw_width,
                     height,

--- a/feeluown/gui/widgets/img_card_list.py
+++ b/feeluown/gui/widgets/img_card_list.py
@@ -353,7 +353,6 @@ class ImgCardListDelegate(QAbstractItemDelegate):
                     draw_width,
                     height,
                     self._device_pixel_ratio,
-                    "img-card",
                 )
                 brush = QBrush(pixmap) if pixmap is not None else QBrush(border_color)
             painter.setBrush(brush)

--- a/feeluown/gui/widgets/img_card_list.py
+++ b/feeluown/gui/widgets/img_card_list.py
@@ -60,7 +60,11 @@ from feeluown.gui.helpers import (
     fetch_cover_wrapper,
     random_solarized_color,
 )
-from feeluown.gui.thumbnail_cache import ThumbnailImageCache, scale_image
+from feeluown.gui.thumbnail_cache import (
+    ThumbnailCache,
+    ThumbnailImageCache,
+    scale_image,
+)
 from feeluown.i18n import human_readable_number
 
 if TYPE_CHECKING:
@@ -258,6 +262,7 @@ class ImgCardListDelegate(QAbstractItemDelegate):
         self.w_h_ratio = 1.0
 
         self._device_pixel_ratio = QGuiApplication.instance().devicePixelRatio()
+        self._thumb_cache = ThumbnailCache()
 
         self.card_min_width = card_min_width
         self.card_spacing = card_spacing
@@ -343,18 +348,14 @@ class ImgCardListDelegate(QAbstractItemDelegate):
                 # Fall back to a flat fill when the image is invalid or height is zero.
                 brush = QBrush(border_color)
             else:
-                if img_w / img_h > draw_width / height:
-                    img = obj.scaledToHeight(
-                        int(height * self._device_pixel_ratio),
-                        Qt.TransformationMode.SmoothTransformation,
-                    )
-                else:
-                    img = obj.scaledToWidth(
-                        int(draw_width * self._device_pixel_ratio),
-                        Qt.TransformationMode.SmoothTransformation,
-                    )
-                img.setDevicePixelRatio(self._device_pixel_ratio)
-                brush = QBrush(img)
+                pixmap = self._thumb_cache.pixmap_for_image(
+                    obj,
+                    draw_width,
+                    height,
+                    self._device_pixel_ratio,
+                    "img-card",
+                )
+                brush = QBrush(pixmap) if pixmap is not None else QBrush(border_color)
             painter.setBrush(brush)
         border_radius = 3
         if self.as_circle:

--- a/feeluown/gui/widgets/song_minicard_list.py
+++ b/feeluown/gui/widgets/song_minicard_list.py
@@ -35,7 +35,7 @@ from feeluown.gui.helpers import (
     painter_save,
 )
 from feeluown.gui.thumbnail_cache import (
-    ThumbnailCache,
+    ScaledPixmapCache,
     ThumbnailImageCache,
     scale_image,
 )
@@ -182,7 +182,7 @@ class SongMiniCardListDelegate(QStyledItemDelegate):
         self.view.set_row_height(card_height + card_padding[1] + card_padding[3])
 
         self._device_pixel_ratio = QGuiApplication.instance().devicePixelRatio()
-        self._thumb_cache = ThumbnailCache()
+        self._pixmap_cache = ScaledPixmapCache()
 
     def item_sizehint(self) -> tuple:
         # HELP: listview needs about 20 spacing left on macOS
@@ -343,7 +343,7 @@ class SongMiniCardListDelegate(QStyledItemDelegate):
             if img.isNull() or width <= 0 or height <= 0:
                 brush = QBrush(border_color)
             else:
-                pixmap = self._thumb_cache.pixmap_for_image(
+                pixmap = self._pixmap_cache.scaled_to_fill(
                     img,
                     width,
                     height,

--- a/feeluown/gui/widgets/song_minicard_list.py
+++ b/feeluown/gui/widgets/song_minicard_list.py
@@ -34,7 +34,11 @@ from feeluown.gui.helpers import (
     fetch_cover_wrapper,
     painter_save,
 )
-from feeluown.gui.thumbnail_cache import ThumbnailImageCache, scale_image
+from feeluown.gui.thumbnail_cache import (
+    ThumbnailCache,
+    ThumbnailImageCache,
+    scale_image,
+)
 
 if TYPE_CHECKING:
     from feeluown.gui import GuiApp
@@ -178,6 +182,7 @@ class SongMiniCardListDelegate(QStyledItemDelegate):
         self.view.set_row_height(card_height + card_padding[1] + card_padding[3])
 
         self._device_pixel_ratio = QGuiApplication.instance().devicePixelRatio()
+        self._thumb_cache = ThumbnailCache()
 
     def item_sizehint(self) -> tuple:
         # HELP: listview needs about 20 spacing left on macOS
@@ -334,18 +339,18 @@ class SongMiniCardListDelegate(QStyledItemDelegate):
             brush = QBrush(color)
             painter.setBrush(brush)
         else:  # QImage
-            if decoration.height() < decoration.width():
-                pixmap = decoration.scaledToHeight(
-                    int(height * self._device_pixel_ratio),
-                    Qt.TransformationMode.SmoothTransformation,
-                )
+            img = decoration
+            if img.isNull() or width <= 0 or height <= 0:
+                brush = QBrush(border_color)
             else:
-                pixmap = decoration.scaledToWidth(
-                    int(width * self._device_pixel_ratio),
-                    Qt.TransformationMode.SmoothTransformation,
+                pixmap = self._thumb_cache.pixmap_for_image(
+                    img,
+                    width,
+                    height,
+                    self._device_pixel_ratio,
+                    "song-mini",
                 )
-            pixmap.setDevicePixelRatio(self._device_pixel_ratio)
-            brush = QBrush(pixmap)
+                brush = QBrush(pixmap) if pixmap is not None else QBrush(border_color)
             painter.setBrush(brush)
         cover_rect = QRect(0, 0, width, height)
         painter.drawRoundedRect(cover_rect, border_radius, border_radius)

--- a/feeluown/gui/widgets/song_minicard_list.py
+++ b/feeluown/gui/widgets/song_minicard_list.py
@@ -348,7 +348,6 @@ class SongMiniCardListDelegate(QStyledItemDelegate):
                     width,
                     height,
                     self._device_pixel_ratio,
-                    "song-mini",
                 )
                 brush = QBrush(pixmap) if pixmap is not None else QBrush(border_color)
             painter.setBrush(brush)

--- a/tests/gui/test_drawers.py
+++ b/tests/gui/test_drawers.py
@@ -1,0 +1,18 @@
+from PyQt6.QtCore import QRect
+from PyQt6.QtGui import QImage, QPainter
+
+from feeluown.gui.drawers import SizedPixmapDrawer
+
+
+def test_sized_pixmap_drawer_uses_placeholder_for_null_image(qapp):
+    drawer = SizedPixmapDrawer(QImage(), QRect(0, 0, 20, 20))
+    canvas = QImage(20, 20, QImage.Format.Format_ARGB32)
+    painter = QPainter(canvas)
+
+    try:
+        drawer.draw(painter)
+    finally:
+        painter.end()
+
+    assert drawer.get_img() is None
+    assert drawer.get_pixmap() is None

--- a/tests/gui/test_drawers.py
+++ b/tests/gui/test_drawers.py
@@ -1,5 +1,5 @@
 from PyQt6.QtCore import QRect
-from PyQt6.QtGui import QImage, QPainter
+from PyQt6.QtGui import QColor, QImage, QPainter
 
 from feeluown.gui.drawers import SizedPixmapDrawer
 
@@ -15,4 +15,20 @@ def test_sized_pixmap_drawer_uses_placeholder_for_null_image(qapp):
         painter.end()
 
     assert drawer.get_img() is None
+    assert drawer.get_pixmap() is None
+
+
+def test_sized_pixmap_drawer_skips_non_empty_image_with_empty_rect(qapp):
+    image = QImage(20, 20, QImage.Format.Format_ARGB32)
+    image.fill(QColor("red"))
+    drawer = SizedPixmapDrawer(image, QRect(0, 0, 0, 20))
+    canvas = QImage(20, 20, QImage.Format.Format_ARGB32)
+    painter = QPainter(canvas)
+
+    try:
+        drawer.draw(painter)
+    finally:
+        painter.end()
+
+    assert drawer.get_img() is image
     assert drawer.get_pixmap() is None

--- a/tests/gui/test_thumbnail_cache.py
+++ b/tests/gui/test_thumbnail_cache.py
@@ -1,6 +1,6 @@
-from PyQt6.QtGui import QImage
+from PyQt6.QtGui import QImage, QColor
 
-from feeluown.gui.thumbnail_cache import ThumbnailImageCache, scale_image
+from feeluown.gui.thumbnail_cache import ThumbnailCache, ThumbnailImageCache, scale_image
 
 
 def test_thumbnail_image_cache_evicts_least_recently_used_item_by_count():
@@ -52,3 +52,24 @@ def test_scale_image_limits_large_images_to_max_edge():
 
     assert scaled.width() == 5
     assert scaled.height() == 2
+
+
+def test_thumbnail_cache_reuses_pixmap_for_same_image_and_size(qapp):
+    image = QImage(20, 10, QImage.Format.Format_ARGB32)
+    image.fill(QColor("red"))
+    cache = ThumbnailCache()
+
+    pixmap = cache.pixmap_for_image(image, 8, 8, 1.0, "test-thumbnail-cache")
+    cached_pixmap = cache.pixmap_for_image(image, 8, 8, 1.0, "test-thumbnail-cache")
+
+    assert pixmap is not None
+    assert cached_pixmap is not None
+    assert pixmap.cacheKey() == cached_pixmap.cacheKey()
+
+
+def test_thumbnail_cache_returns_none_for_null_image(qapp):
+    cache = ThumbnailCache()
+
+    pixmap = cache.pixmap_for_width(QImage(), 8, 1.0, "test-null-image")
+
+    assert pixmap is None

--- a/tests/gui/test_thumbnail_cache.py
+++ b/tests/gui/test_thumbnail_cache.py
@@ -63,10 +63,8 @@ def test_scaled_pixmap_cache_reuses_pixmap_for_same_image_and_fill_size(qapp):
     image.fill(QColor("red"))
     cache = ScaledPixmapCache()
 
-    pixmap = cache.scaled_to_fill(image, 8, 8, 1.0, "test-scaled-pixmap-cache")
-    cached_pixmap = cache.scaled_to_fill(
-        image, 8, 8, 1.0, "test-scaled-pixmap-cache"
-    )
+    pixmap = cache.scaled_to_fill(image, 8, 8, 1.0)
+    cached_pixmap = cache.scaled_to_fill(image, 8, 8, 1.0)
 
     assert pixmap is not None
     assert cached_pixmap is not None
@@ -76,6 +74,6 @@ def test_scaled_pixmap_cache_reuses_pixmap_for_same_image_and_fill_size(qapp):
 def test_scaled_pixmap_cache_returns_none_for_null_image(qapp):
     cache = ScaledPixmapCache()
 
-    pixmap = cache.scaled_to_width(QImage(), 8, 1.0, "test-null-image")
+    pixmap = cache.scaled_to_width(QImage(), 8, 1.0)
 
     assert pixmap is None

--- a/tests/gui/test_thumbnail_cache.py
+++ b/tests/gui/test_thumbnail_cache.py
@@ -1,6 +1,10 @@
 from PyQt6.QtGui import QImage, QColor
 
-from feeluown.gui.thumbnail_cache import ThumbnailCache, ThumbnailImageCache, scale_image
+from feeluown.gui.thumbnail_cache import (
+    ScaledPixmapCache,
+    ThumbnailImageCache,
+    scale_image,
+)
 
 
 def test_thumbnail_image_cache_evicts_least_recently_used_item_by_count():
@@ -54,22 +58,24 @@ def test_scale_image_limits_large_images_to_max_edge():
     assert scaled.height() == 2
 
 
-def test_thumbnail_cache_reuses_pixmap_for_same_image_and_size(qapp):
+def test_scaled_pixmap_cache_reuses_pixmap_for_same_image_and_fill_size(qapp):
     image = QImage(20, 10, QImage.Format.Format_ARGB32)
     image.fill(QColor("red"))
-    cache = ThumbnailCache()
+    cache = ScaledPixmapCache()
 
-    pixmap = cache.pixmap_for_image(image, 8, 8, 1.0, "test-thumbnail-cache")
-    cached_pixmap = cache.pixmap_for_image(image, 8, 8, 1.0, "test-thumbnail-cache")
+    pixmap = cache.scaled_to_fill(image, 8, 8, 1.0, "test-scaled-pixmap-cache")
+    cached_pixmap = cache.scaled_to_fill(
+        image, 8, 8, 1.0, "test-scaled-pixmap-cache"
+    )
 
     assert pixmap is not None
     assert cached_pixmap is not None
     assert pixmap.cacheKey() == cached_pixmap.cacheKey()
 
 
-def test_thumbnail_cache_returns_none_for_null_image(qapp):
-    cache = ThumbnailCache()
+def test_scaled_pixmap_cache_returns_none_for_null_image(qapp):
+    cache = ScaledPixmapCache()
 
-    pixmap = cache.pixmap_for_width(QImage(), 8, 1.0, "test-null-image")
+    pixmap = cache.scaled_to_width(QImage(), 8, 1.0, "test-null-image")
 
     assert pixmap is None


### PR DESCRIPTION
## Summary
- Add a QPixmapCache-backed ScaledPixmapCache for scaled drawing results.
- Use it in drawers, right-panel background painting, and image-card delegates with `scaled_to_width` and `scaled_to_fill`.
- Add coverage for cache reuse, null-image drawer fallback, and empty target rect handling.

Stacked on #1042. Review this PR after #1042, or compare against the temporary base branch `codex/pr-1042-thumbnail-image-cache-base`.

## Test Plan
- `QT_QPA_PLATFORM=offscreen uv run --extra qt pytest tests/gui/test_thumbnail_cache.py tests/gui/test_drawers.py tests/gui/widgets/test_song_minicard_list.py tests/gui/pages/test_pages.py -q`
- `QT_QPA_PLATFORM=offscreen uv run --extra qt --group dev flake8 feeluown/gui/thumbnail_cache.py feeluown/gui/drawers.py feeluown/gui/uimain/page_view.py feeluown/gui/widgets/img_card_list.py feeluown/gui/widgets/song_minicard_list.py tests/gui/test_thumbnail_cache.py tests/gui/test_drawers.py tests/gui/widgets/test_song_minicard_list.py`
- `QT_QPA_PLATFORM=offscreen uv run --extra qt python -m py_compile feeluown/gui/thumbnail_cache.py feeluown/gui/drawers.py feeluown/gui/uimain/page_view.py feeluown/gui/widgets/img_card_list.py feeluown/gui/widgets/song_minicard_list.py`
- `git diff --check codex/pr-1042-thumbnail-image-cache`
