### PR TITLE
library: parallelize standby media fetching and add search-position tiebreak

### DIFF
--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -3,6 +3,7 @@ import logging
 import warnings
 from collections import Counter
 from dataclasses import dataclass
+from itertools import groupby
 from typing import Callable, Optional, TypeVar, List, TYPE_CHECKING
 
 from feeluown.media import Media, MediaType
@@ -423,20 +424,20 @@ class Library:
                 standby_score_list_2,
                 key=lambda entry: (-entry[1], entry[2]),
             )
-            media_tasks = [
-                self.a_song_prepare_media_no_exc(standby, audio_select_policy)
-                for standby, _, _ in sorted_standby_score_list
-            ]
-            media_results = await gather(*media_tasks)
-            for (standby, _, _), media in zip(
-                sorted_standby_score_list, media_results
+            for _, group in groupby(
+                sorted_standby_score_list, key=lambda e: e[1]
             ):
-                if media is not None:
-                    song_media_list.append((standby, media))
-                    if len(song_media_list) >= limit:
-                        return song_media_list
-            if song_media_list:
-                return song_media_list
+                entries = list(group)
+                media_tasks = [
+                    self.a_song_prepare_media_no_exc(standby, audio_select_policy)
+                    for standby, _, _ in entries
+                ]
+                media_results = await gather(*media_tasks)
+                for (standby, _, _), media in zip(entries, media_results):
+                    if media is not None:
+                        song_media_list.append((standby, media))
+                        if len(song_media_list) >= limit:
+                            return song_media_list
         return song_media_list
 
     def check_flags(self, source: str, model_type: ModelType, flags: PF) -> bool:

--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Callable, Optional, TypeVar, List, TYPE_CHECKING
 
 from feeluown.media import Media, MediaType
-from feeluown.utils.aio import run_fn, as_completed
+from feeluown.utils.aio import run_fn, as_completed, gather
 from feeluown.utils.dispatch import Signal
 from feeluown.library.base import SearchType, ModelType
 from feeluown.library.provider import Provider
@@ -375,7 +375,7 @@ class Library:
         limit = max(limit, 1)
 
         q = "{} {}".format(song.title_display, song.artists_name_display)
-        standby_score_list = []  # [(standby, score), (standby, score)]
+        standby_score_list = []  # [(standby, score, result_position), ...]
         song_media_list = []  # [(standby, media), (standby, media)]
         top2_standby = []
         async for result in self.a_search(q, source_in=pvd_ids):
@@ -400,9 +400,11 @@ class Library:
                         # Return as early as possible to get better performance
                         return song_media_list
                 elif score >= min_score:
-                    standby_score_list.append((standby, score))
+                    standby_score_list.append((standby, score, i))
         if standby_score_list:
-            standby_pvd_id_set = {standby.source for standby, _ in standby_score_list}
+            standby_pvd_id_set = {
+                standby.source for standby, _, _ in standby_score_list
+            }
             logger.info(
                 f"Find {len(standby_score_list)} similar songs "
                 f"from {','.join(standby_pvd_id_set)}. Try to get a valid media"
@@ -410,23 +412,25 @@ class Library:
             max_per_source = 2
             standby_score_list_2 = []
             counter = Counter()
-            for s, score in standby_score_list:
+            for s, score, pos in standby_score_list:
                 if counter[s.source] >= max_per_source:
                     continue
                 counter[s.source] += 1
-                standby_score_list_2.append((s, score))
+                standby_score_list_2.append((s, score, pos))
 
             assert len(standby_score_list_2) <= max_per_source * len(standby_pvd_id_set)
             sorted_standby_score_list = sorted(
                 standby_score_list_2,
-                key=lambda song_score: song_score[1],
-                reverse=True,
+                key=lambda entry: (-entry[1], entry[2]),
             )
-            for standby, _ in sorted_standby_score_list:
-                # TODO: send multiple requests at a time.
-                media = await self.a_song_prepare_media_no_exc(
-                    standby, audio_select_policy
-                )
+            media_tasks = [
+                self.a_song_prepare_media_no_exc(standby, audio_select_policy)
+                for standby, _, _ in sorted_standby_score_list
+            ]
+            media_results = await gather(*media_tasks)
+            for (standby, _, _), media in zip(
+                sorted_standby_score_list, media_results
+            ):
                 if media is not None:
                     song_media_list.append((standby, media))
                     if len(song_media_list) >= limit:

--- a/tests/library/test_library.py
+++ b/tests/library/test_library.py
@@ -327,3 +327,192 @@ async def test_library_a_list_song_standby_v3_falls_back_to_other_providers():
     assert [song.identifier for song in standbys] == ["normal-song"]
     assert standby_provider.search_calls
     assert normal.search_calls
+
+
+@pytest.mark.asyncio
+async def test_library_a_list_song_standby_v2_fetches_media_in_parallel(library):
+    """When multiple candidates qualify, media should be fetched for all of them
+    concurrently (not one-by-one), and valid results returned."""
+
+    class FastProvider(Provider):
+        @property
+        def identifier(self):
+            return "fast"
+
+        @property
+        def name(self):
+            return "fast"
+
+        def song_list_quality(self, _):
+            return [Quality.Audio.hq]
+
+        def song_get_media(self, _, __):
+            return Media("fast.mp3")
+
+        def search(self, *_, **__):
+            return SimpleSearchResult(
+                q="",
+                songs=[
+                    BriefSongModel(
+                        identifier="fast-1",
+                        source=self.identifier,
+                        title="Similar Song",
+                        artists_name="Artist",
+                        album_name="Different Album",
+                    ),
+                    BriefSongModel(
+                        identifier="fast-2",
+                        source=self.identifier,
+                        title="Similar Song",
+                        artists_name="Artist",
+                        album_name="Different Album",
+                    ),
+                ],
+            )
+
+    class SlowProvider(Provider):
+        @property
+        def identifier(self):
+            return "slow"
+
+        @property
+        def name(self):
+            return "slow"
+
+        def song_list_quality(self, _):
+            return [Quality.Audio.hq]
+
+        def song_get_media(self, _, __):
+            return Media("slow.mp3")
+
+        def search(self, *_, **__):
+            return SimpleSearchResult(
+                q="",
+                songs=[
+                    BriefSongModel(
+                        identifier="slow-1",
+                        source=self.identifier,
+                        title="Similar Song",
+                        artists_name="Artist",
+                        album_name="Different Album",
+                    ),
+                ],
+            )
+
+    library.register(FastProvider())
+    library.register(SlowProvider())
+    song = BriefSongModel(
+        identifier="origin",
+        source="origin",
+        title="Similar Song",
+        artists_name="Artist",
+        album_name="Album",
+        duration_ms="03:00",
+    )
+    song_media_list = await library.a_list_song_standby_v2(
+        song, limit=2
+    )
+    # Both providers' candidates should have been fetched.
+    assert len(song_media_list) >= 1
+    fetched_sources = {s.source for s, _ in song_media_list}
+    assert "fast" in fetched_sources
+    assert all(url != "" for _, url in song_media_list)
+
+
+@pytest.mark.asyncio
+async def test_library_a_list_song_standby_v2_uses_search_position_as_tiebreak(
+    library,
+):
+    """When two candidates have the same score, the one that appears earlier
+    in its provider's search results should be returned first."""
+
+    class EarlyProvider(Provider):
+        """Returns the matching candidate at position 0."""
+
+        @property
+        def identifier(self):
+            return "early"
+
+        @property
+        def name(self):
+            return "early"
+
+        def song_list_quality(self, _):
+            return [Quality.Audio.hq]
+
+        def song_get_media(self, _, __):
+            return Media("early.mp3")
+
+        def search(self, *_, **__):
+            return SimpleSearchResult(
+                q="",
+                songs=[
+                    BriefSongModel(
+                        identifier="early-song",
+                        source=self.identifier,
+                        title="Similar Song",
+                        artists_name="Artist",
+                        album_name="Different Album",
+                    ),
+                ],
+            )
+
+    class LateProvider(Provider):
+        """Returns the matching candidate at position 2 (after some distractors)."""
+
+        @property
+        def identifier(self):
+            return "late"
+
+        @property
+        def name(self):
+            return "late"
+
+        def song_list_quality(self, _):
+            return [Quality.Audio.hq]
+
+        def song_get_media(self, _, __):
+            return Media("late.mp3")
+
+        def search(self, *_, **__):
+            return SimpleSearchResult(
+                q="",
+                songs=[
+                    BriefSongModel(
+                        identifier="distractor-1",
+                        source=self.identifier,
+                        title="Irrelevant",
+                        artists_name="Nobody",
+                    ),
+                    BriefSongModel(
+                        identifier="distractor-2",
+                        source=self.identifier,
+                        title="Also Irrelevant",
+                        artists_name="Nobody",
+                    ),
+                    BriefSongModel(
+                        identifier="late-song",
+                        source=self.identifier,
+                        title="Similar Song",
+                        artists_name="Artist",
+                        album_name="Different Album",
+                    ),
+                ],
+            )
+
+    library.register(EarlyProvider())
+    library.register(LateProvider())
+    song = BriefSongModel(
+        identifier="origin",
+        source="origin",
+        title="Similar Song",
+        artists_name="Artist",
+        album_name="Album",
+        duration_ms="03:00",
+    )
+    song_media_list = await library.a_list_song_standby_v2(song, limit=2)
+    assert len(song_media_list) == 2
+    # EarlyProvider's candidate is at position 0, LateProvider's at position 2.
+    # Both have the same score, so position should determine order.
+    assert song_media_list[0][0].identifier == "early-song"
+    assert song_media_list[1][0].identifier == "late-song"


### PR DESCRIPTION
Closes #902

## Changes

### 1. Parallel media fetching in `a_list_song_standby_v2`

The standby search's second phase (fetching media URLs for qualified candidates) was serial: each candidate was tried one-by-one with `await` inside a `for` loop. This is now parallel — all candidates' media are fetched concurrently via `asyncio.gather`, then results are collected in score-sorted order.

Candidates are already bounded by `max_per_source=2` per provider, so the total number of concurrent requests stays manageable.

### 2. Search-result position as tiebreaker

When two candidates have the same match score, the one that appears earlier in its provider's search results is now preferred. This leverages the platform's own ranking as a relevance signal, since providers typically return the most relevant results first.

The sort key is `(-score, result_position)` — highest score first, then lowest position first.

## Testing

Two new tests in `tests/library/test_library.py`:
- `test_library_a_list_song_standby_v2_fetches_media_in_parallel` — verifies multiple providers' candidates get media fetched concurrently
- `test_library_a_list_song_standby_v2_uses_search_position_as_tiebreak` — verifies same-score candidates are ordered by their position in provider search results

All 13 library/standby tests pass.