### PR TITLE
AI: Add AI assistant UI and AI radio function

### DIFF
--- a/examples/macos_native_titlebar.py
+++ b/examples/macos_native_titlebar.py
@@ -1,0 +1,99 @@
+"""macOS PyQt6: native traffic-light buttons, hidden titlebar.
+
+Run: uv run --extra qt python examples/macos_native_titlebar.py
+"""
+
+import ctypes
+import sys
+from ctypes import c_bool, c_char_p, c_long, c_ulong, c_void_p
+
+from PyQt6.QtCore import QTimer, Qt
+from PyQt6.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+objc = ctypes.cdll.LoadLibrary("/usr/lib/libobjc.A.dylib")
+objc.sel_registerName.restype = c_void_p
+objc.sel_registerName.argtypes = [c_char_p]
+
+
+def sel(name):
+    return objc.sel_registerName(name.encode())
+
+
+def msg(receiver, selector, restype=c_void_p, argtypes=(), *args):
+    send = objc.objc_msgSend
+    send.restype = restype
+    send.argtypes = [c_void_p, c_void_p, *argtypes]
+    return send(receiver, sel(selector), *args)
+
+
+def expand_client_area(widget):
+    for name in ("ExpandedClientAreaHint", "NoTitleBarBackgroundHint"):
+        flag = getattr(Qt.WindowType, name, None)
+        if flag is not None:
+            widget.setWindowFlag(flag, True)
+    attr = getattr(Qt.WidgetAttribute, "WA_ContentsMarginsRespectsSafeArea", None)
+    if attr is not None:
+        widget.setAttribute(attr, False)
+
+
+def make_titlebar_transparent(widget):
+    ns_window = msg(c_void_p(int(widget.winId())), "window")
+    style = msg(ns_window, "styleMask", c_ulong)
+    style |= (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 15)
+    msg(ns_window, "setStyleMask:", None, (c_ulong,), style)
+    msg(ns_window, "setTitleVisibility:", None, (c_long,), 1)
+    msg(ns_window, "setTitlebarAppearsTransparent:", None, (c_bool,), True)
+    msg(ns_window, "setMovableByWindowBackground:", None, (c_bool,), True)
+
+
+class Toolbar(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setFixedHeight(38)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(86, 0, 12, 0)
+        layout.setSpacing(8)
+        layout.addWidget(QLabel("Toolbar at y=0"), 0, Qt.AlignmentFlag.AlignTop)
+        layout.addStretch()
+        for text in ("Back", "Forward", "Search"):
+            button = QPushButton(text)
+            button.setFixedHeight(28)
+            layout.addWidget(button, 0, Qt.AlignmentFlag.AlignTop)
+
+    def mousePressEvent(self, event):
+        window = self.window().windowHandle()
+        if event.button() == Qt.MouseButton.LeftButton and window is not None:
+            if window.startSystemMove():
+                event.accept()
+                return
+        super().mousePressEvent(event)
+
+
+def main():
+    if sys.platform != "darwin":
+        print("This demo is macOS-only.")
+        return 1
+
+    app = QApplication(sys.argv)
+    window = QWidget()
+    expand_client_area(window)
+    window.setWindowTitle("Hidden titlebar")
+    window.resize(720, 420)
+
+    layout = QVBoxLayout(window)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(0)
+    layout.addWidget(Toolbar())
+
+    body = QLabel("Native buttons are kept; the titlebar is not visible.")
+    body.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    layout.addWidget(body, 1)
+
+    window.show()
+    QTimer.singleShot(0, lambda: make_titlebar_transparent(window))
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/feeluown/ai/__init__.py
+++ b/feeluown/ai/__init__.py
@@ -1,4 +1,7 @@
 # flake8: noqa
 
-from .copilot import AISongModel, Copilot, AISongMatcher
+from .models import SongSuggestion
+from .copilot import Copilot
+from .matcher import SongSuggestionMatcher
 from .ai import AI
+from .radio import AIRadioSession

--- a/feeluown/ai/ai.py
+++ b/feeluown/ai/ai.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 from feeluown.app import App
 from feeluown.ai.copilot import Copilot
-
+from feeluown.ai.radio import AIRadioSession
 
 # FIXME: Other packages should only import things from feeluown.ai
 #  They should not import things from feeluown.ai.copilot or other inner moduels.
@@ -10,6 +12,32 @@ class AI:
     def __init__(self, app: App):
         self._app = app
         self._copilot = Copilot(self._app)
+        self.radio = None
 
     def get_copilot(self):
         return self._copilot
+
+    def get_active_radio(self) -> Optional["AIRadioSession"]:
+        if self.radio is not None and self.radio.is_active:
+            return self.radio
+        return None
+
+    def activate_radio(self, reset=True) -> AIRadioSession:
+        """Activate AI Radio and return the active session."""
+        active_radio = self.get_active_radio()
+        if active_radio is not None:
+            return active_radio
+
+        radio = AIRadioSession(self._app)
+        radio.activate(reset=reset)
+        return radio
+
+    def deactivate_radio(self) -> bool:
+        """Deactivate AI Radio. Return True when a session was active."""
+        radio = self.radio
+        if radio is None:
+            return False
+
+        was_active = radio.is_active
+        radio.deactivate()
+        return was_active

--- a/feeluown/ai/copilot.py
+++ b/feeluown/ai/copilot.py
@@ -1,8 +1,6 @@
-import datetime
 from typing import List
 from dataclasses import dataclass
 
-from langchain.chat_models import init_chat_model
 from langchain.agents import create_agent
 from langchain.tools import tool, ToolRuntime
 from langgraph.checkpoint.memory import InMemorySaver
@@ -10,46 +8,50 @@ from langchain_core.messages import BaseMessage
 from langchain_core.callbacks import BaseCallbackHandler
 
 from feeluown.app import App
-from feeluown.library import (
-    BriefSongModel,
-    ModelState,
-    get_standby_score,
-    STANDBY_FULL_SCORE,
-    STANDBY_DEFAULT_MIN_SCORE,
-)
-from feeluown.ai.prompt import generate_prompt_for_library
+from feeluown.ai.llm import create_chat_model_with_config
+from feeluown.ai.matcher import SongSuggestionMatcher
+from feeluown.ai.models import SongSuggestion
+from feeluown.ai.playback import playback_tools
+from feeluown.ai.radio import ai_radio_tools
+from feeluown.library import BriefSongModel
 from feeluown.utils.dispatch import Signal
 
 
 @dataclass
-class AISongModel:
-    """A song recommended by the AI.
+class CopilotArtifact:
+    """A structured UI artifact produced by AI tools."""
 
-    :param description: Recommendation reason or song description.
-    """
-
+    identifier: int
+    type: str
     title: str
-    artists_name: str
-    description: str
+    songs: List[SongSuggestion]
 
-    def to_brief_song(self) -> BriefSongModel:
-        return BriefSongModel(
-            state=ModelState.not_exists,
-            source="ai",
-            identifier="not-exists",
-            title=self.title,
-            artists_name=self.artists_name,
+
+class ArtifactsManager:
+    def __init__(self):
+        self._artifacts: List[CopilotArtifact] = []
+        self._next_artifact_id = 1
+        self.added = Signal()
+
+    def add_songs(
+        self, songs: List[SongSuggestion], title: str = ""
+    ) -> CopilotArtifact:
+        artifact = CopilotArtifact(
+            identifier=self._next_artifact_id,
+            type="songs",
+            title=title or "Songs",
+            songs=songs,
         )
+        self._next_artifact_id += 1
+        self._artifacts.append(artifact)
+        self.added.emit(artifact)
+        return artifact
 
+    def list(self) -> List[CopilotArtifact]:
+        return list(self._artifacts)
 
-def create_chat_model_with_config(config):
-    return init_chat_model(
-        config.OPENAI_MODEL,
-        api_key=config.OPENAI_API_KEY,
-        base_url=config.OPENAI_API_BASEURL,
-        temperature=0,
-        model_provider="openai",  # OpenAI compatible API
-    )
+    def clear(self):
+        self._artifacts.clear()
 
 
 @dataclass
@@ -59,72 +61,76 @@ class CopilotContext:
 
 
 @tool
-def add_songs_to_playlist_candidates(
-    songs: List[AISongModel], runtime: ToolRuntime
-) -> bool:
-    """Add songs to playlist candidates.
+def play_song_suggestion(song: SongSuggestion, runtime: ToolRuntime):
+    """Play a song suggestion.
 
-    :param songs: A list of AISongModel.
-    """
-    runtime.context.copilot.set_candidates(songs)
-
-
-@tool
-def play_song(song: AISongModel, runtime: ToolRuntime):
-    """Play a song.
-
-    :param song: A AISongModel.
+    :param song: A SongSuggestion.
     """
     runtime.context.app.playlist.play_model(song.to_brief_song())
 
 
-tools = [add_songs_to_playlist_candidates, play_song]
+@tool
+def create_song_suggestions_artifact(
+    songs: List[SongSuggestion],
+    runtime: ToolRuntime,
+    title: str = "",
+) -> bool:
+    """Create an interactive artifact for song suggestions.
+
+    Use this when you recommend multiple songs and want the user to inspect them
+    in the AI assistant UI.
+
+    :param songs: A list of SongSuggestion.
+    :param title: Optional artifact title.
+    """
+    runtime.context.copilot.add_songs_artifact(songs, title=title)
+    return True
+
+
+tools = [
+    play_song_suggestion,
+    create_song_suggestions_artifact,
+    *playback_tools,
+    *ai_radio_tools,
+]
+
+
+_AGENT_SYSTEM_PROMPT = (
+    "你是一个音乐播放器 AI 助手。"
+    "当你向用户推荐或整理一组歌曲时，优先调用 create_song_suggestions_artifact "
+    "工具创建可交互歌曲建议列表。"
+    "上一首、下一首、暂停、继续、停止、音量调整等基础播放控制，"
+    "应通过 playback_ 开头的工具完成。"
+    "AI 电台开关、状态和偏好应优先通过 ai_radio_ 开头的工具完成，"
+    "不要要求用户去其它界面操作。"
+    "当用户要求开启、启动、进入 AI 电台时，调用 ai_radio_activate。"
+    "当用户要求关闭、停止、退出 AI 电台时，调用 ai_radio_deactivate。"
+    "当用户想查看或修改 FM 候选列表时，先调用 ai_radio_get_state。"
+    "FM 候选歌曲指播放列表中当前播放歌曲后面的真实歌曲，"
+    "不是 SongSuggestion，也不是正文中的 fuo://song-suggestion 链接。"
+    "候选列表操作必须通过 fm_candidates_ 开头的工具完成。"
+    "AI 电台和候选列表的命令型工具只返回是否成功；"
+    "如果需要查看操作后的候选列表，继续调用 ai_radio_get_state。"
+    "如果用户在 AI 电台未开启时提出使用或修改候选列表，先调用 ai_radio_activate，"
+    "再根据用户需求继续操作；如果用户只是询问状态，请说明当前未开启。"
+    "当用户反馈会影响后续 AI 电台推荐偏好时，调用 ai_radio_update_preferences。"
+    "如果你在回复正文里展示尚未匹配成真实资源的 AI 歌曲建议，使用 Markdown 链接："
+    "[歌名](fuo://song-suggestion?title=歌名&artists=歌手)。"
+    "如果你展示的是已经存在于音乐库或工具返回结果中的真实歌曲资源，"
+    "使用它的真实 URI，例如 [歌名](fuo://netease/songs/12345)。"
+    "不要把未确认的 AI 歌曲建议伪装成真实 provider URI。"
+)
 
 
 def create_agent_with_config(config):
     model = create_chat_model_with_config(config)
     return create_agent(
         model=model,
-        system_prompt="你是一个音乐播放器 AI 助手。",
+        system_prompt=_AGENT_SYSTEM_PROMPT,
         tools=tools,
         context_schema=CopilotContext,
         checkpointer=InMemorySaver(),
     )
-
-
-def create_recommendation_agent_with_config(config):
-    model = create_chat_model_with_config(config)
-    return create_agent(
-        model=model,
-        system_prompt="你是一个音乐播放器 AI 助手。",
-        tools=[add_songs_to_playlist_candidates],
-        context_schema=CopilotContext,
-    )
-
-
-class AISongMatcher:
-    def __init__(self, app: App):
-        self._app = app
-
-    async def match(self, ai_song: AISongModel) -> BriefSongModel:
-        """Math a song by title and artists name.
-
-        This API is in alpha stage.
-        """
-        origin = ai_song.to_brief_song()
-        title, artists_name = ai_song.title, ai_song.artists_name
-        candidates = []
-        async for result in self._app.library.a_search(f"{title} {artists_name}"):
-            if result is None:
-                continue
-            for standby in result.songs:
-                score = get_standby_score(origin, standby)
-                if score == STANDBY_FULL_SCORE:
-                    return standby
-                elif score >= STANDBY_DEFAULT_MIN_SCORE:
-                    candidates.append((score, standby))
-        sorted_candidates = sorted(candidates, key=lambda x: x[0], reverse=True)
-        return sorted_candidates[0][1] if sorted_candidates else None
 
 
 class AgentStreamCallback(BaseCallbackHandler):
@@ -148,8 +154,8 @@ class Copilot:
         self._agent = create_agent_with_config(self._app.config)
         self._agent_context = CopilotContext(copilot=self, app=app)
         self._agent_stream_callback = AgentStreamCallback(self)
-        self._candidates: List[AISongModel] = []
-        self.candidates_changed = Signal()
+        self._artifacts = ArtifactsManager()
+        self.artifact_added = self._artifacts.added
         self._current_thread_id = 1
         # Agent is working or not
         # When the agent is streaming messages, it is working.
@@ -168,30 +174,13 @@ class Copilot:
 
     def new_thread(self):
         self._current_thread_id += 1
+        self._artifacts.clear()
 
-    async def recommend_a_song(self) -> List[AISongModel]:
-        """Create an adhoc agent to recommend a song.
-
-        :return: A list of AISongModel.
-        """
-        agent = create_recommendation_agent_with_config(self._app.config)
-        input = {
-            "messages": [
-                {"role": "system", "content": await generate_prompt(self._app)},
-                {
-                    "role": "system",
-                    "content": (
-                        "根据用户的音乐库收藏，分析用户的喜好，并且综合当前日期/时间等信息，"
-                        "推荐1首合适的歌给用户，并将歌曲加入到播放列表候选中。"
-                    ),
-                },
-            ]
-        }
-        await agent.ainvoke(
-            input,
-            context=self._agent_context,
-        )
-        return self._candidates
+    async def match_song_suggestion(
+        self, suggestion: SongSuggestion
+    ) -> BriefSongModel | None:
+        matcher = SongSuggestionMatcher(self._app)
+        return await matcher.match(suggestion)
 
     async def astream_user_query(self, query: str):
         async for v in self._agent.astream(
@@ -202,9 +191,13 @@ class Copilot:
         ):
             yield v
 
-    def set_candidates(self, ai_songs: List[AISongModel]):
-        self._candidates = ai_songs
-        self.candidates_changed.emit(ai_songs)
+    def add_songs_artifact(
+        self, songs: List[SongSuggestion], title: str = ""
+    ) -> CopilotArtifact:
+        return self._artifacts.add_songs(songs, title=title)
+
+    def get_artifacts(self) -> List[CopilotArtifact]:
+        return self._artifacts.list()
 
     def get_config(self):
         return {
@@ -214,31 +207,3 @@ class Copilot:
 
     def get_current_thread_history_messages(self) -> List[BaseMessage]:
         return self._agent.get_state(self.get_config()).values["messages"]
-
-
-async def generate_prompt(app: App):
-    """
-    1. Today's date and current time.
-    2. User's music library, including songs, albums, artists, playlists.
-    """
-    time_prompt = (
-        f"当前时间是 {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}。"
-    )
-    library_prompt = await generate_prompt_for_library(app.coll_mgr.get_coll_library())
-    return f"{time_prompt}\n\n{library_prompt}"
-
-
-if __name__ == "__main__":
-    import os
-    import asyncio
-
-    from feeluown.debug import mock_app
-
-    with mock_app() as app:
-        app.config.OPENAI_API_KEY = os.environ.get("DEEPSEEK_API_KEY", "")
-        app.config.OPENAI_API_BASEURL = "https://api.deepseek.com"
-        app.config.OPENAI_MODEL = "deepseek-chat"
-
-        copilot = Copilot(app)
-        songs = asyncio.run(copilot.recommend_a_song())
-        state = copilot._agent.get_state(copilot.get_config())

--- a/feeluown/ai/llm.py
+++ b/feeluown/ai/llm.py
@@ -1,0 +1,11 @@
+from langchain.chat_models import init_chat_model
+
+
+def create_chat_model_with_config(config):
+    return init_chat_model(
+        config.OPENAI_MODEL,
+        api_key=config.OPENAI_API_KEY,
+        base_url=config.OPENAI_API_BASEURL,
+        temperature=0,
+        model_provider="openai",  # OpenAI compatible API
+    )

--- a/feeluown/ai/matcher.py
+++ b/feeluown/ai/matcher.py
@@ -1,0 +1,32 @@
+from feeluown.app import App
+from feeluown.library import (
+    BriefSongModel,
+    get_standby_score,
+    STANDBY_FULL_SCORE,
+    STANDBY_DEFAULT_MIN_SCORE,
+)
+
+
+class SongSuggestionMatcher:
+    def __init__(self, app: App):
+        self._app = app
+
+    async def match(self, suggestion) -> BriefSongModel | None:
+        """Match a suggested song by title and artists name.
+
+        This API is in alpha stage.
+        """
+        origin = suggestion.to_brief_song()
+        title, artists_name = suggestion.title, suggestion.artists_name
+        candidates = []
+        async for result in self._app.library.a_search(f"{title} {artists_name}"):
+            if result is None:
+                continue
+            for standby in result.songs:
+                score = get_standby_score(origin, standby)
+                if score == STANDBY_FULL_SCORE:
+                    return standby
+                elif score >= STANDBY_DEFAULT_MIN_SCORE:
+                    candidates.append((score, standby))
+        sorted_candidates = sorted(candidates, key=lambda x: x[0], reverse=True)
+        return sorted_candidates[0][1] if sorted_candidates else None

--- a/feeluown/ai/models.py
+++ b/feeluown/ai/models.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from feeluown.library import BriefSongModel, ModelState
+
+
+@dataclass
+class SongSuggestion:
+    """A song suggested by the AI before it is matched to a provider song.
+
+    :param description: Recommendation reason or song description.
+    """
+
+    title: str
+    artists_name: str
+    description: str
+
+    def to_brief_song(self) -> BriefSongModel:
+        return BriefSongModel(
+            state=ModelState.not_exists,
+            source="ai",
+            identifier="not-exists",
+            title=self.title,
+            artists_name=self.artists_name,
+        )

--- a/feeluown/ai/playback.py
+++ b/feeluown/ai/playback.py
@@ -1,0 +1,128 @@
+from langchain.tools import tool, ToolRuntime
+
+from feeluown.library import BriefSongModel
+from feeluown.serializers import serialize
+
+
+def _clamp_volume(volume: int) -> int:
+    return max(0, min(100, int(volume)))
+
+
+def _song_to_ai_dict(song: BriefSongModel | None):
+    if song is None:
+        return None
+    data = serialize("python", song)
+    data["source"] = data.pop("provider", data.get("source"))
+    data.pop("__type__", None)
+    return data
+
+
+def _playback_state(app):
+    player = app.player
+    playlist = app.playlist
+    return {
+        "current_song": _song_to_ai_dict(playlist.current_song),
+        "player_state": player.state.name,
+        "volume": player.volume,
+        "position": player.position,
+        "duration": player.duration,
+    }
+
+
+def _playback_result(app, action: str, message: str = ""):
+    return {
+        "ok": True,
+        "action": action,
+        **_playback_state(app),
+        "message": message,
+    }
+
+
+@tool
+def playback_get_state(runtime: ToolRuntime) -> dict:
+    """Get current playback state, current song, and volume."""
+    app = runtime.context.app
+    return _playback_result(app, "get_state")
+
+
+@tool
+def playback_next_track(runtime: ToolRuntime) -> dict:
+    """Play the next track in the current playlist."""
+    app = runtime.context.app
+    app.playlist.next()
+    return _playback_result(app, "next_track")
+
+
+@tool
+def playback_previous_track(runtime: ToolRuntime) -> dict:
+    """Play the previous track in the current playlist."""
+    app = runtime.context.app
+    app.playlist.previous()
+    return _playback_result(app, "previous_track")
+
+
+@tool
+def playback_pause(runtime: ToolRuntime) -> dict:
+    """Pause playback."""
+    app = runtime.context.app
+    app.player.pause()
+    return _playback_result(app, "pause")
+
+
+@tool
+def playback_resume(runtime: ToolRuntime) -> dict:
+    """Resume playback."""
+    app = runtime.context.app
+    app.player.resume()
+    return _playback_result(app, "resume")
+
+
+@tool
+def playback_toggle(runtime: ToolRuntime) -> dict:
+    """Toggle between playing and paused states."""
+    app = runtime.context.app
+    app.player.toggle()
+    return _playback_result(app, "toggle")
+
+
+@tool
+def playback_stop(runtime: ToolRuntime) -> dict:
+    """Stop playback."""
+    app = runtime.context.app
+    app.player.stop()
+    return _playback_result(app, "stop")
+
+
+@tool
+def playback_set_volume(volume: int, runtime: ToolRuntime) -> dict:
+    """Set playback volume from 0 to 100.
+
+    :param volume: Target volume percentage. Values outside 0-100 are clamped.
+    """
+    app = runtime.context.app
+    app.player.volume = _clamp_volume(volume)
+    return _playback_result(app, "set_volume")
+
+
+@tool
+def playback_adjust_volume(delta: int, runtime: ToolRuntime) -> dict:
+    """Adjust playback volume by a relative delta.
+
+    :param delta: Positive or negative volume change.
+    """
+    app = runtime.context.app
+    app.player.volume = _clamp_volume(app.player.volume + delta)
+    return _playback_result(app, "adjust_volume")
+
+
+playback_tools = [
+    playback_get_state,
+    playback_next_track,
+    playback_previous_track,
+    playback_pause,
+    playback_resume,
+    playback_toggle,
+    playback_stop,
+    playback_set_volume,
+    playback_adjust_volume,
+]

--- a/feeluown/ai/radio.py
+++ b/feeluown/ai/radio.py
@@ -1,0 +1,714 @@
+import datetime
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+from langchain.agents import create_agent
+from langchain.tools import tool, ToolRuntime
+
+from feeluown.ai.llm import create_chat_model_with_config
+from feeluown.ai.matcher import SongSuggestionMatcher
+from feeluown.ai.models import SongSuggestion
+from feeluown.ai.prompt import generate_prompt_for_library
+from feeluown.i18n import t
+from feeluown.player.playlist import PlaylistMode
+from feeluown.serializers import serialize
+from feeluown.utils.dispatch import Signal
+
+if TYPE_CHECKING:
+    from feeluown.app import App
+    from feeluown.library import BriefSongModel
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_CANDIDATE_BATCH_SIZE = 3
+
+
+def _get_active_ai_radio(runtime: ToolRuntime):
+    ai = runtime.context.app.ai
+    if ai is None:
+        return None
+    return ai.get_active_radio()
+
+
+def _get_fm_candidates(runtime: ToolRuntime):
+    return runtime.context.app.fm.candidates
+
+
+def _ai_radio_status_result(
+    ok: bool,
+    message: str,
+    action: str = "",
+    error_code: str = "",
+) -> dict:
+    result = {
+        "ok": ok,
+        "active": False,
+        "candidates": [],
+        "candidate_count": 0,
+        "message": message,
+    }
+    if action:
+        result["action"] = action
+    if error_code:
+        result["error_code"] = error_code
+    return result
+
+
+def _ai_radio_inactive_result():
+    return _ai_radio_status_result(
+        ok=False,
+        error_code="AI_RADIO_INACTIVE",
+        message="AI Radio is not active.",
+    )
+
+
+def _ai_radio_unavailable_result():
+    return _ai_radio_status_result(
+        ok=False,
+        error_code="AI_UNAVAILABLE",
+        message="AI is not available.",
+    )
+
+
+@dataclass
+class AIRadioRecommendationContext:
+    suggestions: list[SongSuggestion]
+
+
+@dataclass
+class AIRadioState:
+    active: bool
+    candidate_batch_size: int
+    current_song: Optional["BriefSongModel"] = None
+    candidates: list["BriefSongModel"] = field(default_factory=list)
+    preferences: list[str] = field(default_factory=list)
+    avoidances: list[str] = field(default_factory=list)
+    preference_notes: list[str] = field(default_factory=list)
+
+    def to_ai_dict(self):
+        return {
+            "active": self.active,
+            "current_song": (
+                song_to_ai_dict(self.current_song)
+                if self.current_song is not None
+                else None
+            ),
+            "candidates": [
+                song_to_ai_dict(song, position)
+                for position, song in enumerate(self.candidates, start=1)
+            ],
+            "candidate_count": len(self.candidates),
+            "candidate_batch_size": self.candidate_batch_size,
+            "preferences": self.preferences,
+            "avoidances": self.avoidances,
+            "preference_notes": self.preference_notes,
+        }
+
+
+def song_to_ai_dict(song: "BriefSongModel", position: int | None = None):
+    data = serialize("python", song)
+    data["source"] = data.pop("provider", data.get("source"))
+    data.pop("__type__", None)
+    if position is not None:
+        data["position"] = position
+    return data
+
+
+@tool
+def collect_ai_radio_suggestions(
+    songs: list[SongSuggestion],
+    runtime: ToolRuntime,
+) -> bool:
+    """Collect song suggestions for AI radio playback.
+
+    :param songs: A list of SongSuggestion.
+    """
+    runtime.context.suggestions = songs
+    return True
+
+
+def create_recommendation_agent_with_config(config):
+    model = create_chat_model_with_config(config)
+    return create_agent(
+        model=model,
+        system_prompt="你是一个音乐播放器 AI 电台推荐助手。",
+        tools=[collect_ai_radio_suggestions],
+        context_schema=AIRadioRecommendationContext,
+    )
+
+
+async def generate_prompt(app: "App"):
+    """
+    1. Today's date and current time.
+    2. User's music library, including songs, albums, artists, playlists.
+    """
+    time_prompt = (
+        f"当前时间是 {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}。"
+    )
+    library_prompt = await generate_prompt_for_library(app.coll_mgr.get_coll_library())
+    return f"{time_prompt}\n\n{library_prompt}"
+
+
+@tool
+def ai_radio_activate(runtime: ToolRuntime, reset: bool = True) -> bool:
+    """Activate AI Radio.
+
+    This switches the playlist into FM mode and lets the current AI radio
+    session provide future candidate songs.
+
+    :param reset: Whether to reset the current playlist when entering FM mode.
+    """
+    app = runtime.context.app
+    if app.ai is None:
+        return False
+
+    radio = app.ai.get_active_radio()
+    if radio is not None:
+        return True
+
+    app.ai.activate_radio(reset=reset)
+    return True
+
+
+@tool
+def ai_radio_deactivate(runtime: ToolRuntime) -> bool:
+    """Deactivate AI Radio and leave playlist FM mode."""
+    app = runtime.context.app
+    if app.ai is None:
+        return False
+    app.ai.deactivate_radio()
+    return True
+
+
+@tool
+def ai_radio_get_state(runtime: ToolRuntime) -> dict:
+    """Get current AI radio state and upcoming candidate songs."""
+    if runtime.context.app.ai is None:
+        return _ai_radio_unavailable_result()
+    radio = _get_active_ai_radio(runtime)
+    if radio is None:
+        return _ai_radio_inactive_result()
+    return {"ok": True, **radio.get_state_for_ai()}
+
+
+@tool
+def fm_candidates_clear(runtime: ToolRuntime) -> bool:
+    """Clear all upcoming FM candidate songs while AI Radio is active."""
+    radio = _get_active_ai_radio(runtime)
+    if radio is None:
+        return False
+    radio.set_candidate_status(t("ai-radio-candidates-clearing"))
+    ok = _get_fm_candidates(runtime).clear()
+    radio.set_candidate_status(t("ai-radio-candidates-cleared"))
+    return ok
+
+
+@tool
+def fm_candidates_remove(positions: list[int], runtime: ToolRuntime) -> bool:
+    """Remove upcoming FM candidate songs by 1-based positions.
+
+    :param positions: 1-based candidate positions to remove.
+    """
+    radio = _get_active_ai_radio(runtime)
+    if radio is None:
+        return False
+    fm_candidates = _get_fm_candidates(runtime)
+    old_candidates = fm_candidates.list_candidates()
+    remove_positions = _normalize_positions(positions, len(old_candidates))
+    ok = fm_candidates.remove(positions)
+    removed_count = len(remove_positions) if ok else 0
+    radio.set_candidate_status(
+        t("ai-radio-candidates-updated", count=removed_count)
+    )
+    return ok
+
+
+@tool
+def fm_candidates_keep(positions: list[int], runtime: ToolRuntime) -> bool:
+    """Keep only selected upcoming FM candidates by 1-based positions.
+
+    :param positions: 1-based candidate positions to keep.
+    """
+    radio = _get_active_ai_radio(runtime)
+    if radio is None:
+        return False
+    ok = _get_fm_candidates(runtime).keep(positions)
+    radio.set_candidate_status(t("ai-radio-candidates-kept"))
+    return ok
+
+
+@tool
+async def fm_candidates_append(
+    songs: list[SongSuggestion], runtime: ToolRuntime
+) -> bool:
+    """Append song suggestions to the FM candidate list.
+
+    The input songs are AI song suggestions, not playlist candidates yet. This
+    tool conservatively matches at most the radio batch size into real provider
+    songs, then appends those real songs as upcoming FM candidates.
+
+    :param songs: Suggested songs to match and append.
+    """
+    radio = _get_active_ai_radio(runtime)
+    if radio is None:
+        return False
+    fm_candidates = _get_fm_candidates(runtime)
+    matched_songs = await radio.match_suggestions(songs)
+    old_candidates = fm_candidates.list_candidates()
+    if matched_songs:
+        radio.set_candidate_status(
+            t("ai-radio-candidates-adding", count=len(matched_songs))
+        )
+        ok = fm_candidates.append(matched_songs)
+        candidates = fm_candidates.list_candidates()
+        added_count = len(candidates) - len(old_candidates) if ok else 0
+        radio.set_candidate_status(
+            t("ai-radio-candidates-updated", count=added_count)
+        )
+    else:
+        ok = fm_candidates.append([])
+        radio.set_candidate_status(t("ai-radio-candidates-update-failed"))
+    return ok
+
+
+@tool
+async def fm_candidates_replace(
+    songs: list[SongSuggestion],
+    runtime: ToolRuntime,
+    keep_positions: list[int] | None = None,
+) -> bool:
+    """Replace FM candidates, optionally keeping selected 1-based positions.
+
+    FM candidates are real songs already in the playlist after the current song.
+    The input songs are AI song suggestions to match into new real candidates.
+
+    :param songs: Suggested songs to match and append.
+    :param keep_positions: Existing 1-based candidate positions to preserve.
+    """
+    radio = _get_active_ai_radio(runtime)
+    if radio is None:
+        return False
+    fm_candidates = _get_fm_candidates(runtime)
+    matched_songs = await radio.match_suggestions(songs)
+    candidates_count = len(fm_candidates.list_candidates())
+    keep_positions = _normalize_positions(keep_positions or [], candidates_count)
+    if matched_songs:
+        radio.set_candidate_status(
+            t("ai-radio-candidates-adding", count=len(matched_songs))
+        )
+        ok = fm_candidates.replace(
+            matched_songs, keep_positions=keep_positions
+        )
+        candidates = fm_candidates.list_candidates()
+        added_count = max(0, len(candidates) - len(keep_positions)) if ok else 0
+        radio.set_candidate_status(
+            t("ai-radio-candidates-updated", count=added_count)
+        )
+    else:
+        ok = fm_candidates.replace([], keep_positions=keep_positions)
+        radio.set_candidate_status(t("ai-radio-candidates-update-failed"))
+    return ok
+
+
+@tool
+def ai_radio_update_preferences(
+    runtime: ToolRuntime,
+    preferences: list[str] | None = None,
+    avoidances: list[str] | None = None,
+    reason: str = "",
+) -> bool:
+    """Update current-session AI radio preferences.
+
+    Use this when the user gives feedback that should affect future automatic
+    AI radio recommendations.
+
+    :param preferences: Musical traits the user wants more of.
+    :param avoidances: Musical traits the user wants less of.
+    :param reason: Short reason derived from the user's feedback.
+    """
+    radio = _get_active_ai_radio(runtime)
+    if radio is None:
+        return False
+    return radio.update_preferences(
+        preferences=preferences or [],
+        avoidances=avoidances or [],
+        reason=reason,
+    )
+
+
+ai_radio_tools = [
+    ai_radio_activate,
+    ai_radio_deactivate,
+    ai_radio_get_state,
+    fm_candidates_clear,
+    fm_candidates_remove,
+    fm_candidates_keep,
+    fm_candidates_append,
+    fm_candidates_replace,
+    ai_radio_update_preferences,
+]
+
+
+class AIRadioRecommender:
+    def __init__(
+        self,
+        app: "App",
+        set_status,
+        matcher_cls=None,
+        recommendation_agent_factory=None,
+        candidate_batch_size=DEFAULT_CANDIDATE_BATCH_SIZE,
+    ):
+        self._app = app
+        self._set_status = set_status
+        self._matcher_cls = matcher_cls
+        self._recommendation_agent_factory = (
+            recommendation_agent_factory or create_recommendation_agent_with_config
+        )
+        self._candidate_batch_size = candidate_batch_size
+        self._thread_id = 1
+        self._preferences = []
+        self._avoidances = []
+        self._preference_notes = []
+        self._seen_songs = set()
+
+    @property
+    def candidate_batch_size(self) -> int:
+        return self._candidate_batch_size
+
+    @property
+    def preferences(self) -> list[str]:
+        return list(self._preferences)
+
+    @property
+    def avoidances(self) -> list[str]:
+        return list(self._avoidances)
+
+    @property
+    def preference_notes(self) -> list[str]:
+        return list(self._preference_notes)
+
+    def update_preferences(
+        self,
+        preferences: list[str] | None = None,
+        avoidances: list[str] | None = None,
+        reason: str = "",
+    ) -> bool:
+        self._preferences.extend(_clean_texts(preferences or []))
+        self._avoidances.extend(_clean_texts(avoidances or []))
+        if reason.strip():
+            self._preference_notes.append(reason.strip())
+        self._set_status(t("ai-radio-instruction-updated"))
+        return True
+
+    async def recommend_matched_songs(self, number: int, radio_state: dict):
+        number = self.normalize_fetch_count(number)
+
+        try:
+            self._set_status(t("ai-radio-candidates-requesting", count=number))
+            suggestions = await self.recommend_suggestions(number, radio_state)
+        except Exception:  # noqa
+            logger.exception("AI radio failed to recommend songs")
+            return []
+
+        matched = await self.match_suggestions(
+            suggestions,
+            count=number,
+            limit_processed=False,
+        )
+        return matched
+
+    async def recommend_suggestions(
+        self, count: int, radio_state: dict | None = None
+    ) -> list[SongSuggestion]:
+        """Recommend songs for AI radio without matching provider resources."""
+        count = self.normalize_fetch_count(count)
+        agent = self._recommendation_agent_factory(self._app.config)
+        context = AIRadioRecommendationContext(suggestions=[])
+        radio_state = radio_state or {}
+        preferences = "\n".join(
+            f"- {item}" for item in radio_state.get("preferences", [])
+        )
+        avoidances = "\n".join(
+            f"- {item}" for item in radio_state.get("avoidances", [])
+        )
+        notes = "\n".join(
+            f"- {item}" for item in radio_state.get("preference_notes", [])
+        )
+        input = {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": self._app.config.AI_RADIO_PROMPT,
+                },
+                {"role": "system", "content": await generate_prompt(self._app)},
+                {
+                    "role": "system",
+                    "content": (
+                        "AI 电台当前状态：\n"
+                        f"{radio_state}\n"
+                        "用户偏好：\n"
+                        f"{preferences or '- 暂无'}\n"
+                        "用户想避免：\n"
+                        f"{avoidances or '- 暂无'}\n"
+                        "近期反馈摘要：\n"
+                        f"{notes or '- 暂无'}\n"
+                        "根据用户的音乐库收藏，分析用户的喜好，并且综合当前日期/时间等信息，"
+                        f"推荐{count}首适合继续播放的歌给用户，"
+                        "并调用 collect_ai_radio_suggestions 生成歌曲建议列表。"
+                    ),
+                },
+            ]
+        }
+        await agent.ainvoke(
+            input,
+            self.get_agent_config(),
+            context=context,
+        )
+        return context.suggestions
+
+    def get_agent_config(self):
+        return {
+            "configurable": {"thread_id": f"ai-radio-{self._thread_id}"},
+        }
+
+    async def match_suggestions(
+        self,
+        suggestions: list["SongSuggestion"],
+        count: int | None = None,
+        limit_processed: bool = True,
+    ):
+        count = self.normalize_fetch_count(count or len(suggestions) or 1)
+        suggestions_to_process = (
+            suggestions[:count] if limit_processed else suggestions
+        )
+        songs = []
+        matcher = self._create_matcher()
+        for suggestion in suggestions_to_process:
+            if len(songs) >= count:
+                break
+            try:
+                self._set_status(
+                    t("ai-radio-candidates-matching", title=suggestion.title)
+                )
+                song = await matcher.match(suggestion)
+            except Exception:  # noqa
+                logger.exception(
+                    "AI radio failed to match song suggestion: %s", suggestion
+                )
+                continue
+            if song is None:
+                continue
+            if self._is_duplicate(song, songs):
+                continue
+            self._seen_songs.add(song)
+            songs.append(song)
+        return songs
+
+    def normalize_fetch_count(self, number: int):
+        return max(1, min(number, self._candidate_batch_size))
+
+    def _is_duplicate(self, song, batch) -> bool:
+        return (
+            song in self._seen_songs
+            or song in batch
+            or song in self._app.playlist.list()
+        )
+
+    def _create_matcher(self):
+        if self._matcher_cls is None:
+            return SongSuggestionMatcher(self._app)
+        return self._matcher_cls(self._app)
+
+
+class AIRadioFMAdapter:
+    """Connect AI radio sessions to FM mode."""
+
+    def __init__(
+        self,
+        app: "App",
+        normalize_fetch_count,
+        fetch_more_songs,
+        on_finished,
+    ):
+        self._app = app
+        self._normalize_fetch_count = normalize_fetch_count
+        self._fetch_more_songs = fetch_more_songs
+        self._on_finished = on_finished
+        self._active = False
+
+    @property
+    def is_active(self) -> bool:
+        return self._active and self._app.playlist.mode is PlaylistMode.fm
+
+    def activate(self, reset=True):
+        if self._app.fm.is_active:
+            self._app.fm.deactivate()
+
+        self._active = True
+        self._app.playlist.mode_changed.connect(self._on_playlist_mode_changed)
+        self._app.fm.activate(self.fetch_songs, reset=reset)
+
+    def deactivate(self):
+        if self.is_active:
+            self._app.fm.deactivate()
+        else:
+            self.finish()
+
+    def finish(self):
+        if self._active:
+            self._app.playlist.mode_changed.disconnect(
+                self._on_playlist_mode_changed
+            )
+        self._active = False
+
+    async def fetch_songs(self, number: int):
+        number = self._normalize_fetch_count(number)
+        return await self._fetch_more_songs(number)
+
+    def _on_playlist_mode_changed(self, mode):
+        if mode is not PlaylistMode.fm:
+            self._on_finished()
+
+
+class AIRadioSession:
+    """AI radio session backed by the existing FM queue."""
+
+    def __init__(
+        self,
+        app: "App",
+        matcher_cls=None,
+        recommendation_agent_factory=None,
+        candidate_batch_size=DEFAULT_CANDIDATE_BATCH_SIZE,
+    ):
+        self._app = app
+        self.status = ""
+        self.status_changed = Signal()
+        self._recommender = AIRadioRecommender(
+            app,
+            self._set_status,
+            matcher_cls=matcher_cls,
+            recommendation_agent_factory=recommendation_agent_factory,
+            candidate_batch_size=candidate_batch_size,
+        )
+        self._fm = AIRadioFMAdapter(
+            app,
+            normalize_fetch_count=self._recommender.normalize_fetch_count,
+            fetch_more_songs=self._fetch_more_songs,
+            on_finished=self._finish,
+        )
+
+    @property
+    def is_active(self) -> bool:
+        return self._fm.is_active
+
+    @property
+    def candidate_batch_size(self) -> int:
+        return self._recommender.candidate_batch_size
+
+    @property
+    def preferences(self) -> list[str]:
+        return self._recommender.preferences
+
+    @property
+    def avoidances(self) -> list[str]:
+        return self._recommender.avoidances
+
+    @property
+    def preference_notes(self) -> list[str]:
+        return self._recommender.preference_notes
+
+    def activate(self, reset=True):
+        old_session = self._app.ai.radio
+        if old_session is not None and old_session is not self:
+            old_session._finish()
+
+        self._app.ai.radio = self
+        self._fm.activate(reset=reset)
+
+    def deactivate(self):
+        self._fm.deactivate()
+
+    @property
+    def fetch_songs_func(self):
+        return self._fm.fetch_songs
+
+    def get_state_for_ai(self):
+        return AIRadioState(
+            active=self.is_active,
+            current_song=self._app.playlist.current_song,
+            candidates=self.list_upcoming_candidates(),
+            candidate_batch_size=self.candidate_batch_size,
+            preferences=self.preferences,
+            avoidances=self.avoidances,
+            preference_notes=self.preference_notes,
+        ).to_ai_dict()
+
+    def list_upcoming_candidates(self):
+        return self._app.fm.candidates.list_candidates()
+
+    def set_candidate_status(self, status: str):
+        self._set_status(status)
+
+    async def match_suggestions(
+        self, suggestions: list["SongSuggestion"], count: int | None = None
+    ):
+        return await self._recommender.match_suggestions(suggestions, count=count)
+
+    def update_preferences(
+        self,
+        preferences: list[str] | None = None,
+        avoidances: list[str] | None = None,
+        reason: str = "",
+    ):
+        return self._recommender.update_preferences(
+            preferences=preferences,
+            avoidances=avoidances,
+            reason=reason,
+        )
+
+    async def recommend_song_suggestions(
+        self, count: int, instructions: list[str] | None = None
+    ) -> list[SongSuggestion]:
+        """Recommend songs for AI radio without matching provider resources."""
+        radio_state = {
+            "preferences": instructions or [],
+            "avoidances": [],
+            "preference_notes": [],
+        }
+        return await self._recommender.recommend_suggestions(
+            count, radio_state=radio_state
+        )
+
+    async def a_fetch_songs_func(self, number: int):
+        return await self.fetch_songs_func(number)
+
+    async def _fetch_more_songs(self, number: int):
+        return await self._recommender.recommend_matched_songs(
+            number,
+            radio_state=self.get_state_for_ai(),
+        )
+
+    def _finish(self):
+        self._fm.finish()
+        self._set_status("")
+        if self._app.ai.radio is self:
+            self._app.ai.radio = None
+
+    def _set_status(self, status: str):
+        self.status = status
+        self.status_changed.emit(status)
+
+
+def _clean_texts(texts: list[str]) -> list[str]:
+    return [text.strip() for text in texts if text.strip()]
+
+
+def _normalize_positions(positions: list[int], candidate_count: int) -> list[int]:
+    normalized = []
+    for position in positions:
+        if 1 <= position <= candidate_count and position not in normalized:
+            normalized.append(position)
+    return normalized

--- a/feeluown/gui/assets/themes/common.qss
+++ b/feeluown/gui/assets/themes/common.qss
@@ -63,7 +63,7 @@ TextButton {
     height: 18px;
     background-color: transparent;
     padding: 2px 8px;
-    border-radius: 3px;
+    border-radius: 6px;
 }
 
 VideoPlayerCtlBar Button {
@@ -78,7 +78,7 @@ ToolbarButton {
     border: 0px;
 }
 TextButton:hover, ToolbarButton:hover {
-    border: 1px solid #777;
+    border: 1px solid #999;
 }
 TextButton:checked {
     border: 1px solid #d75a4a;  /* same as like_btn red color */

--- a/feeluown/gui/assets/themes/dark.qss
+++ b/feeluown/gui/assets/themes/dark.qss
@@ -15,7 +15,7 @@ Separator {
 }
 
 TextButton {
-    border: 1px solid #444;
+    border: 1px solid #555;
 }
 
 TextButton:pressed, ToolbarButton:pressed {

--- a/feeluown/gui/assets/themes/light.qss
+++ b/feeluown/gui/assets/themes/light.qss
@@ -6,7 +6,7 @@ TopPanel {
 }
 
 TextButton {
-    border: 1px solid #AAA;
+    border: 1px solid #CCC;
 }
 
 TextButton:pressed, ToolbarButton:pressed {

--- a/feeluown/gui/components/ai_radio_card.py
+++ b/feeluown/gui/components/ai_radio_card.py
@@ -5,7 +5,8 @@ from PyQt6.QtWidgets import (
 )
 
 from feeluown.app.gui_app import GuiApp
-from feeluown.ai import AISongMatcher
+from feeluown.ai import AIRadioSession, SongSuggestionMatcher
+from feeluown.i18n import t
 from feeluown.library import reverse
 from feeluown.gui.widgets import PlayButton
 from feeluown.gui.widgets.cover_label import CoverLabelV2
@@ -25,17 +26,17 @@ class AIRadioCard(QFrame):
     def __init__(self, app: GuiApp, parent=None):
         super().__init__(parent)
         self._app = app
-        self.ai_radio = self._app.ai.get_copilot()
+        self._radio_preview = AIRadioSession(self._app)
 
         # Widgets and layouts
-        self._header = Header('AI 电台')
-        self._header.setToolTip('暂未实现，欢迎 PR :)')
+        self._header = Header(t("ai-radio-title"))
+        self._header.setToolTip(t("ai-radio-activate-tooltip"))
         self._summary_label = QLabel(self)
         self._summary_label.setWordWrap(True)
         self._cover_label = CoverLabelV2(self._app, self)
         self._status_label = QLabel(self)
         self._play_btn = PlayButton(length=20, padding=0.2)
-        self._play_btn.setDisabled(True)
+        self._play_btn.setToolTip(t("ai-radio-activate-tooltip"))
         self._play_btn.clicked.connect(self.on_play_btn_clicked)
         self._header.clicked.connect(self.on_header_clicked)
         self.setup_ui()
@@ -67,32 +68,48 @@ class AIRadioCard(QFrame):
         self._layout.addWidget(self._cover_label)
 
     async def render(self):
-        self._status_label.setText('正在获取电台歌曲...')
-        ai_songs = await self.ai_radio.recommend_a_song()
-        if not ai_songs:
-            self._status_label.setText('AI 推荐歌曲失败...')
-            logger.warning("AI radio recommend_a_song return empty")
+        self._status_label.setText(t("ai-radio-preview-loading"))
+        try:
+            suggestions = await self._radio_preview.recommend_song_suggestions(1)
+        except Exception:  # noqa
+            logger.exception("AI radio preview failed")
+            suggestions = []
+        if not suggestions:
+            self._status_label.setText(t("ai-radio-preview-failed"))
+            logger.warning("AI radio recommend_song_suggestions return empty")
         else:
-            first = ai_songs[0]
+            first = suggestions[0]
             self._status_label.setText(f'{first.title} • {first.artists_name}')
             self._summary_label.setText(first.description)
-            song = await AISongMatcher(self._app).match(first)
-            logger.info(f"matched song: {song}, ai_song: {first}")
+            song = await SongSuggestionMatcher(self._app).match(first)
+            logger.info(f"matched song: {song}, suggestion: {first}")
             if song is not None:
                 self._song = song
                 self._play_btn.setEnabled(True)
-                self._play_btn.setToolTip('点击播放')
+                self._play_btn.setToolTip(t("ai-radio-activate-tooltip"))
                 self._status_label.setText(f'{song.title} • {song.artists_name}')
                 cover_media = await aio.run_fn(
                     self._app.library.model_get_cover_media, song
                 )
                 await self._cover_label.show_cover_media(cover_media, reverse(song))
             else:
-                self._play_btn.setToolTip('未匹配到音源')
+                self._play_btn.setToolTip(t("ai-radio-activate-tooltip"))
 
     def on_play_btn_clicked(self):
-        self._app.playlist.play_model(self._song)
+        self.enter_ai_radio()
 
     def on_header_clicked(self):
-        # TODO: to be implemented
-        pass
+        self.enter_ai_radio()
+
+    def enter_ai_radio(self):
+        self._app.ai.activate_radio()
+        if self._song is not None:
+            self._app.fm.candidates.append([self._song])
+        self._app.show_msg(t("ai-radio-activated"))
+        self._show_ai_chat_overlay()
+
+    def _show_ai_chat_overlay(self):
+        overlay = self._app.ui.ai_chat_overlay
+        if overlay is not None:
+            overlay.show()
+            overlay.raise_()

--- a/feeluown/gui/components/overlay.py
+++ b/feeluown/gui/components/overlay.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, cast
 
-from PyQt6.QtCore import QEvent, Qt
+from PyQt6.QtCore import QEvent, QMargins, Qt
 from PyQt6.QtGui import QColor, QPainter, QResizeEvent
 from PyQt6.QtWidgets import QWidget, QHBoxLayout
 
@@ -8,6 +9,14 @@ from feeluown.gui.helpers import esc_hide_widget
 
 if TYPE_CHECKING:
     from feeluown.app.gui_app import GuiApp
+
+
+@dataclass
+class AppOverlayOptions:
+    adhoc: bool = False
+    margins: Optional[QMargins] = None
+    dim_background: bool = True
+    close_on_focus_in: bool = True
 
 
 class AppOverlayContainer(QWidget):
@@ -26,15 +35,21 @@ class AppOverlayContainer(QWidget):
         app: "GuiApp",
         body: QWidget,
         parent: Optional[QWidget] = None,
-        adhoc=False,
+        options: Optional[AppOverlayOptions] = None,
     ):
         super().__init__(parent=parent)
+        options = options or AppOverlayOptions()
         self._app = app
-        self._adhoc = adhoc
+        self._adhoc = options.adhoc
+        self._dim_background = options.dim_background
+        self._close_on_focus_in = options.close_on_focus_in
 
         self.body = body
         self._layout = QHBoxLayout(self)
-        self._layout.setContentsMargins(100, 80, 100, 80)
+        margins = options.margins
+        if margins is None:
+            margins = QMargins(100, 80, 100, 80)
+        self._layout.setContentsMargins(margins)
         self._layout.addWidget(self.body)
         self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
         # Add ClickFocus for the body so that when Overlay will not
@@ -58,6 +73,9 @@ class AppOverlayContainer(QWidget):
 
     def paintEvent(self, event):
         """Draw semi-transparent background"""
+        if self._dim_background is False:
+            super().paintEvent(event)
+            return
         painter = QPainter(self)
         painter.fillRect(self.rect(), QColor(0, 0, 0, 100))
 
@@ -69,5 +87,6 @@ class AppOverlayContainer(QWidget):
         return super().eventFilter(obj, event)
 
     def focusInEvent(self, event):
-        self.hide()
+        if self._close_on_focus_in:
+            self.hide()
         super().focusInEvent(event)

--- a/feeluown/gui/components/player_playlist.py
+++ b/feeluown/gui/components/player_playlist.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
-from PyQt6.QtCore import Qt, QModelIndex, QItemSelectionModel
+from PyQt6.QtCore import Qt, QModelIndex, QItemSelectionModel, QRectF
+from PyQt6.QtGui import QPainter, QPalette
 from PyQt6.QtWidgets import QMenu, QAbstractItemView
 
 from feeluown.utils.aio import run_fn, run_afn
@@ -15,6 +16,7 @@ from feeluown.gui.helpers import fetch_cover_wrapper
 from feeluown.gui.widgets.song_minicard_list import (
     SongMiniCardListView,
     SongMiniCardListModel,
+    SongMiniCardListDelegate,
 )
 from feeluown.i18n import t
 from feeluown.utils.reader import create_reader
@@ -64,6 +66,62 @@ class PlayerPlaylistModel(SongMiniCardListModel):
     def on_songs_reordered(self, index, count):
         self.on_songs_removed(index, count)
         self.on_songs_added(index, count)
+
+
+class FMCandidatePlaylistDelegate(SongMiniCardListDelegate):
+    def __init__(self, app: "GuiApp", view, *args, **kwargs):
+        super().__init__(view, *args, **kwargs)
+        self._app = app
+
+    def paint(self, painter, option, index):
+        super().paint(painter, option, index)
+        if self.is_fm_candidate(index):
+            self._paint_candidate_badge(painter, option)
+
+    def is_fm_candidate(self, index) -> bool:
+        if not index.isValid():
+            return False
+        playlist = self._app.playlist
+        if playlist.mode is not PlaylistMode.fm:
+            return False
+        row = index.row()
+        songs = playlist.list()
+        if not 0 <= row < len(songs):
+            return False
+        current_row = playlist.current_song_index()
+        return current_row is None or row > current_row
+
+    def _paint_candidate_badge(self, painter, option):
+        text = t("fm-candidate-badge")
+        painter.save()
+        font = painter.font()
+        pixel_size = font.pixelSize()
+        if pixel_size > 0:
+            font.setPixelSize(max(9, pixel_size - 2))
+        painter.setFont(font)
+        text_width = painter.fontMetrics().horizontalAdvance(text)
+        rect = option.rect
+        item_width, _ = self.item_sizehint()
+        bg_width = min(
+            rect.width() - self.card_left_padding - self.card_right_spacing,
+            item_width,
+        )
+        badge_width = max(22, text_width + 12)
+        badge_rect = QRectF(
+            rect.x() + self.card_left_padding + bg_width - badge_width - 6,
+            rect.y() + self.card_top_padding + 5,
+            badge_width,
+            14,
+        )
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setPen(Qt.PenStyle.NoPen)
+        color = option.palette.color(QPalette.ColorRole.Highlight)
+        color.setAlpha(90)
+        painter.setBrush(color)
+        painter.drawRoundedRect(badge_rect, 7, 7)
+        painter.setPen(option.palette.color(QPalette.ColorRole.HighlightedText))
+        painter.drawText(badge_rect, Qt.AlignmentFlag.AlignCenter, text)
+        painter.restore()
 
 
 class PlayerPlaylistView(SongMiniCardListView):
@@ -116,11 +174,14 @@ class PlayerPlaylistView(SongMiniCardListView):
             SongMenuInitializer(self._app, songs[0]).apply(menu)
         menu.exec(e.globalPos())
 
-    def scroll_to_current_song(self):
+    def scroll_to_current_song(
+        self,
+        hint=QAbstractItemView.ScrollHint.PositionAtCenter,
+    ):
         """Scroll to the current song, and select it to highlight it."""
         current_song = self._app.playlist.current_song
         songs = self._app.playlist.list()
-        if current_song is not None:
+        if current_song is not None and current_song in songs:
             model = self.model()
             row = songs.index(current_song)
             index = model.index(row, 0)
@@ -128,7 +189,7 @@ class PlayerPlaylistView(SongMiniCardListView):
             self.selectionModel().select(
                 index, QItemSelectionModel.SelectionFlag.SelectCurrent
             )
-            self.scrollTo(index, QAbstractItemView.ScrollHint.PositionAtCenter)
+            self.scrollTo(index, hint)
 
     async def _dislike_and_remove_songs(self, songs):
         song: BriefSongModel = songs[0]

--- a/feeluown/gui/components/search.py
+++ b/feeluown/gui/components/search.py
@@ -4,7 +4,7 @@ from PyQt6.QtWidgets import QAbstractItemView, QFrame, QVBoxLayout, QScrollArea
 
 from feeluown.library import SearchType
 from feeluown.utils.aio import run_afn
-from feeluown.gui.components.overlay import AppOverlayContainer
+from feeluown.gui.components.overlay import AppOverlayContainer, AppOverlayOptions
 from feeluown.gui.page_containers.table import TableContainer, Renderer
 from feeluown.gui.widgets.img_card_list import ImgCardListDelegate
 from feeluown.gui.widgets.songs import SongsTableView, ColumnsMode
@@ -41,7 +41,12 @@ def get_tab_idx(search_type):
 def create_search_result_view(app, song):
     q = f"{song.title} {song.artists_name}"
     body = SearchResultView(app, transparent_bg=False)
-    view = AppOverlayContainer(app, body, parent=app, adhoc=True)
+    view = AppOverlayContainer(
+        app,
+        body,
+        parent=app,
+        options=AppOverlayOptions(adhoc=True),
+    )
 
     source_in = app.browser.local_storage.get(KeySourceIn, None)
     run_afn(body.search_and_render, q, SearchType.so, source_in)

--- a/feeluown/gui/macos_titlebar.py
+++ b/feeluown/gui/macos_titlebar.py
@@ -1,0 +1,149 @@
+import logging
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+from PyQt6.QtWidgets import QWidget
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _NSWindowState:
+    ns_window: object
+    style_mask: int
+    title_visibility: int
+    titlebar_appears_transparent: bool
+    movable_by_window_background: bool
+
+
+class MacOSNativeTitlebarMode:
+    """Temporarily hide a macOS native titlebar while keeping traffic lights."""
+
+    def __init__(self, widget):
+        self._widget = widget if isinstance(widget, QWidget) else None
+        self._state: Optional[_NSWindowState] = None
+
+    @property
+    def is_supported(self) -> bool:
+        return sys.platform == "darwin" and self._widget is not None
+
+    def enter(self):
+        if not self.is_supported:
+            return
+        if self._state is not None:
+            self.reapply()
+            return
+        try:
+            ns_window = _get_ns_window(self._widget)
+            if not ns_window:
+                return
+            self._state = _read_state(ns_window)
+            _hide_titlebar(ns_window)
+        except Exception:  # noqa
+            logger.exception("enter macOS native titlebar mode failed")
+            self._state = None
+
+    def reapply(self):
+        if not self.is_supported or self._state is None:
+            return
+        try:
+            ns_window = _get_ns_window(self._widget)
+            if not ns_window:
+                return
+            if ns_window != self._state.ns_window:
+                self._state = _read_state(ns_window)
+            _hide_titlebar(ns_window)
+        except Exception:  # noqa
+            logger.exception("reapply macOS native titlebar mode failed")
+
+    def exit(self):
+        if self._state is None:
+            return
+        state = self._state
+        self._state = None
+        try:
+            _restore_state(state)
+        except Exception:  # noqa
+            logger.exception("exit macOS native titlebar mode failed")
+
+
+def _objc():
+    import ctypes
+    from ctypes import c_char_p, c_void_p
+
+    objc = ctypes.cdll.LoadLibrary("/usr/lib/libobjc.A.dylib")
+    objc.sel_registerName.restype = c_void_p
+    objc.sel_registerName.argtypes = [c_char_p]
+    return objc
+
+
+def _sel(name):
+    return _objc().sel_registerName(name.encode())
+
+
+def _msg(receiver, selector, restype=None, argtypes=(), *args):
+    from ctypes import c_void_p
+
+    if restype is None:
+        restype = c_void_p
+    send = _objc().objc_msgSend
+    send.restype = restype
+    send.argtypes = [c_void_p, c_void_p, *argtypes]
+    return send(receiver, _sel(selector), *args)
+
+
+def _get_ns_window(widget: QWidget):
+    from ctypes import c_void_p
+
+    return _msg(c_void_p(int(widget.winId())), "window")
+
+
+def _read_state(ns_window) -> _NSWindowState:
+    from ctypes import c_bool, c_long, c_ulong
+
+    return _NSWindowState(
+        ns_window=ns_window,
+        style_mask=_msg(ns_window, "styleMask", c_ulong),
+        title_visibility=_msg(ns_window, "titleVisibility", c_long),
+        titlebar_appears_transparent=bool(
+            _msg(ns_window, "titlebarAppearsTransparent", c_bool)
+        ),
+        movable_by_window_background=bool(
+            _msg(ns_window, "isMovableByWindowBackground", c_bool)
+        ),
+    )
+
+
+def _hide_titlebar(ns_window):
+    from ctypes import c_bool, c_long, c_ulong
+
+    style = _msg(ns_window, "styleMask", c_ulong)
+    style |= (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 15)
+    _msg(ns_window, "setStyleMask:", None, (c_ulong,), style)
+    _msg(ns_window, "setTitleVisibility:", None, (c_long,), 1)
+    _msg(ns_window, "setTitlebarAppearsTransparent:", None, (c_bool,), True)
+    _msg(ns_window, "setMovableByWindowBackground:", None, (c_bool,), True)
+
+
+def _restore_state(state: _NSWindowState):
+    from ctypes import c_bool, c_long, c_ulong
+
+    ns_window = state.ns_window
+    _msg(ns_window, "setStyleMask:", None, (c_ulong,), state.style_mask)
+    _msg(ns_window, "setTitleVisibility:", None, (c_long,), state.title_visibility)
+    _msg(
+        ns_window,
+        "setTitlebarAppearsTransparent:",
+        None,
+        (c_bool,),
+        state.titlebar_appears_transparent,
+    )
+    _msg(
+        ns_window,
+        "setMovableByWindowBackground:",
+        None,
+        (c_bool,),
+        state.movable_by_window_background,
+    )

--- a/feeluown/gui/theme.py
+++ b/feeluown/gui/theme.py
@@ -165,9 +165,9 @@ def dump_colors():
     json_ = defaultdict(dict)  # type: ignore[var-annotated]
     palette = QGuiApplication.palette()
     for group_attr in Groups:
-        group = getattr(QPalette, group_attr)
+        group = getattr(QPalette.ColorGroup, group_attr)
         for role_attr in Roles:
-            role = getattr(QPalette, role_attr)
+            role = getattr(QPalette.ColorRole, role_attr)
             json_[group_attr][role_attr] = palette.color(group, role).name()
     return json_
 
@@ -177,8 +177,8 @@ def load_colors(colors):
     for group_attr, value in colors.items():
         for role_attr, color_name in value.items():
             try:
-                role = getattr(QPalette, role_attr)
-                group = getattr(QPalette, group_attr)
+                role = getattr(QPalette.ColorRole, role_attr)
+                group = getattr(QPalette.ColorGroup, group_attr)
                 palette.setColor(group, role, QColor(color_name))
             except AttributeError:
                 pass

--- a/feeluown/gui/uimain/ai_chat.py
+++ b/feeluown/gui/uimain/ai_chat.py
@@ -1,241 +1,495 @@
-import asyncio
 import logging
 import time
-from typing import List
+from dataclasses import dataclass
+from urllib.parse import parse_qs, urlencode, urlparse
 
-from PyQt6.QtCore import Qt, QSize, QRect
-from PyQt6.QtGui import QPalette, QResizeEvent, QFontMetrics
+from PyQt6.QtCore import QEvent, QMargins, QRectF, QSize, Qt, QTimer, pyqtSignal
+from PyQt6.QtGui import (
+    QFont,
+    QGuiApplication,
+    QLinearGradient,
+    QPainter,
+    QPalette,
+)
 from PyQt6.QtWidgets import (
+    QAbstractItemView,
     QFrame,
     QHBoxLayout,
     QLabel,
     QListWidget,
     QListWidgetItem,
+    QMenu,
+    QSizePolicy,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
 
-from feeluown.ai import AISongModel, AISongMatcher
+from feeluown.ai import SongSuggestion
 from feeluown.app.gui_app import GuiApp
-from feeluown.gui.consts import ScrollBarWidth
+from feeluown.gui.components.search import create_search_result_view
+from feeluown.gui.helpers import IS_MACOS, secondary_text_color
 from feeluown.gui.widgets import PlayButton, PlusButton
+from feeluown.gui.widgets.textbtn import TextButton
 from feeluown.gui.widgets.header import MidHeader
-from feeluown.gui.widgets.ai_chat import ChatHistoryWidget, ChatInputWidget
-from feeluown.gui.components.overlay import AppOverlayContainer
+from feeluown.gui.widgets.ai_chat import (
+    ChatHistoryWidget,
+    ChatInputWidget,
+    SurfaceRadius,
+    draw_round_surface,
+    surface_border_color,
+)
+from feeluown.gui.components.player_playlist import (
+    PlayerPlaylistView,
+    FMCandidatePlaylistDelegate,
+)
+from feeluown.gui.widgets.song_minicard_list import (
+    SongMiniCardListDelegate,
+)
+from feeluown.gui.components.overlay import AppOverlayContainer, AppOverlayOptions
+from feeluown.library import BriefSongModel, ModelState, ResolveFailed, parse_line
 from feeluown.i18n import t
 from feeluown.utils import aio
 
 logger = logging.getLogger(__name__)
 
 
-class AISongItemWidget(QWidget):
-    """Display a single AISongModel with play support."""
+def _create_titlebar_mode(app):
+    if not IS_MACOS:
+        return None
+    from feeluown.gui.macos_titlebar import MacOSNativeTitlebarMode
 
-    def __init__(self, app: "GuiApp", ai_song: AISongModel, parent=None):
+    return MacOSNativeTitlebarMode(app)
+
+
+@dataclass
+class ParsedSongLink:
+    kind: str
+    model: SongSuggestion | BriefSongModel
+    url: str
+
+
+def _song_suggestion_to_display_song(
+    suggestion: SongSuggestion, identifier: str
+) -> BriefSongModel:
+    return BriefSongModel(
+        state=ModelState.not_exists,
+        source="ai",
+        identifier=identifier,
+        title=suggestion.title,
+        artists_name=suggestion.artists_name,
+    )
+
+
+def song_suggestion_to_markdown_url(suggestion: SongSuggestion) -> str:
+    query = urlencode({"title": suggestion.title, "artists": suggestion.artists_name})
+    return f"fuo://song-suggestion?{query}"
+
+
+def parse_song_link(url: str):
+    parsed_link = parse_song_link_info(url)
+    return parsed_link.model if parsed_link is not None else None
+
+
+def parse_song_link_info(url: str):
+    parsed = urlparse(url)
+    if parsed.scheme != "fuo":
+        return None
+
+    query = parse_qs(parsed.query)
+    if parsed.netloc in ("song-suggestion", "ai-song"):
+        title = query.get("title", [""])[0].strip()
+        artists_name = query.get("artists", [""])[0].strip()
+        if title:
+            return ParsedSongLink(
+                kind="suggestion",
+                model=SongSuggestion(
+                    title=title,
+                    artists_name=artists_name,
+                    description="",
+                ),
+                url=url,
+            )
+    elif parsed.netloc == "song":
+        source = query.get("source", [""])[0].strip()
+        identifier = query.get("identifier", [""])[0].strip()
+        title = query.get("title", [""])[0].strip()
+        artists_name = query.get("artists", [""])[0].strip()
+        if source and identifier:
+            return ParsedSongLink(
+                kind="resource",
+                model=BriefSongModel(
+                    source=source,
+                    identifier=identifier,
+                    title=title,
+                    artists_name=artists_name,
+                ),
+                url=url,
+            )
+    else:
+        try:
+            model, path = parse_line(url)
+        except (ResolveFailed, ValueError):
+            return None
+        if path == "" and isinstance(model, BriefSongModel):
+            return ParsedSongLink(kind="resource", model=model, url=url)
+    return None
+
+
+class SongSuggestionItemWidget(QWidget):
+    row_height = 56
+    _palette_ready = False
+
+    def __init__(self, song: BriefSongModel, list_view: QListWidget):
+        parent = list_view
         super().__init__(parent=parent)
-        self._app = app
+        self._palette_ready = False
+        self.song = song
+        self._list_view = list_view
+        self._hovered = False
+        self.setAutoFillBackground(False)
+        self.setAttribute(Qt.WidgetAttribute.WA_Hover, True)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.setFixedHeight(self.row_height)
 
-        self._ai_song = ai_song
-        self._matched_song = None
-        self._match_lock = asyncio.Lock()
+        self._title_label = QLabel(song.title_display, self)
+        self._title_label.setWordWrap(False)
+        self._artist_label = QLabel(song.artists_name_display, self)
+        self._artist_label.setWordWrap(False)
+        artist_font = self._artist_label.font()
+        artist_font.setPixelSize(max(10, artist_font.pixelSize() - 1))
+        self._artist_label.setFont(artist_font)
 
-        self._title_label = QLabel(f"{ai_song.title} • {ai_song.artists_name}")
-        self._desc_label = QLabel(ai_song.description)
-        self._desc_label.setWordWrap(True)
-        self._play_btn = PlayButton(length=16, padding=0.22)
-        self._add_to_playlist_btn = PlusButton(length=16, padding=0.25)
-        self._btns = [self._play_btn, self._add_to_playlist_btn]
+        self.play_btn = PlayButton(length=24, padding=0.3)
+        self.add_btn = PlusButton(length=24, padding=0.3)
+        self.play_btn.setToolTip(t("ai-chat-link-play"))
+        self.add_btn.setToolTip(t("add-to-playlist"))
+        self.play_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.add_btn.setCursor(Qt.CursorShape.PointingHandCursor)
 
-        self._play_btn.clicked.connect(self._on_play_clicked)
-        self._add_to_playlist_btn.clicked.connect(self._on_add_to_playlist_clicked)
+        text_layout = QVBoxLayout()
+        text_layout.setContentsMargins(0, 0, 0, 0)
+        text_layout.setSpacing(2)
+        text_layout.addWidget(self._title_label)
+        text_layout.addWidget(self._artist_label)
 
-        self._setup_ui()
-
-    def _setup_ui(self):
-        font = self._desc_label.font()
-        font.setPixelSize(11)
-        self._desc_label.setFont(font)
-        palette = self._desc_label.palette()
-        palette.setColor(
-            QPalette.ColorRole.Text,
-            palette.color(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text),
-        )
-        self._desc_label.setPalette(palette)
+        button_layout = QHBoxLayout()
+        button_layout.setContentsMargins(0, 0, 0, 0)
+        button_layout.setSpacing(2)
+        button_layout.addWidget(self.play_btn)
+        button_layout.addWidget(self.add_btn)
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(10, 5, ScrollBarWidth + 5, 5)
-        layout.setSpacing(5)
+        layout.setContentsMargins(10, 6, 8, 6)
+        layout.setSpacing(8)
+        layout.addLayout(text_layout, 1)
+        layout.addLayout(button_layout)
+        self._palette_ready = True
+        self._apply_palette()
 
-        self.label_layout = label_layout = QVBoxLayout()
-        label_layout.addWidget(self._title_label)
-        label_layout.addWidget(self._desc_label)
-        label_layout.addStretch(0)
+    def _apply_palette(self):
+        if not self._palette_ready:
+            return
+        pal = QPalette(QGuiApplication.palette())
+        secondary = secondary_text_color(pal)
+        pal.setColor(QPalette.ColorRole.WindowText, secondary)
+        pal.setColor(QPalette.ColorRole.Text, secondary)
+        self._artist_label.setPalette(pal)
 
-        self.btn_layout = btn_layout = QHBoxLayout()
-        btn_layout.setSpacing(0)
-        for btn in self._btns:
-            btn_layout.addWidget(btn)
+    def enterEvent(self, event):
+        self._hovered = True
+        self.update()
+        super().enterEvent(event)
 
-        layout.addLayout(label_layout)
-        layout.addLayout(btn_layout)
+    def leaveEvent(self, event):
+        self._hovered = False
+        self.update()
+        super().leaveEvent(event)
 
-    def height_for_width(self, width) -> QSize:
-        desc_fm = QFontMetrics(self._desc_label.font())
-        h_spacing = (self.layout().spacing() +
-                     self.btn_layout.spacing() * (len(self._btns) - 1))
-        v_spacing = self.layout().spacing()
-        margins = self.layout().contentsMargins()
-        h_margins = margins.left() + margins.right()
-        v_margins = margins.top() + margins.bottom()
-        btn_width = self._play_btn.width() + self._add_to_playlist_btn.width()
-        desc_width = width - btn_width - h_spacing - h_margins
-        desc_height = desc_fm.boundingRect(
-            QRect(0, 0, desc_width, 0), Qt.TextFlag.TextWordWrap, self._desc_label.text()
-        ).height()
-        title_height = 16
-        total_height = title_height + desc_height + v_spacing + v_margins
-        return total_height
-
-    def _on_play_clicked(self):
-        if self._matched_song is not None:
-            self._app.playlist.play_model(self._matched_song)
-        else:
-            aio.run_afn_ref(self.match_and_play)
-
-    def _on_add_to_playlist_clicked(self):
-        if self._matched_song is not None:
-            self._app.playlist.add(self._matched_song)
-        else:
-            aio.run_afn_ref(self.match_and_add_to_playlist)
-
-    async def match_and_play(self):
-        await self.match()
-        if self._matched_song:
-            self._app.playlist.play_model(self._matched_song)
-
-    async def match_and_add_to_playlist(self):
-        await self.match()
-        if self._matched_song:
-            self._app.playlist.add(self._matched_song)
-
-    async def match(self):
-        async with self._match_lock:
-            return await self.match_no_lock()
-
-    async def match_no_lock(self):
-        if self._matched_song is not None:
-            return self._matched_song
-
-        for btn in self._btns:
-            btn.setEnabled(False)
-            btn.setToolTip(t("ai-chat-match-resource"))
-        try:
-            self._matched_song = await AISongMatcher(self._app).match(self._ai_song)
-        except Exception:
-            logger.exception("match ai song failed")
-            for btn in self._btns:
-                btn.setEnabled(True)
-        else:
-            if self._matched_song is not None:
-                for btn in self._btns:
-                    btn.setEnabled(True)
-            else:
-                for btn in self._btns:
-                    btn.setToolTip(t("ai-chat-match-resource-failed"))
+    def paintEvent(self, event):
+        current_item = self._list_view.currentItem()
+        current = (
+            current_item is not None
+            and self._list_view.itemWidget(current_item) is self
+        )
+        if current or self._hovered:
+            painter = QPainter(self)
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+            color = self.palette().color(QPalette.ColorRole.Highlight)
+            color.setAlpha(42 if current else 24)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(color)
+            painter.drawRoundedRect(
+                QRectF(self.rect()).adjusted(2, 2, -2, -2),
+                SurfaceRadius,
+                SurfaceRadius,
+            )
+            painter.end()
+        super().paintEvent(event)
 
 
-class AISongListWidget(QWidget):
-    """Container widget to display AISongModel list."""
-
+class AIArtifactSongListView(QListWidget):
     def __init__(self, app: "GuiApp", parent=None):
         super().__init__(parent=parent)
         self._app = app
+        self._suggestion_by_display_song = {}
+        self._radius = SurfaceRadius
+        self.setMinimumWidth(280)
+        self.setMaximumWidth(360)
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setResizeMode(QListWidget.ResizeMode.Adjust)
+        self.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        self.setMouseTracking(True)
+        self.setSpacing(4)
+        self.setStyleSheet(
+            """
+            AIArtifactSongListView {
+                background: transparent;
+                border: 0;
+                outline: none;
+            }
+            AIArtifactSongListView::item {
+                background: transparent;
+            }
+            """
+        )
+        self.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self.currentItemChanged.connect(self._on_current_item_changed)
 
-        self._title_label = QLabel(t("ai-chat-track-candidate-list"))
-        self._title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self._list_widget = QListWidget(self)
-        self._list_widget.setFrameShape(QFrame.Shape.NoFrame)
-        self._list_widget.setSelectionMode(QListWidget.SelectionMode.NoSelection)
-        self._list_widget.setResizeMode(QListWidget.ResizeMode.Adjust)
-        self._list_widget.setAlternatingRowColors(True)
+    def set_artifact(self, artifact):
+        self.clear()
+        self._suggestion_by_display_song = {}
+        for index, suggestion in enumerate(artifact.songs):
+            display_song = _song_suggestion_to_display_song(
+                suggestion, f"{artifact.identifier}-{index}"
+            )
+            self._suggestion_by_display_song[display_song] = suggestion
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(5, 5, 5, 5)
-        layout.setSpacing(10)
-        layout.addWidget(self._title_label)
-        layout.addWidget(self._list_widget)
+            list_item = QListWidgetItem(self)
+            list_item.setData(Qt.ItemDataRole.UserRole, display_song)
+            list_item.setSizeHint(QSize(260, SongSuggestionItemWidget.row_height))
+            self.addItem(list_item)
+            item_widget = SongSuggestionItemWidget(display_song, self)
+            item_widget.play_btn.clicked.connect(
+                lambda _checked=False, song=display_song: self._play_display_song(song)
+            )
+            item_widget.add_btn.clicked.connect(
+                lambda _checked=False, song=display_song: aio.run_afn(
+                    self._add_display_song, song
+                )
+            )
+            self.setItemWidget(list_item, item_widget)
 
-        self.setAutoFillBackground(True)
+    def paintEvent(self, event):
+        draw_round_surface(self.viewport(), self._radius, QPalette.ColorRole.Base)
+        super().paintEvent(event)
 
-    def set_ai_songs(self, ai_songs: List[AISongModel]):
-        self._clear_items()
-        for ai_song in ai_songs:
-            item = AISongItemWidget(self._app, ai_song, parent=self)
-            list_item = QListWidgetItem(self._list_widget)
-            width = self._get_width_for_items()
-            list_item.setSizeHint(QSize(width, item.height_for_width(width)))
-            self._list_widget.addItem(list_item)
-            self._list_widget.setItemWidget(list_item, item)
-
-    def _clear_items(self):
-        self._list_widget.clear()
-
-    def _get_width_for_items(self):
-        margins = self.layout().contentsMargins()
-        return self.width() - ScrollBarWidth * 2 - margins.left() - margins.right()
-
-    def resizeEvent(self, event: QResizeEvent):
-        """Update item sizes when widget is resized."""
-        super().resizeEvent(event)
-        self._update_item_sizes()
-
-    def _update_item_sizes(self):
-        """Update all item sizes based on current viewport width."""
-        width = self._get_width_for_items()
-        if width <= 0:
+    def contextMenuEvent(self, event):
+        item = self.itemAt(event.pos()) or self.currentItem()
+        if item is None:
             return
 
-        for i in range(self._list_widget.count()):
-            list_item = self._list_widget.item(i)
-            item_widget = self._list_widget.itemWidget(list_item)
-            if item_widget is not None:
-                height = item_widget.height_for_width(width)
-                list_item.setSizeHint(QSize(width, height))
+        self.setCurrentItem(item)
+        song = item.data(Qt.ItemDataRole.UserRole)
+        menu = QMenu(self)
+        action = menu.addAction(t("ai-chat-link-search"))
+        action.setObjectName("ai-chat-link-search")
+        action.triggered.connect(lambda: self._show_search(song))
+        action = menu.addAction(t("ai-chat-link-play"))
+        action.setObjectName("ai-chat-link-play")
+        action.triggered.connect(lambda: self._play_display_song(song))
+        action = menu.addAction(t("add-to-playlist"))
+        action.setObjectName("ai-chat-link-add-to-playlist")
+        action.triggered.connect(lambda: aio.run_afn(self._add_display_song, song))
+        menu.exec(event.globalPos())
+
+    def _on_item_double_clicked(self, item):
+        song = item.data(Qt.ItemDataRole.UserRole)
+        if song is not None:
+            self._play_display_song(song)
+
+    def _on_current_item_changed(self, current, previous):
+        for item in (current, previous):
+            if item is not None:
+                widget = self.itemWidget(item)
+                if widget is not None:
+                    widget.update()
+
+    def _show_search(self, song: BriefSongModel):
+        view = create_search_result_view(self._app, song)
+        view.show()
+
+    def _play_display_song(self, song: BriefSongModel):
+        aio.run_afn(self._match_and_play, song)
+
+    async def _match_and_play(self, song: BriefSongModel):
+        matched = await self._match_display_song(song)
+        if matched is None:
+            self._show_search(song)
+            self._app.show_msg(t("ai-chat-song-match-failed"))
+            return
+        self._app.playlist.play_model(matched)
+
+    async def _add_display_song(self, song: BriefSongModel):
+        matched = await self._match_display_song(song)
+        if matched is None:
+            self._show_search(song)
+            self._app.show_msg(t("ai-chat-song-match-failed"))
+            return
+        self._app.playlist.add(matched)
+
+    async def _match_display_song(self, song: BriefSongModel):
+        suggestion = self._suggestion_by_display_song.get(song)
+        if suggestion is None:
+            return None
+        return await self._app.ai.get_copilot().match_song_suggestion(suggestion)
+
+
+class AIArtifactSidebar(QWidget):
+    def __init__(self, app: "GuiApp", parent=None):
+        super().__init__(parent=parent)
+        self._app = app
+        self._song_list_view = AIArtifactSongListView(app, self)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._song_list_view, 1)
+
+    def set_artifact(self, artifact):
+        self._song_list_view.set_artifact(artifact)
+
+
+def _apply_surface_palette(widget, color):
+    pal = QPalette(QGuiApplication.palette())
+    for group in (
+        QPalette.ColorGroup.Active,
+        QPalette.ColorGroup.Inactive,
+        QPalette.ColorGroup.Disabled,
+    ):
+        pal.setColor(group, QPalette.ColorRole.Window, color)
+        pal.setColor(group, QPalette.ColorRole.Base, color)
+    widget.setPalette(pal)
+    widget.setAutoFillBackground(True)
+
+
+def _apply_transparent_surface_palette(widget, color):
+    _apply_surface_palette(widget, color)
+    widget.setAutoFillBackground(False)
+
+
+def _apply_scroll_surface_palette(widget, color):
+    _apply_surface_palette(widget, color)
+    viewport = widget.viewport()
+    viewport.setPalette(widget.palette())
+    viewport.setAutoFillBackground(True)
+
+
+def _connect_theme_changed(theme_mgr, receiver):
+    try:
+        theme_mgr.theme_changed.connect(receiver, weak=False)
+    except TypeError:
+        theme_mgr.theme_changed.connect(receiver)
+
+
+class DraggableToolbar(QWidget):
+    def mousePressEvent(self, event):
+        window = self._window_handle()
+        if event.button() == Qt.MouseButton.LeftButton and window is not None:
+            if window.startSystemMove():
+                event.accept()
+                return
+        super().mousePressEvent(event)
+
+    def _window_handle(self):
+        return self.window().windowHandle()
+
+
+class ToolbarSeparator(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setFixedHeight(1)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        color = surface_border_color(self.palette(), QPalette.ColorRole.Base)
+        painter.fillRect(QRectF(self.rect()), color)
+        painter.end()
+
+
+class SidebarPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setAutoFillBackground(False)
+
+    def paintEvent(self, event):
+        draw_round_surface(self, SurfaceRadius)
+        super().paintEvent(event)
+
+
+class SidebarShadow(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setFixedWidth(10)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        gradient = QLinearGradient(0, 0, self.width(), 0)
+        shadow = self.palette().color(QPalette.ColorRole.Shadow)
+        shadow.setAlpha(38)
+        transparent = shadow
+        transparent.setAlpha(0)
+        gradient.setColorAt(0.0, transparent)
+        gradient.setColorAt(0.65, transparent)
+        gradient.setColorAt(1.0, shadow)
+        painter.fillRect(QRectF(self.rect()), gradient)
+        painter.end()
 
 
 class AIChatBox(QWidget):
-    """
-    A lightweight AI chat UI for the AI Radio page.
-    This only provides UI; real message sending is intentionally left empty.
-    """
+    """A lightweight AI assistant UI."""
+
+    artifact_added = pyqtSignal(object)
+    working_state_changed = pyqtSignal(bool)
+    playlist_sidebar_requested = pyqtSignal()
 
     def __init__(self, app, parent=None):
         super().__init__(parent=parent)
         self._app = app
         self.copilot = self._app.ai.get_copilot()
 
-        self._header = MidHeader(t("ai-chat-header"))
-        self._new_thread_btn = PlusButton(length=12)
-        self._new_thread_btn.setToolTip(t("ai-chat-new"))
         self.history_widget = ChatHistoryWidget(self)
         self.input_widget = ChatInputWidget(self)
+        self._collecting_artifacts = False
+        self._pending_artifacts = []
 
         self.input_widget.send_clicked.connect(
             lambda q: aio.run_afn_ref(self.exec_user_query, q)
         )
-        self._new_thread_btn.clicked.connect(self.on_new_thread_btn_clicked)
-        self.copilot.working_state_changed.connect(self.on_working_state_changed)
+        self.working_state_changed.connect(self.on_working_state_changed)
+        self.artifact_added.connect(self.on_artifact_added)
+        self.copilot.working_state_changed.connect(
+            self.working_state_changed.emit,
+            weak=False,
+        )
+        self.copilot.artifact_added.connect(
+            self.artifact_added.emit,
+            weak=False,
+        )
+        self._app.playlist.mode_changed.connect(self._refresh_context)
         self.setup_ui()
+        self._refresh_context()
 
     def setup_ui(self):
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(8)
-        header_layout = QHBoxLayout()
-        header_layout.addWidget(self._header)
-        header_layout.addWidget(self._new_thread_btn)
-        header_layout.addStretch(0)
-        layout.addLayout(header_layout)
         layout.addWidget(self.history_widget)
         layout.addWidget(self.input_widget)
 
@@ -243,71 +497,529 @@ class AIChatBox(QWidget):
         self.history_widget.add_message("user", query)
         self.history_widget.scroll_to_bottom()
 
+        status_card = self.history_widget.add_streaming_status(
+            t("ai-chat-stream-thinking")
+        )
         current_label = None
         response_message = ""
         last_update_ts = time.time()
+        seen_tool = False
+        pre_tool_stream_threshold = 16
+        failed = False
+        self._collecting_artifacts = True
+        self._pending_artifacts = []
 
-        async for token, metadata in self.copilot.astream_user_query(query):
-            node = metadata["langgraph_node"]
-            if node == "model":
-                if current_label is None:
-                    current_label = self.history_widget.create_message_label(
-                        "assistant", ""
+        try:
+            async for token, metadata in self.copilot.astream_user_query(query):
+                node = metadata["langgraph_node"]
+                if node == "model":
+                    status_card.set_status(t("ai-chat-stream-writing"))
+                    for block in token.content_blocks:
+                        if block["type"] == "text":
+                            response_message += block["text"]
+
+                    if (
+                        current_label is None
+                        and (seen_tool or len(response_message.strip()) >=
+                             pre_tool_stream_threshold)
+                    ):
+                        current_label = self.history_widget.create_message_label(
+                            "assistant", ""
+                        )
+                        self.history_widget.move_history_widget_to_bottom(status_card)
+                    if current_label is not None and last_update_ts + 0.2 <= time.time():
+                        current_label.setText(response_message)
+                        self.history_widget.scroll_to_bottom()
+                        last_update_ts = time.time()
+                elif node == "tools":
+                    status_card.set_status(
+                        t("ai-chat-stream-tool", tool=token.name)
                     )
-                for block in token.content_blocks:
-                    if block["type"] == "text":
-                        response_message += block["text"]
-                if last_update_ts + 0.2 <= time.time():
-                    current_label.setText(response_message)
-                    self.history_widget.scroll_to_bottom()
-                    last_update_ts = time.time()
-            elif node == "tools":
-                self.history_widget.create_message_label(
-                    "tools", f"tools: {token.name}"
-                )
-                current_label = None
+                    if token.name.startswith(
+                        ("ai_radio_", "fm_candidates_")
+                    ):
+                        self.playlist_sidebar_requested.emit()
+                    if current_label is not None and response_message.strip():
+                        current_label.set_markdown(response_message)
+                    self.history_widget.add_tool_event(
+                        t("ai-chat-tool-called", tool=token.name)
+                    )
+                    current_label = None
+                    response_message = ""
+                    seen_tool = True
+        except Exception:
+            logger.exception("exec_user_query failed")
+            failed = True
+            if current_label is not None and response_message:
+                current_label.setText(response_message)
+            status_card.finish(t("ai-chat-stream-failed"))
+        finally:
+            self._collecting_artifacts = False
 
-        if current_label is not None:
-            current_label.setText(response_message)
+        if failed:
+            self._flush_pending_artifacts()
+            self.history_widget.scroll_to_bottom()
+            return
+
+        self.history_widget.remove_history_widget(status_card)
+
+        # Final rendering: parse accumulated text as markdown
+        if response_message.strip():
+            if current_label is None:
+                current_label = self.history_widget.create_message_label(
+                    "assistant", ""
+                )
+            current_label.set_markdown(response_message)
+
+        self._flush_pending_artifacts()
         self.history_widget.scroll_to_bottom()
 
     def on_new_thread_btn_clicked(self):
         self.copilot.new_thread()
+        self._pending_artifacts = []
         self.history_widget.clear()
 
     def on_working_state_changed(self, working: bool):
         self.input_widget.enable_send(not working)
+
+    def on_artifact_added(self, artifact):
+        if self._collecting_artifacts:
+            self._pending_artifacts.append(artifact)
+        else:
+            self.history_widget.add_artifact(artifact)
+
+    def _flush_pending_artifacts(self):
+        for artifact in self._pending_artifacts:
+            self.history_widget.add_artifact(artifact)
+        self._pending_artifacts = []
+
+    def _get_active_ai_radio(self):
+        return self._app.ai.get_active_radio()
+
+    def _refresh_context(self, *_):
+        if self._get_active_ai_radio() is not None:
+            self.input_widget.set_placeholder(t("ai-radio-input-placeholder"))
+            self.input_widget.set_msg(t("ai-radio-chat-hint"))
+        else:
+            self.input_widget.set_placeholder(t("ai-chat-input-placeholder"))
+            self.input_widget.set_msg("")
 
 
 class Body(QWidget):
     def __init__(self, app: "GuiApp"):
         super().__init__(parent=None)
         self._app = app
-        copilot = self._app.ai.get_copilot()
-        copilot.candidates_changed.connect(
-            self.on_copilot_candidates_changed, aioqueue=True)
-
-        self._list_widget = AISongListWidget(app, self)
+        self._connected_ai_radio = None
+        self._updating_palette = False
+        self._palette_refresh_scheduled = False
+        self._palette_ready = False
+        self._header = MidHeader(t("ai-chat-header"))
+        self._radio_status_label = QLabel(t("ai-radio-active-status"))
+        self._new_thread_btn = TextButton(t("ai-chat-new"), height=26)
+        self._sidebar_btn = TextButton(t("ai-chat-open-sidebar"), height=26)
+        self._collapse_btn = TextButton(t("fold-collapse"), height=26)
         self._chat_box = AIChatBox(app)
+        self._playlist_sidebar = PlayerPlaylistView(
+            self._app,
+            row_height=60,
+            no_scroll_v=False,
+        )
+        self._playlist_sidebar.setMinimumWidth(280)
+        self._playlist_sidebar.setMaximumWidth(360)
+        self._playlist_sidebar.setItemDelegate(
+            FMCandidatePlaylistDelegate(
+                self._app,
+                self._playlist_sidebar,
+                card_min_width=260,
+                card_height=40,
+                card_padding=(5 + SongMiniCardListDelegate.img_padding, 5, 0, 5),
+                card_right_spacing=10,
+            )
+        )
+        self._artifact_sidebar = AIArtifactSidebar(self._app)
+        self._right_sidebar_stack = QStackedWidget(self)
+        self._right_sidebar_stack.setMinimumWidth(280)
+        self._right_sidebar_stack.setMaximumWidth(360)
+        self._right_sidebar_stack.addWidget(self._playlist_sidebar)
+        self._right_sidebar_stack.addWidget(self._artifact_sidebar)
+        self._sidebar_panel = SidebarPanel(self)
+        self._sidebar_panel.setMinimumWidth(300)
+        self._sidebar_panel.setMaximumWidth(380)
+        self._sidebar_header = QLabel(t("playlist"))
+        self._sidebar_status_label = QLabel("")
+        self._sidebar_status_label.setWordWrap(True)
+        self._sidebar_status_label.hide()
+        header_font = self._sidebar_header.font()
+        header_font.setPixelSize(13)
+        header_font.setWeight(QFont.Weight.DemiBold)
+        self._sidebar_header.setFont(header_font)
+        self._sidebar_header.setStyleSheet("padding: 0 2px;")
+        self._sidebar_layout = QVBoxLayout(self._sidebar_panel)
+        self._sidebar_layout.setContentsMargins(12, 10, 12, 12)
+        self._sidebar_layout.setSpacing(8)
+        self._sidebar_layout.addWidget(self._sidebar_header)
+        self._sidebar_layout.addWidget(self._right_sidebar_stack, 1)
+        self._sidebar_layout.addWidget(self._sidebar_status_label)
+        self._sidebar_panel.hide()
+        self._sidebar_shadow = SidebarShadow(self)
+        self._sidebar_shadow.hide()
 
-        self._layout = QHBoxLayout(self)
-        self._layout.setContentsMargins(10, 10, 10, 10)
+        self._new_thread_btn.clicked.connect(self._chat_box.on_new_thread_btn_clicked)
+        self._sidebar_btn.clicked.connect(self.toggle_sidebar)
+        self._collapse_btn.clicked.connect(self._collapse_overlay)
+        self._chat_box.playlist_sidebar_requested.connect(self.show_playlist_sidebar)
+        self._chat_box.history_widget.artifact_clicked.connect(self.show_artifact)
+        self._chat_box.history_widget.link_activated.connect(self._on_link_activated)
+        self._chat_box.history_widget.link_context_menu_requested.connect(
+            self._on_link_context_menu_requested
+        )
+        self._app.playlist.mode_changed.connect(self._refresh_context)
+
+        self._layout = QVBoxLayout(self)
+        if IS_MACOS:
+            self._layout.setContentsMargins(86, 10, 10, 10)
+        else:
+            self._layout.setContentsMargins(10, 10, 10, 10)
         self._layout.setSpacing(10)
-        self._layout.addWidget(self._chat_box)
-        self._layout.addWidget(self._list_widget)
-        self._layout.setStretch(0, 2)
-        self._layout.setStretch(1, 1)
-        self.setAutoFillBackground(True)
+        self._toolbar = DraggableToolbar(self)
+        self._toolbar_separator = ToolbarSeparator(self)
+        self._toolbar_layout = QHBoxLayout(self._toolbar)
+        self._content_layout = QHBoxLayout()
+        self._toolbar_layout.setContentsMargins(0, 0, 0, 0)
+        self._toolbar_layout.addWidget(self._header)
+        self._toolbar_layout.addStretch(0)
+        self._toolbar_layout.addWidget(self._radio_status_label)
+        self._toolbar_layout.addWidget(self._new_thread_btn)
+        self._toolbar_layout.addWidget(self._sidebar_btn)
+        self._toolbar_layout.addWidget(self._collapse_btn)
 
-    def on_copilot_candidates_changed(self, candidates):
-        self._list_widget.set_ai_songs(candidates)
+        self.setAutoFillBackground(True)
+        self._apply_palette()
+        self._playlist_sidebar.setAutoFillBackground(False)
+        self._playlist_sidebar.viewport().setAutoFillBackground(False)
+        self._playlist_sidebar.setStyleSheet(
+            """
+            PlayerPlaylistView {
+                background: transparent;
+                outline: none;
+                border: 0;
+            }
+            PlayerPlaylistView::item:selected,
+            PlayerPlaylistView::item:hover {
+                background: transparent;
+            }
+            """
+        )
+        for btn in (self._new_thread_btn, self._sidebar_btn, self._collapse_btn):
+            btn.setStyleSheet("border-radius: 8px;")
+
+        self._content_layout.addWidget(self._chat_box)
+        self._content_layout.addWidget(self._sidebar_shadow)
+        self._content_layout.addWidget(self._sidebar_panel)
+        self._content_layout.setContentsMargins(0, 0, 0, 0)
+        self._content_layout.setSpacing(0)
+        self._content_layout.setStretch(0, 1)
+        self._content_layout.setStretch(1, 0)
+        self._content_layout.setStretch(2, 0)
+        self._layout.addWidget(self._toolbar)
+        self._layout.addWidget(self._toolbar_separator)
+        self._layout.addLayout(self._content_layout, 1)
+        self.setAutoFillBackground(True)
+        self._refresh_context()
+        self._palette_ready = True
+        self._apply_palette()
+        _connect_theme_changed(self._app.theme_mgr, self._on_theme_changed)
+        self._apply_palette()
+
+    def _on_theme_changed(self, _theme):
+        self._schedule_palette_refresh(force=True)
+
+    def _schedule_palette_refresh(self, force=False):
+        if not self._palette_ready:
+            return
+        if self._palette_refresh_scheduled and not force:
+            return
+        self._palette_refresh_scheduled = True
+        self._apply_palette()
+        QTimer.singleShot(0, self._apply_scheduled_palette)
+
+    def _apply_scheduled_palette(self):
+        self._palette_refresh_scheduled = False
+        self._apply_palette()
+
+    def _apply_palette(self):
+        if not self._palette_ready:
+            return
+        if self._updating_palette:
+            return
+        self._updating_palette = True
+        try:
+            app_pal = QPalette(QGuiApplication.palette())
+            base_color = app_pal.color(QPalette.ColorRole.Base)
+            window_color = app_pal.color(QPalette.ColorRole.Window)
+
+            body_pal = QPalette(app_pal)
+            for group in (
+                QPalette.ColorGroup.Active,
+                QPalette.ColorGroup.Inactive,
+                QPalette.ColorGroup.Disabled,
+            ):
+                body_pal.setColor(group, QPalette.ColorRole.Window, base_color)
+                body_pal.setColor(group, QPalette.ColorRole.Base, base_color)
+            self.setPalette(body_pal)
+
+            _apply_transparent_surface_palette(
+                self._right_sidebar_stack, window_color
+            )
+            _apply_transparent_surface_palette(self._sidebar_panel, window_color)
+            _apply_surface_palette(self._artifact_sidebar, window_color)
+            _apply_scroll_surface_palette(self._playlist_sidebar, window_color)
+            _apply_scroll_surface_palette(
+                self._artifact_sidebar._song_list_view, base_color
+            )
+            self._playlist_sidebar.setAutoFillBackground(False)
+            self._playlist_sidebar.viewport().setAutoFillBackground(False)
+            self._artifact_sidebar._song_list_view.setAutoFillBackground(False)
+            self._artifact_sidebar._song_list_view.viewport().setAutoFillBackground(
+                False
+            )
+            self._chat_box.history_widget._apply_palette()
+            self._chat_box.input_widget._apply_palette()
+            self._refresh_artist_labels()
+
+            radio_pal = QPalette(app_pal)
+            secondary_color = secondary_text_color(app_pal)
+            radio_pal.setColor(QPalette.ColorRole.WindowText, secondary_color)
+            radio_pal.setColor(QPalette.ColorRole.Text, secondary_color)
+            self._radio_status_label.setPalette(radio_pal)
+            self._sidebar_status_label.setPalette(radio_pal)
+            self._sidebar_shadow.setPalette(body_pal)
+            self.update()
+            self._toolbar_separator.update()
+            self._sidebar_panel.update()
+            self._right_sidebar_stack.update()
+            self._artifact_sidebar.update()
+            self._artifact_sidebar._song_list_view.update()
+            self._artifact_sidebar._song_list_view.viewport().update()
+        finally:
+            self._updating_palette = False
+
+    def _refresh_artist_labels(self):
+        for item_widget in self._artifact_sidebar._song_list_view.findChildren(
+            SongSuggestionItemWidget
+        ):
+            item_widget._apply_palette()
+
+    def toggle_sidebar(self):
+        if (
+            self._sidebar_panel.isVisible()
+            and self._right_sidebar_stack.currentWidget() is self._playlist_sidebar
+        ):
+            self.set_sidebar_visible(False)
+        else:
+            self.set_sidebar_visible(True)
+
+    def set_sidebar_visible(self, visible: bool):
+        if visible:
+            self.show_playlist_sidebar()
+        else:
+            self._sidebar_shadow.hide()
+            self._right_sidebar_stack.hide()
+            self._sidebar_panel.hide()
+
+    def show_playlist_sidebar(self):
+        self._right_sidebar_stack.setCurrentWidget(self._playlist_sidebar)
+        self._sidebar_header.setText(t("playlist"))
+        self._sync_sidebar_status_visibility()
+        self._sidebar_shadow.show()
+        self._right_sidebar_stack.show()
+        self._sidebar_panel.show()
+        self._playlist_sidebar.scroll_to_current_song(
+            QAbstractItemView.ScrollHint.PositionAtTop
+        )
+
+    def show_artifact(self, artifact):
+        self._artifact_sidebar.set_artifact(artifact)
+        self._sidebar_header.setText(
+            artifact.title or t("ai-chat-artifact-sidebar-title")
+        )
+        self._right_sidebar_stack.setCurrentWidget(self._artifact_sidebar)
+        self._sync_sidebar_status_visibility()
+        self._sidebar_shadow.show()
+        self._right_sidebar_stack.show()
+        self._sidebar_panel.show()
+
+    def _on_link_activated(self, url: str):
+        link = parse_song_link_info(url)
+        if link is None:
+            return
+        if link.kind == "suggestion":
+            self._show_link_search(link.model)
+        else:
+            aio.run_afn(self._play_link_model, link.model)
+
+    def _on_link_context_menu_requested(self, url: str, global_pos):
+        link = parse_song_link_info(url)
+        if link is None:
+            return
+
+        menu = QMenu(self)
+        model = link.model
+        if link.kind == "suggestion":
+            action = menu.addAction(t("ai-chat-link-search"))
+            action.setObjectName("ai-chat-link-search")
+            action.triggered.connect(lambda: self._show_link_search(model))
+        action = menu.addAction(t("ai-chat-link-play"))
+        action.setObjectName("ai-chat-link-play")
+        action.triggered.connect(lambda: aio.run_afn(self._play_link_model, model))
+        action = menu.addAction(t("add-to-playlist"))
+        action.setObjectName("ai-chat-link-add-to-playlist")
+        action.triggered.connect(lambda: aio.run_afn(self._add_link_model, model))
+        menu.addSeparator()
+        action = menu.addAction(t("ai-chat-link-copy"))
+        action.setObjectName("ai-chat-link-copy")
+        action.triggered.connect(lambda: QGuiApplication.clipboard().setText(url))
+        menu.exec(global_pos)
+
+    def _show_link_search(self, model):
+        song = self._model_to_search_song(model)
+        if song is None:
+            return
+        view = create_search_result_view(self._app, song)
+        view.show()
+
+    async def _play_link_model(self, model):
+        song = await self._model_to_playable_song(model)
+        if song is None:
+            self._show_link_search(model)
+            self._app.show_msg(t("ai-chat-song-match-failed"))
+            return
+        self._app.playlist.play_model(song)
+
+    async def _add_link_model(self, model):
+        song = await self._model_to_playable_song(model)
+        if song is None:
+            self._show_link_search(model)
+            self._app.show_msg(t("ai-chat-song-match-failed"))
+            return
+        self._app.playlist.add(song)
+
+    async def _model_to_playable_song(self, model):
+        if isinstance(model, SongSuggestion):
+            return await self._app.ai.get_copilot().match_song_suggestion(model)
+        return model
+
+    def _model_to_search_song(self, model):
+        if isinstance(model, SongSuggestion):
+            return _song_suggestion_to_display_song(
+                model, song_suggestion_to_markdown_url(model)
+            )
+        return model
+
+    def _collapse_overlay(self):
+        parent = self.parent()
+        while parent is not None:
+            if isinstance(parent, AppOverlayContainer):
+                parent.hide()
+                return
+            parent = parent.parent()
+
+    def _get_active_ai_radio(self):
+        return self._app.ai.get_active_radio()
+
+    def _refresh_context(self, *_):
+        self._header.setText(t("ai-chat-header"))
+        if self._get_active_ai_radio() is not None:
+            self._radio_status_label.show()
+        else:
+            self._radio_status_label.hide()
+        self._connect_ai_radio_status()
+        self._sync_sidebar_status_visibility()
+
+    def _connect_ai_radio_status(self):
+        ai_radio = self._get_active_ai_radio()
+        if ai_radio is self._connected_ai_radio:
+            return
+        if self._connected_ai_radio is not None:
+            self._connected_ai_radio.status_changed.disconnect(
+                self._on_ai_radio_status_changed
+            )
+        self._connected_ai_radio = ai_radio
+        if ai_radio is not None:
+            ai_radio.status_changed.connect(
+                self._on_ai_radio_status_changed, weak=False
+            )
+            self._on_ai_radio_status_changed(ai_radio.status)
+        else:
+            self._on_ai_radio_status_changed("")
+
+    def _on_ai_radio_status_changed(self, status):
+        self._sidebar_status_label.setText(status)
+        self._sync_sidebar_status_visibility()
+
+    def _sync_sidebar_status_visibility(self):
+        visible = (
+            self._right_sidebar_stack.currentWidget() is self._playlist_sidebar
+            and bool(self._sidebar_status_label.text())
+        )
+        self._sidebar_status_label.setVisible(visible)
+
+
+class AIChatOverlay(AppOverlayContainer):
+    def __init__(self, app: "GuiApp", body: Body, parent=None):
+        super().__init__(
+            app,
+            body,
+            parent=parent,
+            options=AppOverlayOptions(
+                margins=QMargins(0, 0, 0, 0),
+                dim_background=False,
+                close_on_focus_in=False,
+            ),
+        )
+        self._titlebar_mode = _create_titlebar_mode(app)
+        self._titlebar_reapply_scheduled = False
+        self.body._schedule_palette_refresh(force=True)
+
+    def showEvent(self, event):
+        if self._titlebar_mode is not None:
+            self._titlebar_mode.enter()
+        super().showEvent(event)
+        self.body._schedule_palette_refresh(force=True)
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        if self._titlebar_mode is not None:
+            self._titlebar_mode.exit()
+
+    def eventFilter(self, obj, event):
+        result = super().eventFilter(obj, event)
+        if (
+            self.isVisible()
+            and obj == self._app
+            and self._titlebar_mode is not None
+            and event.type()
+            in (QEvent.Type.Resize, QEvent.Type.WindowStateChange)
+        ):
+            self._schedule_titlebar_reapply()
+        return result
+
+    def _schedule_titlebar_reapply(self):
+        if self._titlebar_reapply_scheduled:
+            return
+        self._titlebar_reapply_scheduled = True
+        QTimer.singleShot(0, self._reapply_titlebar_mode)
+
+    def _reapply_titlebar_mode(self):
+        self._titlebar_reapply_scheduled = False
+        if self.isVisible() and self._titlebar_mode is not None:
+            self._titlebar_mode.reapply()
 
 
 def create_aichat_overlay(app: "GuiApp", parent=None) -> AppOverlayContainer:
     """Create an overlay for the AI chat"""
     body = Body(app)
-    overlay = AppOverlayContainer(app, body, parent=parent)
-    return overlay
+    return AIChatOverlay(app, body, parent=parent)
 
 
 if __name__ == "__main__":
@@ -316,22 +1028,8 @@ if __name__ == "__main__":
     with simple_layout(theme="dark") as layout, mock_app() as app:
         app.size.return_value = QSize(600, 400)
         overlay = create_aichat_overlay(app)
-        long_description = (
-            "Very long description"
-            "Ahhhhhhhhhhhhhhhhhhhhhhhhhhhhhh"
-            "Ahhhhhhhhhhhhhhhhhhhhhhhhhhhhhh"
-        )
-        sample_ai_songs = [
-            AISongModel(
-                title="Song A", artists_name="Artist A", description=long_description
-            ),
-            AISongModel(title="Song B", artists_name="Artist B", description="Desc B"),
-            AISongModel(title="Song C", artists_name="Artist C", description="Desc C"),
-        ]
-
         overlay.body._chat_box.history_widget.add_message("user", "hello world")
         overlay.body._chat_box.history_widget.add_message("assistant", "Hi, 我是你的音乐助手")
         overlay.body._chat_box.history_widget.add_message("tools", "tools: play_model")
-        overlay.body._list_widget.set_ai_songs(sample_ai_songs)
         overlay.show()
         layout.addWidget(overlay)

--- a/feeluown/gui/uimain/playlist_overlay.py
+++ b/feeluown/gui/uimain/playlist_overlay.py
@@ -16,7 +16,10 @@ from PyQt6.QtGui import (
 from feeluown.i18n import t
 from feeluown.player import PlaybackMode, SongsRadio
 from feeluown.gui.helpers import fetch_cover_wrapper, esc_hide_widget
-from feeluown.gui.components.player_playlist import PlayerPlaylistView
+from feeluown.gui.components.player_playlist import (
+    PlayerPlaylistView,
+    FMCandidatePlaylistDelegate,
+)
 from feeluown.gui.widgets.textbtn import TextButton
 from feeluown.gui.widgets.tabbar import TabBar
 from feeluown.gui.widgets.song_minicard_list import (
@@ -53,12 +56,14 @@ class PlaylistOverlay(QWidget):
         self._playback_mode_switch = PlaybackModeSwitch(app)
         self._goto_current_song_btn = TextButton(t("jump-to-playing-track"))
         self._songs_radio_btn = TextButton(t("song-radio-mode"))
+        self._ai_radio_btn = TextButton(t("ai-radio-title"))
         # Please update the list when you add new buttons.
         self._btns = [
             self._clear_playlist_btn,
             self._playback_mode_switch,
             self._goto_current_song_btn,
             self._songs_radio_btn,
+            self._ai_radio_btn,
         ]
         self._stacked_layout = QStackedLayout()
         self._shadow_width = 15
@@ -72,6 +77,12 @@ class PlaylistOverlay(QWidget):
         self._clear_playlist_btn.clicked.connect(self._app.playlist.clear)
         self._goto_current_song_btn.clicked.connect(self.goto_current_song)
         self._songs_radio_btn.clicked.connect(self.enter_songs_radio)
+        self._ai_radio_btn.clicked.connect(self.enter_ai_radio)
+        if self._app.ai is None:
+            self._ai_radio_btn.setDisabled(True)
+            self._ai_radio_btn.setToolTip(t("ai-configure-tooltip"))
+        else:
+            self._ai_radio_btn.setToolTip(t("ai-radio-activate-tooltip"))
         esc_hide_widget(self)
         q_app = QApplication.instance()
         assert q_app is not None  # make type checker happy.
@@ -105,6 +116,7 @@ class PlaylistOverlay(QWidget):
         self._btn_layout.addWidget(self._playback_mode_switch)
         self._btn_layout.addWidget(self._goto_current_song_btn)
         self._btn_layout2.addWidget(self._songs_radio_btn)
+        self._btn_layout2.addWidget(self._ai_radio_btn)
         self._btn_layout.addStretch(0)
         self._btn_layout2.addStretch(0)
 
@@ -133,6 +145,17 @@ class PlaylistOverlay(QWidget):
             self._app.fm.activate(radio.fetch_songs_func, reset=False)
             self._app.show_msg(t("song-radio-mode-activated"))
 
+    def enter_ai_radio(self):
+        self._app.ai.activate_radio()
+        self._app.show_msg(t("ai-radio-activated"))
+        self._show_ai_chat_overlay()
+
+    def _show_ai_chat_overlay(self):
+        overlay = self._app.ui.ai_chat_overlay
+        if overlay is not None:
+            overlay.show()
+            overlay.raise_()
+
     def show_tab(self, index):
         if not self.isVisible():
             return
@@ -140,6 +163,14 @@ class PlaylistOverlay(QWidget):
         if index == 0:
             self._show_btns()
             view = self._player_playlist_view
+            delegate = FMCandidatePlaylistDelegate(
+                self._app,
+                view,
+                card_min_width=self.width() - self.width() // 6,
+                card_height=40,
+                card_padding=(5 + SongMiniCardListDelegate.img_padding, 5, 0, 5),
+                card_right_spacing=10,
+            )
         else:
             self._hide_btns()
             model = SongMiniCardListModel(
@@ -149,13 +180,13 @@ class PlaylistOverlay(QWidget):
             view = SongMiniCardListView(**self._view_options)
             view.setModel(model)
             view.play_song_needed.connect(self._app.playlist.play_model)
-        delegate = SongMiniCardListDelegate(
-            view,
-            card_min_width=self.width() - self.width() // 6,
-            card_height=40,
-            card_padding=(5 + SongMiniCardListDelegate.img_padding, 5, 0, 5),
-            card_right_spacing=10,
-        )
+            delegate = SongMiniCardListDelegate(
+                view,
+                card_min_width=self.width() - self.width() // 6,
+                card_height=40,
+                card_padding=(5 + SongMiniCardListDelegate.img_padding, 5, 0, 5),
+                card_right_spacing=10,
+            )
         view.setItemDelegate(delegate)
         self._stacked_layout.addWidget(view)
         self._stacked_layout.setCurrentWidget(view)

--- a/feeluown/gui/widgets/ai_chat.py
+++ b/feeluown/gui/widgets/ai_chat.py
@@ -1,23 +1,84 @@
 import logging
 
-from PyQt6.QtCore import QSize, Qt, QRectF, pyqtSignal
-from PyQt6.QtGui import QPainter, QPainterPath, QTextOption
+from PyQt6.QtCore import QPoint, QPointF, QRectF, QSize, Qt, QTimer, pyqtSignal
+from PyQt6.QtGui import (
+    QColor,
+    QGuiApplication,
+    QPainter,
+    QPainterPath,
+    QPen,
+    QPalette,
+    QTextDocument,
+    QTextOption,
+)
 from PyQt6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
     QPlainTextEdit,
+    QPushButton,
     QScrollArea,
     QSizePolicy,
+    QTextBrowser,
     QVBoxLayout,
     QWidget,
 )
 
 from feeluown.i18n import t
-from feeluown.gui.helpers import palette_set_bg_color
+from feeluown.gui.helpers import secondary_text_color
 from feeluown.gui.widgets.textbtn import TextButton
 
 logger = logging.getLogger(__name__)
+
+SurfaceRadius = 8
+
+
+def _application_palette():
+    return QGuiApplication.palette()
+
+
+def _set_text_color(widget, color: QColor):
+    pal = widget.palette()
+    pal.setColor(QPalette.ColorRole.WindowText, color)
+    pal.setColor(QPalette.ColorRole.Text, color)
+    widget.setPalette(pal)
+
+
+def _set_bg_color(widget, color: QColor):
+    pal = QPalette(_application_palette())
+    for group in (
+        QPalette.ColorGroup.Active,
+        QPalette.ColorGroup.Inactive,
+        QPalette.ColorGroup.Disabled,
+    ):
+        pal.setColor(group, QPalette.ColorRole.Window, color)
+        pal.setColor(group, QPalette.ColorRole.Base, color)
+    widget.setPalette(pal)
+
+
+def draw_round_surface(
+    widget,
+    radius=SurfaceRadius,
+    background_role=QPalette.ColorRole.Window,
+):
+    painter = QPainter(widget)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+    path = QPainterPath()
+    rect = QRectF(widget.rect()).adjusted(0.5, 0.5, -0.5, -0.5)
+    path.addRoundedRect(rect, radius, radius)
+    pal = widget.palette()
+    painter.fillPath(path, pal.color(background_role))
+    border_color = surface_border_color(pal, background_role)
+    painter.setPen(border_color)
+    painter.drawPath(path)
+    painter.end()
+
+
+def surface_border_color(palette, background_role=QPalette.ColorRole.Window):
+    bg_color = palette.color(background_role)
+    border_color = palette.color(QPalette.ColorRole.WindowText)
+    border_color.setAlpha(72 if bg_color.lightness() < 128 else 52)
+    return border_color
 
 
 class ChatInputEditor(QPlainTextEdit):
@@ -59,27 +120,310 @@ class ChatInputEditor(QPlainTextEdit):
             super().keyPressEvent(event)
 
 
-class RoundedLabel(QLabel):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._radius = 8
-        self._padding = 8
-        self.setContentsMargins(
-            self._padding, self._padding, self._padding, self._padding
-        )
-        self.setWordWrap(True)
+class ChatSendButton(QPushButton):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setFixedSize(32, 32)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setToolTip(t("ai-chat-send-button"))
+        self.setText("")
 
     def paintEvent(self, event):
         painter = QPainter(self)
-        path = QPainterPath()
-        path.addRoundedRect(QRectF(self.rect()), self._radius, self._radius)
-        # Fill background
-        painter.fillPath(path, self.palette().color(self.backgroundRole()))
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        pal = self.palette()
+        bg_color = pal.color(QPalette.ColorRole.Highlight)
+        arrow_color = pal.color(QPalette.ColorRole.HighlightedText)
+        if not self.isEnabled():
+            bg_color = pal.color(QPalette.ColorRole.Mid)
+            arrow_color = pal.color(QPalette.ColorRole.Window)
+
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(bg_color)
+        painter.drawEllipse(self.rect().adjusted(1, 1, -1, -1))
+
+        pen = QPen(arrow_color, 2)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+        painter.setPen(pen)
+        center_x = self.width() / 2
+        painter.drawLine(QPointF(center_x, 9), QPointF(center_x, 23))
+        painter.drawLine(QPointF(center_x, 9), QPointF(center_x - 6, 15))
+        painter.drawLine(QPointF(center_x, 9), QPointF(center_x + 6, 15))
+        painter.end()
+
+
+class RoundedLabel(QTextBrowser):
+    link_activated = pyqtSignal(str)
+    link_context_menu_requested = pyqtSignal(str, QPoint)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._radius = SurfaceRadius
+        self._padding = 8
+        self._surface_visible = True
+        self.setReadOnly(True)
+        self.setOpenLinks(False)
+        self.setOpenExternalLinks(False)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self.setWordWrapMode(QTextOption.WrapMode.WrapAtWordBoundaryOrAnywhere)
+        self.document().setDocumentMargin(self._padding)
+        self.document().contentsChanged.connect(self._update_height)
+        self.anchorClicked.connect(lambda url: self.link_activated.emit(url.toString()))
+        self.viewport().setAutoFillBackground(False)
+
+    def setWordWrap(self, wrap):  # noqa: N802
+        if wrap:
+            self.setLineWrapMode(QTextBrowser.LineWrapMode.WidgetWidth)
+        else:
+            self.setLineWrapMode(QTextBrowser.LineWrapMode.NoWrap)
+
+    def paintEvent(self, event):
+        if self._surface_visible:
+            painter = QPainter(self.viewport())
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+            path = QPainterPath()
+            rect = QRectF(self.viewport().rect()).adjusted(0.5, 0.5, -0.5, -0.5)
+            path.addRoundedRect(rect, self._radius, self._radius)
+            painter.fillPath(path, self.palette().color(self.backgroundRole()))
+            painter.setPen(surface_border_color(self.palette(), self.backgroundRole()))
+            painter.drawPath(path)
+            painter.end()
         super().paintEvent(event)
+
+    def set_surface_visible(self, visible):
+        self._surface_visible = visible
+        self.update()
+
+    def set_markdown(self, text):
+        document = QTextDocument()
+        document.setMarkdown(text)
+        self.setHtml(document.toHtml())
+        self._update_height()
+
+    def setText(self, text):  # noqa: N802
+        self.setPlainText(text)
+        self._update_height()
+
+    def text(self):
+        return self.toHtml()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._update_height()
+
+    def contextMenuEvent(self, event):
+        href = self.anchorAt(event.pos())
+        if href:
+            self.link_context_menu_requested.emit(href, event.globalPos())
+            event.accept()
+            return
+        super().contextMenuEvent(event)
+
+    def _update_height(self):
+        width = max(1, self.viewport().width())
+        self.document().setTextWidth(width)
+        height = int(self.document().size().height()) + 2
+        self.setMinimumHeight(height)
+        self.setMaximumHeight(height)
+        self.updateGeometry()
+
+
+class ChatMessageRow(QWidget):
+    def __init__(self, role, label, parent=None):
+        super().__init__(parent=parent)
+        self.role = role
+        self.label = label
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        if role == "user":
+            layout.addStretch(1)
+            layout.addWidget(label, 0, Qt.AlignmentFlag.AlignRight)
+        else:
+            layout.addWidget(label)
+
+        self.update_label_width()
+
+    def update_label_width(self):
+        if self.role == "user":
+            available_width = max(1, self.width())
+            max_width = min(available_width, max(240, int(available_width * 0.7)))
+            self.label.setMaximumWidth(max_width)
+        else:
+            self.label.setMaximumWidth(16777215)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self.update_label_width()
+
+
+class ChatArtifactCard(QFrame):
+    clicked = pyqtSignal(object)
+
+    def __init__(self, artifact, parent=None):
+        super().__init__(parent=parent)
+        self.artifact = artifact
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self.setFrameShape(QFrame.Shape.NoFrame)
+
+        title_label = QLabel(artifact.title, self)
+        title_label.setWordWrap(True)
+        subtitle_label = QLabel(
+            t("ai-chat-artifact-songs", count=len(artifact.songs)), self
+        )
+        self._subtitle_label = subtitle_label
+        self._apply_palette()
+        open_btn = TextButton(t("ai-chat-artifact-open"), height=24)
+        open_btn.clicked.connect(lambda: self.clicked.emit(self.artifact))
+
+        text_layout = QVBoxLayout()
+        text_layout.setContentsMargins(0, 0, 0, 0)
+        text_layout.setSpacing(2)
+        text_layout.addWidget(title_label)
+        text_layout.addWidget(subtitle_label)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(10, 8, 10, 8)
+        layout.setSpacing(8)
+        layout.addLayout(text_layout, 1)
+        layout.addWidget(open_btn)
+
+    def _apply_palette(self):
+        _set_text_color(
+            self._subtitle_label,
+            secondary_text_color(_application_palette()),
+        )
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        path = QPainterPath()
+        rect = QRectF(self.rect()).adjusted(0.5, 0.5, -0.5, -0.5)
+        path.addRoundedRect(rect, SurfaceRadius, SurfaceRadius)
+
+        pal = self.palette()
+        # Use Base for a slightly elevated card look
+        card_bg = pal.color(QPalette.ColorRole.Base)
+        painter.fillPath(path, card_bg)
+        painter.setPen(surface_border_color(pal, QPalette.ColorRole.Base))
+        painter.drawPath(path)
+        painter.end()
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit(self.artifact)
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+
+class ChatStreamingStatusCard(QFrame):
+    def __init__(self, text="", parent=None):
+        super().__init__(parent=parent)
+        self._base_text = text
+        self._dots = 0
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+
+        self._label = QLabel(self)
+        self._label.setWordWrap(False)
+        self._label.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+        self._label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self._apply_palette()
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 8, 12, 8)
+        layout.setSpacing(0)
+        layout.addWidget(self._label)
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(500)
+        self._timer.timeout.connect(self._advance)
+        self._timer.start()
+        self._update_text()
+
+    def _apply_palette(self):
+        pal = QPalette(_application_palette())
+        surface_color = pal.color(QPalette.ColorRole.Window)
+        for group in (
+            QPalette.ColorGroup.Active,
+            QPalette.ColorGroup.Inactive,
+            QPalette.ColorGroup.Disabled,
+        ):
+            pal.setColor(group, QPalette.ColorRole.Window, surface_color)
+            pal.setColor(group, QPalette.ColorRole.Base, surface_color)
+        self.setPalette(pal)
+        _set_text_color(self._label, pal.color(QPalette.ColorRole.WindowText))
+        self.update()
+
+    def set_status(self, text):
+        self._base_text = text
+        self._dots = 0
+        self._update_text()
+
+    def text(self):
+        return self._label.text()
+
+    def finish(self, text=None):
+        self._timer.stop()
+        self._dots = 0
+        if text is not None:
+            self._base_text = text
+        self._update_text()
+
+    def paintEvent(self, event):
+        draw_round_surface(
+            self,
+            SurfaceRadius,
+            QPalette.ColorRole.Window,
+        )
+        super().paintEvent(event)
+
+    def _advance(self):
+        self._dots = (self._dots + 1) % 4
+        self._update_text()
+
+    def _update_text(self):
+        self._label.setText(f"{self._base_text}{'.' * self._dots}")
+
+
+class ChatToolEventCard(QWidget):
+    def __init__(self, text="", parent=None):
+        super().__init__(parent=parent)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+
+        self._label = QLabel(text, self)
+        self._label.setWordWrap(True)
+        self._label.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+        self._apply_palette()
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 2, 2, 2)
+        layout.setSpacing(0)
+        layout.addWidget(self._label)
+
+    def _apply_palette(self):
+        _set_text_color(self._label, secondary_text_color(_application_palette()))
+        self.update()
+
+    def text(self):
+        return self._label.text()
 
 
 class ChatHistoryWidget(QWidget):
     """Widget for displaying chat history"""
+
+    artifact_clicked = pyqtSignal(object)
+    link_activated = pyqtSignal(str)
+    link_context_menu_requested = pyqtSignal(str, QPoint)
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
@@ -90,50 +434,149 @@ class ChatHistoryWidget(QWidget):
 
         self._history_area.setFrameShape(QFrame.Shape.NoFrame)
         self._history_area.setAutoFillBackground(True)
+        self._history_area.viewport().setAutoFillBackground(True)
+        self.history_widget.setAutoFillBackground(True)
+        self._apply_palette()
         self._history_layout.setContentsMargins(0, 0, 20, 0)
         self._history_layout.setSpacing(5)
         self._history_area.setWidgetResizable(True)
         # Adjust spacing between messages
         self._history_layout.setSpacing(10)
+        self._history_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self._history_layout.addStretch(0)
 
         layout = QVBoxLayout(self)
         layout.addWidget(self._history_area)
         layout.setContentsMargins(0, 0, 0, 0)
 
+    def _apply_palette(self):
+        pal = _application_palette()
+        bg_color = pal.color(QPalette.ColorRole.Base)
+        self._set_bg_color(self._history_area, bg_color)
+        self._set_bg_color(self._history_area.viewport(), bg_color)
+        self._set_bg_color(self.history_widget, bg_color)
+        for label in self.findChildren(RoundedLabel):
+            row = label.parent()
+            if isinstance(row, ChatMessageRow):
+                self._apply_message_label_palette(label, row.role)
+        for card in self.findChildren(ChatArtifactCard):
+            card._apply_palette()
+        for card in self.findChildren(ChatStreamingStatusCard):
+            card._apply_palette()
+        for card in self.findChildren(ChatToolEventCard):
+            card._apply_palette()
+        self._history_area.update()
+        self._history_area.viewport().update()
+        self.history_widget.update()
+
     def add_message(self, role, content):
         """Add a message to the history"""
         self.create_message_label(role, content)
 
+    def add_artifact(self, artifact):
+        card = ChatArtifactCard(artifact, self)
+        card.clicked.connect(self.artifact_clicked.emit)
+        self._history_layout.addWidget(card)
+        self.scroll_to_bottom()
+        return card
+
+    def add_streaming_status(self, text):
+        status = ChatStreamingStatusCard(text, self)
+        self._history_layout.addWidget(status)
+        self.scroll_to_bottom()
+        return status
+
+    def add_tool_event(self, text):
+        event = ChatToolEventCard(text, self)
+        self._history_layout.addWidget(event)
+        self.scroll_to_bottom()
+        return event
+
+    def remove_history_widget(self, widget):
+        widget = self._history_layout_widget(widget)
+        self._history_layout.removeWidget(widget)
+        widget.hide()
+        widget.setParent(None)
+        widget.deleteLater()
+        self.scroll_to_bottom()
+
+    def move_history_widget_to_bottom(self, widget):
+        widget = self._history_layout_widget(widget)
+        self._history_layout.removeWidget(widget)
+        self._history_layout.addWidget(widget)
+        self.scroll_to_bottom()
+
+    def _history_layout_widget(self, widget):
+        parent = widget.parent()
+        if isinstance(parent, ChatMessageRow):
+            return parent
+        return widget
+
+    def _set_bg_color(self, widget, color: QColor):
+        _set_bg_color(widget, color)
+
+    def _apply_message_label_palette(self, label, role):
+        pal = QPalette(_application_palette())
+        if role == "user":
+            label.setBackgroundRole(QPalette.ColorRole.Window)
+            bg_color = pal.color(QPalette.ColorRole.Window)
+            pal.setColor(QPalette.ColorRole.Window, bg_color)
+            pal.setColor(QPalette.ColorRole.Base, bg_color)
+            label.setPalette(pal)
+            label.update()
+        elif role in ("assistant", "system"):
+            label.setBackgroundRole(QPalette.ColorRole.Base)
+            label.set_surface_visible(False)
+            bg_color = pal.color(QPalette.ColorRole.Base)
+            pal.setColor(QPalette.ColorRole.Window, bg_color)
+            pal.setColor(QPalette.ColorRole.Base, bg_color)
+            label.setPalette(pal)
+            label.update()
+        elif role in ("tools"):
+            text_color = pal.color(QPalette.ColorRole.ToolTipText)
+            bg_color = pal.color(QPalette.ColorRole.ToolTipBase)
+            pal.setColor(QPalette.ColorRole.WindowText, text_color)
+            pal.setColor(QPalette.ColorRole.Text, text_color)
+            pal.setColor(QPalette.ColorRole.Window, bg_color)
+            pal.setColor(QPalette.ColorRole.Base, bg_color)
+            label.setPalette(pal)
+            label.update()
+
     def create_message_label(self, role, content):
         """Create message label"""
         label = RoundedLabel()
-        label.setText(content)
         label.setWordWrap(True)
-        label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         label.setFrameStyle(QFrame.Shape.NoFrame)
+        if role == "assistant":
+            label.setTextInteractionFlags(
+                Qt.TextInteractionFlag.TextSelectableByMouse
+                | Qt.TextInteractionFlag.LinksAccessibleByMouse
+            )
+            label.set_markdown(content)
+            label.link_activated.connect(self.link_activated.emit)
+            label.link_context_menu_requested.connect(
+                self.link_context_menu_requested.emit
+            )
+        else:
+            label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+            label.setText(content)
 
-        label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         label.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
-        pal = label.palette()
-        if role in ("user", "system"):
-            origin_window = pal.color(pal.ColorRole.Window)
-            palette_set_bg_color(pal, pal.color(pal.ColorRole.Highlight))
-            pal.setColor(pal.ColorRole.Text, pal.color(pal.ColorRole.HighlightedText))
-            pal.setColor(pal.ColorRole.Highlight, origin_window)
-            label.setPalette(pal)
+        if role == "user":
+            self._apply_message_label_palette(label, role)
+        elif role in ("assistant", "system"):
+            self._apply_message_label_palette(label, role)
         elif role in ("tools"):
             font = label.font()
             font.setPixelSize(11)
             font.setFamilies(["Monaco", "Menlo", "monospace"])
             label.setFont(font)
+            self._apply_message_label_palette(label, role)
 
-            pal.setColor(pal.ColorRole.Text, pal.color(pal.ColorRole.ToolTipText))
-            palette_set_bg_color(pal, pal.color(pal.ColorRole.ToolTipBase))
-            label.setPalette(pal)
-
-        self._history_layout.addWidget(label)
+        row = ChatMessageRow(role, label, self)
+        self._history_layout.addWidget(row)
         self.scroll_to_bottom()
         return label
 
@@ -164,31 +607,92 @@ class ChatInputWidget(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
+        self._radius = SurfaceRadius
         self._editor = ChatInputEditor(self)
         self._editor.setPlaceholderText(t("ai-chat-input-placeholder"))
         self._editor.setFrameShape(QFrame.Shape.NoFrame)
+        self._editor.setObjectName("ai_chat_input_editor")
+        self._editor.setAutoFillBackground(False)
+        self._editor.viewport().setAutoFillBackground(False)
+        self._editor.setStyleSheet(
+            """
+            #ai_chat_input_editor {
+                background: transparent;
+                border: 0;
+                padding: 0;
+            }
+            """
+        )
         self._msg_label = QLabel(self)
         self._msg_label.setWordWrap(True)
-        self._send_btn = TextButton(t("ai-chat-send-button"))
+        self._send_btn = ChatSendButton(self)
+        self._msg_level = "hint"
+        self._updating_palette = False
 
         self._editor.enter_pressed.connect(self._on_enter_pressed)
         self._send_btn.clicked.connect(self._on_send_clicked)
         self._editor.setMinimumHeight(80)
+        self.setAutoFillBackground(False)
+        self._apply_palette()
         self.setup_ui()
+
+    def _apply_editor_surface(self):
+        pal = QPalette(_application_palette())
+        editor_color = pal.color(QPalette.ColorRole.Window)
+        for group in (
+            QPalette.ColorGroup.Active,
+            QPalette.ColorGroup.Inactive,
+            QPalette.ColorGroup.Disabled,
+        ):
+            pal.setColor(group, QPalette.ColorRole.Window, editor_color)
+            pal.setColor(group, QPalette.ColorRole.Base, editor_color)
+        self._editor.setPalette(pal)
+        self._editor.viewport().setPalette(pal)
+
+    def _apply_palette(self):
+        if self._updating_palette:
+            return
+        self._updating_palette = True
+        try:
+            pal = QPalette(_application_palette())
+            window_color = pal.color(QPalette.ColorRole.Window)
+            pal.setColor(QPalette.ColorRole.Window, window_color)
+            pal.setColor(QPalette.ColorRole.Base, window_color)
+            self.setPalette(pal)
+            self._apply_editor_surface()
+            self._apply_msg_palette(self._msg_level)
+            self.update()
+        finally:
+            self._updating_palette = False
+
+    def _apply_msg_palette(self, level):
+        if level == "hint":
+            color = secondary_text_color(_application_palette())
+        elif level == "warn":
+            color = _application_palette().color(QPalette.ColorRole.ToolTipText)
+        else:  # err
+            color = _application_palette().color(QPalette.ColorRole.Highlight)
+        _set_text_color(self._msg_label, color)
 
     def setup_ui(self):
         self._msg_label.setWordWrap(True)
-        self._msg_label.setTextFormat(Qt.TextFormat.RichText)
+        self._msg_label.setTextFormat(Qt.TextFormat.PlainText)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(5)
-        layout.addWidget(self._msg_label)
+        layout.setContentsMargins(14, 10, 12, 6)
+        layout.setSpacing(4)
+        layout.addWidget(self._editor)
 
-        input_layout = QHBoxLayout()
-        input_layout.addWidget(self._editor)
-        input_layout.addWidget(self._send_btn, 0, Qt.AlignmentFlag.AlignBottom)
-        layout.addLayout(input_layout)
+        footer_layout = QHBoxLayout()
+        footer_layout.setContentsMargins(0, 0, 0, 0)
+        footer_layout.setSpacing(8)
+        footer_layout.addWidget(self._msg_label, 1)
+        footer_layout.addWidget(self._send_btn, 0, Qt.AlignmentFlag.AlignRight)
+        layout.addLayout(footer_layout)
+
+    def paintEvent(self, event):
+        draw_round_surface(self, self._radius)
+        super().paintEvent(event)
 
     def _on_enter_pressed(self):
         self._on_send_clicked()
@@ -200,13 +704,9 @@ class ChatInputWidget(QWidget):
             self._editor.clear()
 
     def set_msg(self, text, level="hint"):
-        if level == "hint":
-            color = "green"
-        elif level == "warn":
-            color = "yellow"
-        else:  # err
-            color = "magenta"
-        self._msg_label.setText(f'<span style="color: {color}">{text}</span>')
+        self._msg_level = level
+        self._apply_msg_palette(level)
+        self._msg_label.setText(text)
 
     def clear_input(self):
         self._editor.clear()
@@ -216,3 +716,6 @@ class ChatInputWidget(QWidget):
 
     def enable_send(self, enabled):
         self._send_btn.setEnabled(enabled)
+
+    def set_placeholder(self, text):
+        self._editor.setPlaceholderText(text)

--- a/feeluown/gui/widgets/song_minicard_list.py
+++ b/feeluown/gui/widgets/song_minicard_list.py
@@ -204,7 +204,7 @@ class SongMiniCardListDelegate(QStyledItemDelegate):
         card_right_spacing = self.card_right_spacing
         card_height = self.card_height
         card_left_padding = self.card_left_padding
-        border_radius = 3
+        border_radius = 8
 
         rect = option.rect
         # HACK(cosven): from the QFontMetrics doc, there is usually a small spacing
@@ -218,24 +218,33 @@ class SongMiniCardListDelegate(QStyledItemDelegate):
             return
 
         selected = option.state & QStyle.StateFlag.State_Selected
+        item_width, _ = self.item_sizehint()
+        bg_rect = QRectF(
+            rect.x() + card_left_padding,
+            rect.y() + card_top_padding,
+            min(rect.width() - card_left_padding - card_right_spacing, item_width),
+            card_height,
+        )
         if selected:
             with painter_save(painter):
                 painter.setPen(Qt.PenStyle.NoPen)
-                painter.setBrush(option.palette.color(QPalette.ColorRole.Highlight))
-                painter.drawRect(rect)
+                color = option.palette.color(QPalette.ColorRole.Highlight)
+                color.setAlpha(55)
+                painter.setBrush(color)
+                painter.drawRoundedRect(bg_rect, border_radius, border_radius)
         elif option.state & QStyle.StateFlag.State_MouseOver:
             with painter_save(painter):
                 painter.setPen(Qt.PenStyle.NoPen)
                 painter.setBrush(option.palette.color(self.hover_color_role))
-                painter.drawRect(rect)
+                painter.drawRoundedRect(bg_rect, border_radius, border_radius)
 
         with painter_save(painter):
             painter.translate(rect.x() + card_left_padding, rect.y() + card_top_padding)
 
             if selected:
-                text_color = option.palette.color(QPalette.ColorRole.HighlightedText)
+                text_color = option.palette.color(QPalette.ColorRole.Text)
                 non_text_color = QColor(text_color)
-                non_text_color.setAlpha(200)
+                non_text_color.setAlpha(140)
             else:
                 text_color = option.palette.color(QPalette.ColorRole.Text)
                 if text_color.lightness() > 150:

--- a/feeluown/i18n/assets/en-US/app.ftl
+++ b/feeluown/i18n/assets/en-US/app.ftl
@@ -401,9 +401,39 @@ remove-from-playlist = Remove { -track }
 # ----------------------------------------
 ai-chat-header = AI Assistant
 ai-chat-new = New chat
-ai-chat-match-resource = Matching resources...
-ai-chat-match-resource-failed = Resource matching failed
-ai-chat-track-candidate-list = { -track(capitalization: "uppercase") } candidate list
+ai-chat-open-sidebar = Open Sidebar
+ai-chat-artifact-songs = { $count } songs
+ai-chat-artifact-open = Open
+ai-chat-artifact-sidebar-title = Songs
+ai-chat-link-search = Search Song
+ai-chat-link-play = Play
+ai-chat-link-copy = Copy Link
+ai-chat-song-match-failed = No playable matching song found
+ai-chat-stream-thinking = AI is thinking
+ai-chat-stream-writing = AI is writing
+ai-chat-stream-tool = AI is using tool: { $tool }
+ai-chat-stream-failed = AI response failed
+ai-chat-tool-called = Tool called: { $tool }
+
+ai-radio-title = AI Radio
+ai-radio-active-status = AI Radio: On
+ai-radio-activate-tooltip = Start AI Radio
+ai-radio-activated = AI Radio activated
+ai-radio-deactivated = AI Radio deactivated
+ai-radio-chat-hint = AI Radio is active. Candidate songs are shown in the playlist.
+ai-radio-input-placeholder = Tell AI what to play next...
+ai-radio-instruction-updated = AI Radio recommendation instructions updated
+ai-radio-candidates-clearing = Clearing upcoming radio candidates
+ai-radio-candidates-cleared = Radio candidates cleared
+ai-radio-candidates-kept = Radio candidates kept
+ai-radio-candidates-requesting = Requesting { $count } song suggestions
+ai-radio-candidates-matching = Matching: { $title }
+ai-radio-candidates-adding = Adding { $count } radio candidates
+ai-radio-candidates-updated = Radio candidates updated: { $count } songs
+ai-radio-candidates-update-failed = Failed to update radio candidates
+ai-radio-preview-loading = Fetching AI Radio songs...
+ai-radio-preview-failed = AI failed to recommend a song...
+fm-candidate-badge = Candidate
 
 # feeluown.gui.uimain.player_bar
 # ----------------------------------------

--- a/feeluown/i18n/assets/ja-JP/app.ftl
+++ b/feeluown/i18n/assets/ja-JP/app.ftl
@@ -403,9 +403,39 @@ remove-from-playlist = { -track } を削除
 # ----------------------------------------
 ai-chat-header = AI アシスタント
 ai-chat-new = 新しい会話
-ai-chat-match-resource = リソースをマッチング中…
-ai-chat-match-resource-failed = マッチングに失敗
-ai-chat-track-candidate-list = { -track } 候補リスト
+ai-chat-open-sidebar = サイドバーを開く
+ai-chat-artifact-songs = { $count } 曲
+ai-chat-artifact-open = 開く
+ai-chat-artifact-sidebar-title = 曲リスト
+ai-chat-link-search = 曲を検索
+ai-chat-link-play = 再生
+ai-chat-link-copy = リンクをコピー
+ai-chat-song-match-failed = 再生可能な一致曲が見つかりません
+ai-chat-stream-thinking = AI が考えています
+ai-chat-stream-writing = AI が返信を生成しています
+ai-chat-stream-tool = AI がツールを使用しています: { $tool }
+ai-chat-stream-failed = AI の返信に失敗しました
+ai-chat-tool-called = ツールを呼び出しました: { $tool }
+
+ai-radio-title = AI ラジオ
+ai-radio-active-status = AI ラジオ：オン
+ai-radio-activate-tooltip = AI ラジオを開始
+ai-radio-activated = AI ラジオを開始しました
+ai-radio-deactivated = AI ラジオを停止しました
+ai-radio-chat-hint = AI ラジオが有効です。候補曲はプレイリストで確認できます
+ai-radio-input-placeholder = 次に聴きたい内容を AI に伝えてください...
+ai-radio-instruction-updated = AI ラジオの推薦条件を更新しました
+ai-radio-candidates-clearing = ラジオ候補曲をクリアしています
+ai-radio-candidates-cleared = ラジオ候補曲をクリアしました
+ai-radio-candidates-kept = ラジオ候補曲を保持しました
+ai-radio-candidates-requesting = { $count } 曲の候補をリクエストしています
+ai-radio-candidates-matching = マッチング中：{ $title }
+ai-radio-candidates-adding = ラジオ候補曲を { $count } 曲追加しています
+ai-radio-candidates-updated = ラジオ候補曲を更新しました：{ $count } 曲
+ai-radio-candidates-update-failed = ラジオ候補曲更新に失敗しました
+ai-radio-preview-loading = AI ラジオの曲を取得中...
+ai-radio-preview-failed = AI の曲推薦に失敗しました...
+fm-candidate-badge = 候補
 
 # feeluown.gui.uimain.player_bar
 # ----------------------------------------

--- a/feeluown/i18n/assets/zh-CN/app.ftl
+++ b/feeluown/i18n/assets/zh-CN/app.ftl
@@ -403,9 +403,39 @@ remove-from-playlist = 移除{ -track }
 # ----------------------------------------
 ai-chat-header = AI 助手
 ai-chat-new = 新的对话
-ai-chat-match-resource = 正在匹配资源...
-ai-chat-match-resource-failed = 匹配资源失败
-ai-chat-track-candidate-list = { -track }候选列表
+ai-chat-open-sidebar = 打开侧边栏
+ai-chat-artifact-songs = { $count } 首歌曲
+ai-chat-artifact-open = 打开
+ai-chat-artifact-sidebar-title = 歌曲列表
+ai-chat-link-search = 搜索歌曲
+ai-chat-link-play = 播放
+ai-chat-link-copy = 复制链接
+ai-chat-song-match-failed = 没有找到可播放的匹配歌曲
+ai-chat-stream-thinking = AI 正在思考
+ai-chat-stream-writing = AI 正在生成回复
+ai-chat-stream-tool = AI 正在使用工具：{ $tool }
+ai-chat-stream-failed = AI 回复失败
+ai-chat-tool-called = 已调用工具：{ $tool }
+
+ai-radio-title = AI 电台
+ai-radio-active-status = AI 电台：开启
+ai-radio-activate-tooltip = 开启 AI 电台
+ai-radio-activated = AI 电台已开启
+ai-radio-deactivated = AI 电台已关闭
+ai-radio-chat-hint = AI 电台开启中，候选歌曲可在播放列表中查看
+ai-radio-input-placeholder = 告诉 AI 接下来想听什么...
+ai-radio-instruction-updated = 已更新 AI 电台推荐要求
+ai-radio-candidates-clearing = 正在清理电台候选歌曲
+ai-radio-candidates-cleared = 电台候选歌曲已清空
+ai-radio-candidates-kept = 已保留电台候选歌曲
+ai-radio-candidates-requesting = 正在请求 { $count } 首歌曲建议
+ai-radio-candidates-matching = 正在匹配：{ $title }
+ai-radio-candidates-adding = 正在添加 { $count } 首电台候选歌曲
+ai-radio-candidates-updated = 电台候选歌曲已更新：{ $count } 首
+ai-radio-candidates-update-failed = 电台候选歌曲更新失败
+ai-radio-preview-loading = 正在获取电台歌曲...
+ai-radio-preview-failed = AI 推荐歌曲失败...
+fm-candidate-badge = 候选
 
 # feeluown.gui.uimain.player_bar
 # ----------------------------------------

--- a/feeluown/player/fm.py
+++ b/feeluown/player/fm.py
@@ -1,10 +1,12 @@
 from typing import TYPE_CHECKING
 
 import asyncio
+import inspect
 import logging
 
 from feeluown.excs import ProviderIOError
 from feeluown.player import PlaylistMode
+from feeluown.player.fm_candidates import FMCandidateManager
 from feeluown.i18n import t
 
 if TYPE_CHECKING:
@@ -39,6 +41,7 @@ class FM:
         self._fetch_songs_task_name = "fm-fetch-songs"
         self._fetch_songs_func = None  # fn(number_to_fetch)
         self._minimum_per_fetch = 3
+        self.candidates = FMCandidateManager(app)
 
         self._app.playlist.mode_changed.connect(self._on_playlist_mode_changed)
 
@@ -46,6 +49,7 @@ class FM:
         """change playlist mode to fm
 
         :param fetch_songs_func: `func(minimum, *args, **kwargs): -> list`
+            or `async func(minimum, *args, **kwargs): -> list`
             please ensure that fetch_songs_func can receive keyword arguments,
             we may send some keyword args(such as timeout) in the future.
             If exception occured in fetch_songs_func, it should raise
@@ -86,9 +90,12 @@ class FM:
 
         self._is_fetching_songs = True
         task_spec = self._app.task_mgr.get_or_create(self._fetch_songs_task_name)
-        task = task_spec.bind_blocking_io(
-            self._fetch_songs_func, self._minimum_per_fetch
-        )
+        if inspect.iscoroutinefunction(self._fetch_songs_func):
+            task = task_spec.bind_coro(self._fetch_songs_func(self._minimum_per_fetch))
+        else:
+            task = task_spec.bind_blocking_io(
+                self._fetch_songs_func, self._minimum_per_fetch
+            )
         task.add_done_callback(self._on_songs_fetched)
 
     def _on_playlist_mode_changed(self, mode):

--- a/feeluown/player/fm_candidates.py
+++ b/feeluown/player/fm_candidates.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING
+
+from feeluown.player.playlist import PlaylistMode
+
+if TYPE_CHECKING:
+    from feeluown.app import App
+    from feeluown.library import BriefSongModel
+
+
+class FMCandidateManager:
+    """Manage upcoming FM candidates stored in the playlist."""
+
+    def __init__(self, app: "App"):
+        self._app = app
+
+    @property
+    def _playlist(self):
+        return self._app.playlist
+
+    def list_candidates(self) -> list["BriefSongModel"]:
+        return self._playlist.list_fm_candidates()
+
+    def clear(self) -> bool:
+        if not self._is_active:
+            return False
+        for song in self.list_candidates():
+            self._playlist.remove(song)
+        return True
+
+    def remove(self, positions: list[int]) -> bool:
+        if not self._is_active:
+            return False
+        candidates = self.list_candidates()
+        remove_positions = _normalize_positions(positions, len(candidates))
+        removed_songs = [candidates[position - 1] for position in remove_positions]
+        for song in removed_songs:
+            self._playlist.remove(song)
+        return True
+
+    def keep(self, positions: list[int]) -> bool:
+        if not self._is_active:
+            return False
+        candidates = self.list_candidates()
+        keep_positions = _normalize_positions(positions, len(candidates))
+        removed_songs = [
+            song
+            for index, song in enumerate(candidates, start=1)
+            if index not in keep_positions
+        ]
+        for song in removed_songs:
+            self._playlist.remove(song)
+        return True
+
+    def append(self, songs: list["BriefSongModel"]) -> bool:
+        if not self._is_active:
+            return False
+        for song in songs:
+            if song in self._playlist.list():
+                continue
+            self._playlist.fm_add(song)
+        return True
+
+    def replace(
+        self,
+        songs: list["BriefSongModel"],
+        keep_positions: list[int] | None = None,
+    ) -> bool:
+        if not self._is_active:
+            return False
+        self.keep(keep_positions or [])
+        self.append(songs)
+        return True
+
+    @property
+    def _is_active(self):
+        return self._playlist.mode is PlaylistMode.fm
+
+
+def _normalize_positions(positions: list[int], candidate_count: int) -> list[int]:
+    normalized = []
+    for position in positions:
+        if 1 <= position <= candidate_count and position not in normalized:
+            normalized.append(position)
+    return normalized

--- a/feeluown/player/playlist.py
+++ b/feeluown/player/playlist.py
@@ -416,6 +416,33 @@ class Playlist:
         """Get all songs in playlists"""
         return self._queue
 
+    def current_song_index(self):
+        """Return current song index in playlist, or None if not found."""
+        current_song = self.current_song
+        if current_song is None:
+            return None
+        for index, song in enumerate(self._queue):
+            if song is current_song:
+                return index
+        try:
+            return self._queue.index(current_song)
+        except ValueError:
+            return None
+
+    def list_fm_candidates(self):
+        """Return upcoming FM candidates from the playlist.
+
+        In FM mode, the playlist is the canonical candidate storage. Songs after
+        the current song are candidates. When no current song is selected yet,
+        all playlist songs are upcoming candidates.
+        """
+        if self.mode is not PlaylistMode.fm:
+            return []
+        current_index = self.current_song_index()
+        if current_index is None:
+            return list(self._queue)
+        return list(self._queue[current_index + 1:])
+
     def list_unshuffled(self):
         """Get all songs in original order"""
         if self._shuffled_songs is not None:

--- a/tests/ai/test_copilot.py
+++ b/tests/ai/test_copilot.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from feeluown.ai.copilot import (
+    SongSuggestion,
+    Copilot,
+    play_song_suggestion,
+    tools,
+)
+
+
+def test_copilot_adds_song_artifact_without_mutating_playlist(mocker):
+    app = SimpleNamespace(config=SimpleNamespace())
+    mocker.patch("feeluown.ai.copilot.create_agent_with_config")
+    copilot = Copilot(app)
+    received = []
+    copilot.artifact_added.connect(received.append, weak=False)
+    songs = [
+        SongSuggestion(
+            title="hello world",
+            artists_name="mary",
+            description="",
+        )
+    ]
+
+    artifact = copilot.add_songs_artifact(songs, title="Night Songs")
+
+    assert artifact.identifier == 1
+    assert artifact.type == "songs"
+    assert artifact.title == "Night Songs"
+    assert artifact.songs == songs
+    assert copilot.get_artifacts() == [artifact]
+    assert received == [artifact]
+
+
+def test_play_song_suggestion_tool_plays_song_suggestion():
+    playlist = SimpleNamespace(play_model=MagicMock())
+    runtime = SimpleNamespace(
+        context=SimpleNamespace(app=SimpleNamespace(playlist=playlist))
+    )
+    suggestion = SongSuggestion(
+        title="hello world",
+        artists_name="mary",
+        description="",
+    )
+
+    play_song_suggestion.func(song=suggestion, runtime=runtime)
+
+    playlist.play_model.assert_called_once()
+    song = playlist.play_model.call_args.args[0]
+    assert song.source == "ai"
+    assert song.title == "hello world"
+    assert song.artists_name == "mary"
+
+
+def test_copilot_tool_names_are_specific_to_song_suggestions():
+    tool_names = {tool.name for tool in tools}
+
+    assert "play_song_suggestion" in tool_names
+    assert "play_song" not in tool_names
+
+
+def test_copilot_exposes_playback_tools():
+    tool_names = {tool.name for tool in tools}
+
+    assert {
+        "playback_get_state",
+        "playback_next_track",
+        "playback_previous_track",
+        "playback_pause",
+        "playback_resume",
+        "playback_toggle",
+        "playback_stop",
+        "playback_set_volume",
+        "playback_adjust_volume",
+    }.issubset(tool_names)

--- a/tests/ai/test_playback.py
+++ b/tests/ai/test_playback.py
@@ -1,0 +1,117 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from feeluown.ai.playback import (
+    playback_adjust_volume,
+    playback_get_state,
+    playback_next_track,
+    playback_pause,
+    playback_previous_track,
+    playback_resume,
+    playback_set_volume,
+    playback_stop,
+    playback_toggle,
+)
+from feeluown.library import BriefSongModel
+from feeluown.player import State
+
+
+class FakeRuntime:
+    def __init__(self, app):
+        self.context = SimpleNamespace(app=app)
+
+
+class FakePlayer:
+    def __init__(self):
+        self.state = State.paused
+        self.position = 12
+        self.duration = 120
+        self._volume = 50
+        self.pause = MagicMock()
+        self.resume = MagicMock()
+        self.toggle = MagicMock()
+        self.stop = MagicMock()
+
+    @property
+    def volume(self):
+        return self._volume
+
+    @volume.setter
+    def volume(self, value):
+        self._volume = value
+
+
+def create_runtime(song=None):
+    app = SimpleNamespace(
+        player=FakePlayer(),
+        playlist=SimpleNamespace(
+            current_song=song,
+            next=MagicMock(),
+            previous=MagicMock(),
+        ),
+    )
+    return FakeRuntime(app)
+
+
+def test_playback_get_state_exposes_current_playback_state():
+    song = BriefSongModel(
+        source="fake",
+        identifier="1",
+        title="hello world",
+        artists_name="mary",
+    )
+    runtime = create_runtime(song)
+
+    result = playback_get_state.func(runtime=runtime)
+
+    assert result["ok"] is True
+    assert result["action"] == "get_state"
+    assert result["player_state"] == "paused"
+    assert result["volume"] == 50
+    assert result["position"] == 12
+    assert result["duration"] == 120
+    assert result["current_song"]["source"] == "fake"
+    assert result["current_song"]["identifier"] == "1"
+
+
+def test_playback_track_navigation_uses_playlist():
+    runtime = create_runtime()
+
+    next_result = playback_next_track.func(runtime=runtime)
+    previous_result = playback_previous_track.func(runtime=runtime)
+
+    runtime.context.app.playlist.next.assert_called_once()
+    runtime.context.app.playlist.previous.assert_called_once()
+    assert next_result["action"] == "next_track"
+    assert previous_result["action"] == "previous_track"
+
+
+def test_playback_player_controls_use_player():
+    runtime = create_runtime()
+
+    pause_result = playback_pause.func(runtime=runtime)
+    resume_result = playback_resume.func(runtime=runtime)
+    toggle_result = playback_toggle.func(runtime=runtime)
+    stop_result = playback_stop.func(runtime=runtime)
+
+    player = runtime.context.app.player
+    player.pause.assert_called_once()
+    player.resume.assert_called_once()
+    player.toggle.assert_called_once()
+    player.stop.assert_called_once()
+    assert pause_result["action"] == "pause"
+    assert resume_result["action"] == "resume"
+    assert toggle_result["action"] == "toggle"
+    assert stop_result["action"] == "stop"
+
+
+def test_playback_volume_tools_clamp_values():
+    runtime = create_runtime()
+
+    too_high = playback_set_volume.func(volume=120, runtime=runtime)
+    down = playback_adjust_volume.func(delta=-130, runtime=runtime)
+    up = playback_adjust_volume.func(delta=20, runtime=runtime)
+
+    assert too_high["volume"] == 100
+    assert down["volume"] == 0
+    assert up["volume"] == 20

--- a/tests/ai/test_radio.py
+++ b/tests/ai/test_radio.py
@@ -1,0 +1,365 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from feeluown.ai.radio import AIRadioSession
+from feeluown.ai.radio import (
+    ai_radio_activate,
+    ai_radio_deactivate,
+    ai_radio_get_state,
+    ai_radio_update_preferences,
+    fm_candidates_append,
+    fm_candidates_clear,
+    fm_candidates_keep,
+    fm_candidates_remove,
+    fm_candidates_replace,
+)
+from feeluown.player.fm_candidates import FMCandidateManager
+from feeluown.player import Playlist, PlaylistMode
+from feeluown.utils.dispatch import Signal
+
+
+class FakeAI:
+    def __init__(self):
+        self.radio = None
+        self._app = None
+
+    def get_copilot(self):
+        raise AssertionError("AI radio recommendation should not use Copilot")
+
+    def get_active_radio(self):
+        if self.radio is not None and self.radio.is_active:
+            return self.radio
+        return None
+
+    def activate_radio(self, reset=True):
+        radio = self.get_active_radio()
+        if radio is not None:
+            return radio
+        radio = AIRadioSession(self._app)
+        radio.activate(reset=reset)
+        return radio
+
+    def deactivate_radio(self):
+        if self.radio is None:
+            return False
+        was_active = self.radio.is_active
+        self.radio.deactivate()
+        return was_active
+
+
+class FakeFM:
+    def __init__(self, app):
+        self._app = app
+        self.is_active = False
+        self.fetch_songs_func = None
+        self.reset = None
+        self.candidates = FMCandidateManager(app)
+        self.activate_count = 0
+
+    def activate(self, fetch_songs_func, reset=True):
+        self.is_active = True
+        self.fetch_songs_func = fetch_songs_func
+        self.reset = reset
+        self.activate_count += 1
+        self._app.playlist.mode = PlaylistMode.fm
+
+    def deactivate(self):
+        self.is_active = False
+        self._app.playlist.mode = PlaylistMode.normal
+
+
+class FakeRuntime:
+    def __init__(self, app):
+        self.context = SimpleNamespace(app=app)
+
+
+class FakeRecommendationAgent:
+    def __init__(self, suggestions):
+        self.suggestions = suggestions
+        self.calls = []
+
+    async def ainvoke(self, input_, config, context):
+        self.calls.append((input_, config, context))
+        context.suggestions = self.suggestions
+
+
+class FakeMatcher:
+    songs_by_title = {}
+
+    def __init__(self, _app):
+        pass
+
+    async def match(self, suggestion):
+        return self.songs_by_title.get(suggestion.title)
+
+
+def create_radio_app():
+    app = SimpleNamespace()
+    app.config = MagicMock()
+    app.coll_mgr = MagicMock()
+    app.player = SimpleNamespace(
+        media_finished=Signal(),
+        set_infinite_loop=lambda _enabled: None,
+    )
+    app.playlist = Playlist(app)
+    app.playlist.mode = PlaylistMode.fm
+    app.ai = FakeAI()
+    app.ai._app = app
+    app.fm = FakeFM(app)
+    return app
+
+
+def create_runtime_with_radio(song, *candidates, matcher_cls=None):
+    app = create_radio_app()
+    app.playlist.fm_add(song)
+    for candidate in candidates:
+        app.playlist.fm_add(candidate)
+    app.playlist._current_song = song
+    radio = AIRadioSession(app, matcher_cls=matcher_cls)
+    radio.activate(reset=False)
+    app.ai.radio = radio
+    return FakeRuntime(app), radio
+
+
+def create_recommendation_agent_factory(suggestions):
+    agent = FakeRecommendationAgent(suggestions)
+
+    def factory(_config):
+        return agent
+
+    return factory, agent
+
+
+@pytest.mark.asyncio
+async def test_ai_radio_fetch_matches_suggestions_with_radio_state(
+    song, song1, song2
+):
+    suggestions = [
+        SimpleNamespace(title="hello world"),
+        SimpleNamespace(title="duplicate"),
+        SimpleNamespace(title="missing"),
+        SimpleNamespace(title="second"),
+    ]
+    recommendation_agent_factory, recommendation_agent = (
+        create_recommendation_agent_factory(suggestions)
+    )
+    app = create_radio_app()
+    app.playlist.fm_add(song1)
+    app.playlist._current_song = song1
+    FakeMatcher.songs_by_title = {
+        "hello world": song,
+        "duplicate": song1,
+        "second": song2,
+    }
+    radio = AIRadioSession(
+        app,
+        matcher_cls=FakeMatcher,
+        recommendation_agent_factory=recommendation_agent_factory,
+    )
+    radio.update_preferences(
+        preferences=["more jazz"],
+        avoidances=["too noisy"],
+        reason="user feedback",
+    )
+
+    songs = await radio.a_fetch_songs_func(2)
+
+    assert songs == [song, song2]
+    input_, config, _context = recommendation_agent.calls[0]
+    assert config["configurable"]["thread_id"] == "ai-radio-1"
+    prompt = input_["messages"][2]["content"]
+    assert "推荐2首适合继续播放的歌给用户" in prompt
+    assert "'preferences': ['more jazz']" in prompt
+    assert "'avoidances': ['too noisy']" in prompt
+    assert "'preference_notes': ['user feedback']" in prompt
+    assert f"'identifier': '{song1.identifier}'" in prompt
+
+
+@pytest.mark.asyncio
+async def test_ai_radio_fetch_recommends_songs_without_local_candidate_queue(song1):
+    recommendation_agent_factory, recommendation_agent = (
+        create_recommendation_agent_factory([SimpleNamespace(title="second")])
+    )
+    app = create_radio_app()
+    FakeMatcher.songs_by_title = {"second": song1}
+    radio = AIRadioSession(
+        app,
+        matcher_cls=FakeMatcher,
+        recommendation_agent_factory=recommendation_agent_factory,
+    )
+
+    assert radio.get_state_for_ai()["candidates"] == []
+
+    songs = await radio.a_fetch_songs_func(2)
+
+    assert songs == [song1]
+    assert len(recommendation_agent.calls) == 1
+    prompt = recommendation_agent.calls[0][0]["messages"][2]["content"]
+    assert "推荐2首适合继续播放的歌给用户" in prompt
+
+
+@pytest.mark.asyncio
+async def test_fm_candidates_append_tool_matches_suggestions_in_small_batch(
+    song, song1, song2, song3
+):
+    app = create_radio_app()
+    app.playlist.fm_add(song)
+    app.playlist._current_song = song
+    FakeMatcher.songs_by_title = {
+        "hello world": song1,
+        "second": song2,
+        "third": song3,
+    }
+    radio = AIRadioSession(app, matcher_cls=FakeMatcher, candidate_batch_size=2)
+    radio.activate(reset=False)
+    app.ai.radio = radio
+    statuses = []
+    radio.status_changed.connect(statuses.append, weak=False)
+
+    result = await fm_candidates_append.coroutine(
+        songs=[
+            SimpleNamespace(title="hello world"),
+            SimpleNamespace(title="second"),
+            SimpleNamespace(title="third"),
+        ],
+        runtime=FakeRuntime(app),
+    )
+
+    assert app.playlist.list() == [song, song1, song2]
+    assert result is True
+    assert statuses[-1] == "Radio candidates updated: 2 songs"
+
+
+def test_ai_radio_tools_return_inactive_error():
+    runtime = FakeRuntime(SimpleNamespace(ai=FakeAI()))
+
+    result = ai_radio_get_state.func(runtime=runtime)
+
+    assert result["ok"] is False
+    assert result["error_code"] == "AI_RADIO_INACTIVE"
+    assert result["active"] is False
+    assert result["candidate_count"] == 0
+
+
+def test_ai_radio_command_tools_return_false_when_unavailable():
+    runtime = FakeRuntime(SimpleNamespace(ai=None))
+
+    assert ai_radio_activate.func(runtime=runtime) is False
+    assert ai_radio_deactivate.func(runtime=runtime) is False
+
+
+def test_ai_radio_candidate_tools_return_false_when_inactive():
+    runtime = FakeRuntime(SimpleNamespace(ai=FakeAI()))
+
+    assert fm_candidates_clear.func(runtime=runtime) is False
+
+
+def test_ai_radio_activate_tool_creates_active_session():
+    app = create_radio_app()
+    runtime = FakeRuntime(app)
+
+    result = ai_radio_activate.func(runtime=runtime, reset=False)
+
+    assert result is True
+    assert app.ai.radio is not None
+    assert app.ai.radio.is_active is True
+    assert app.fm.is_active is True
+    assert app.fm.reset is False
+    assert app.playlist.mode is PlaylistMode.fm
+    assert app.fm.fetch_songs_func == app.ai.radio.fetch_songs_func
+
+
+def test_ai_radio_activate_tool_is_idempotent(song):
+    app = create_radio_app()
+    radio = AIRadioSession(app)
+    radio.activate(reset=False)
+    app.ai.radio = radio
+    runtime = FakeRuntime(app)
+
+    result = ai_radio_activate.func(runtime=runtime)
+
+    assert result is True
+    assert app.ai.radio is radio
+    assert app.fm.activate_count == 1
+
+
+def test_ai_radio_deactivate_tool_stops_active_session():
+    app = create_radio_app()
+    runtime = FakeRuntime(app)
+    ai_radio_activate.func(runtime=runtime)
+
+    result = ai_radio_deactivate.func(runtime=runtime)
+
+    assert result is True
+    assert app.ai.radio is None
+    assert app.fm.is_active is False
+    assert app.playlist.mode is PlaylistMode.normal
+
+
+def test_ai_radio_deactivate_tool_is_idempotent():
+    app = create_radio_app()
+    runtime = FakeRuntime(app)
+
+    result = ai_radio_deactivate.func(runtime=runtime)
+
+    assert result is True
+
+
+def test_ai_radio_tools_expose_state_and_update_preferences(song, song1):
+    runtime, radio = create_runtime_with_radio(song, song1)
+
+    pref_result = ai_radio_update_preferences.func(
+        runtime=runtime,
+        preferences=["more 90s classics"],
+        avoidances=["too popular"],
+        reason="user dislikes current candidates",
+    )
+    state = ai_radio_get_state.func(runtime=runtime)
+
+    assert pref_result is True
+    assert radio.preferences == ["more 90s classics"]
+    assert radio.avoidances == ["too popular"]
+    assert state["ok"] is True
+    assert state["active"] is True
+    assert state["candidates"][0]["position"] == 1
+    assert state["candidates"][0]["identifier"] == song1.identifier
+    assert state["candidates"][0]["uri"] == "fuo://fake/songs/1"
+    assert state["preferences"] == ["more 90s classics"]
+
+
+def test_fm_candidates_clear_tool(song, song1, song2):
+    runtime, _radio = create_runtime_with_radio(song, song1, song2)
+
+    result = fm_candidates_clear.func(runtime=runtime)
+
+    assert result is True
+    assert runtime.context.app.playlist.list() == [song]
+
+
+def test_fm_candidates_remove_and_keep_tools_use_fm_candidates(song, song1, song2):
+    runtime, _radio = create_runtime_with_radio(song, song1, song2)
+
+    remove_result = fm_candidates_remove.func(positions=[1], runtime=runtime)
+    keep_result = fm_candidates_keep.func(positions=[1], runtime=runtime)
+
+    assert remove_result is True
+    assert keep_result is True
+    assert runtime.context.app.playlist.list() == [song, song2]
+
+
+@pytest.mark.asyncio
+async def test_fm_candidates_replace_tool_uses_fm_candidates(song, song1, song2):
+    FakeMatcher.songs_by_title = {"second": song2}
+    runtime, radio = create_runtime_with_radio(song, song1, matcher_cls=FakeMatcher)
+
+    result = await fm_candidates_replace.coroutine(
+        songs=[SimpleNamespace(title="second")],
+        keep_positions=[],
+        runtime=runtime,
+    )
+
+    assert result is True
+    assert runtime.context.app.playlist.list() == [song, song2]
+    assert radio.status == "Radio candidates updated: 1 songs"

--- a/tests/gui/uimain/test_uimain.py
+++ b/tests/gui/uimain/test_uimain.py
@@ -1,7 +1,257 @@
+import asyncio
+import sys
+from types import SimpleNamespace
+
+from PyQt6.QtCore import QPoint, QPointF, QSize, Qt, QTimer
+from PyQt6.QtGui import QColor, QGuiApplication, QMouseEvent, QPalette
+from PyQt6.QtWidgets import QListWidget, QWidget
+
+from feeluown.ai import SongSuggestion
+from feeluown.ai.copilot import CopilotArtifact
+from feeluown.gui.helpers import secondary_text_color
+from feeluown.library import BriefSongModel
 from feeluown.media import Media
-from feeluown.player import PlaybackMode
+from feeluown.player import PlaybackMode, PlaylistMode
+from feeluown.utils.dispatch import Signal
+from feeluown.gui.components.player_playlist import (
+    PlayerPlaylistView,
+    FMCandidatePlaylistDelegate,
+)
 from feeluown.gui.uimain.player_bar import PlayerControlPanel
+from feeluown.gui.uimain.ai_chat import (
+    AIChatOverlay,
+    SongSuggestionItemWidget,
+    song_suggestion_to_markdown_url,
+    create_aichat_overlay,
+    parse_song_link,
+    parse_song_link_info,
+)
 from feeluown.gui.uimain.playlist_overlay import PlaylistOverlay
+from feeluown.gui.widgets.ai_chat import (
+    ChatArtifactCard,
+    ChatHistoryWidget,
+    ChatMessageRow,
+    ChatSendButton,
+    ChatStreamingStatusCard,
+    ChatToolEventCard,
+    RoundedLabel,
+    surface_border_color,
+)
+from feeluown.gui.widgets import PlayButton, PlusButton
+from feeluown.gui.widgets.song_minicard_list import SongMiniCardListDelegate
+from feeluown.gui.widgets.textbtn import TextButton
+
+
+class FakeDelegateView(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.row_height = 0
+        self.resize(320, 200)
+
+    def set_row_height(self, height):
+        self.row_height = height
+
+
+class FakeIndex:
+    def __init__(self, row):
+        self._row = row
+
+    def isValid(self):
+        return True
+
+    def row(self):
+        return self._row
+
+    def data(self, role):
+        assert role == Qt.ItemDataRole.UserRole
+        return (None, None)
+
+
+class FakeActionSignal:
+    def connect(self, _callback):
+        pass
+
+
+class FakeAction:
+    def __init__(self, text=""):
+        self.text = text
+        self.triggered = FakeActionSignal()
+        self._object_name = ""
+
+    def setObjectName(self, name):
+        self._object_name = name
+
+    def objectName(self):
+        return self._object_name
+
+
+class FakeMenu:
+    def __init__(self, _parent=None):
+        self._actions = []
+
+    def addAction(self, text):
+        action = FakeAction(text)
+        self._actions.append(action)
+        return action
+
+    def addSeparator(self):
+        self._actions.append(FakeAction())
+
+    def actions(self):
+        return list(self._actions)
+
+    def exec(self, _pos):
+        pass
+
+
+class FakeCopilot:
+    def __init__(self):
+        self.working_state_changed = Signal()
+        self.artifact_added = Signal()
+        self._artifacts = []
+
+    def new_thread(self):
+        self._artifacts = []
+
+    def add_songs_artifact(self, songs, title=""):
+        artifact = CopilotArtifact(
+            identifier=len(self._artifacts) + 1,
+            type="songs",
+            title=title or "Songs",
+            songs=songs,
+        )
+        self._artifacts.append(artifact)
+        self.artifact_added.emit(artifact)
+        return artifact
+
+    def get_artifacts(self):
+        return list(self._artifacts)
+
+    async def match_song_suggestion(self, suggestion):
+        return BriefSongModel(
+            source="fake",
+            identifier="matched",
+            title=suggestion.title,
+            artists_name=suggestion.artists_name,
+        )
+
+
+class FakeAI:
+    def __init__(self, copilot=None):
+        self._copilot = copilot or FakeCopilot()
+        self.radio = None
+        self.activate_radio_calls = []
+        self.deactivate_radio_calls = 0
+
+    def get_copilot(self):
+        return self._copilot
+
+    def get_active_radio(self):
+        if self.radio is not None and self.radio.is_active:
+            return self.radio
+        return None
+
+    def activate_radio(self, reset=True):
+        self.activate_radio_calls.append(reset)
+        radio = self.get_active_radio()
+        if radio is not None:
+            return radio
+        self.radio = FakeAIRadio()
+        return self.radio
+
+    def deactivate_radio(self):
+        self.deactivate_radio_calls += 1
+        if self.radio is None:
+            return False
+        was_active = self.radio.is_active
+        self.radio = None
+        return was_active
+
+
+class FakeAIRadio:
+    is_active = True
+
+    def __init__(self):
+        self.status = "Updating candidates"
+        self.status_changed = Signal()
+
+
+class FakeThemeManager:
+    def __init__(self):
+        self.theme_changed = Signal()
+
+
+class FakeStreamingCopilot(FakeCopilot):
+    async def astream_user_query(self, _query):
+        yield SimpleNamespace(
+            content_blocks=[{"type": "text", "text": "我来"}]
+        ), {"langgraph_node": "model"}
+        self.add_songs_artifact(
+            [
+                SongSuggestion(
+                    title="hello world",
+                    artists_name="mary",
+                    description="",
+                )
+            ],
+            title="Night Songs",
+        )
+        yield SimpleNamespace(name="create_song_suggestions_artifact"), {
+            "langgraph_node": "tools"
+        }
+        yield SimpleNamespace(
+            content_blocks=[{"type": "text", "text": "我为您推荐了这些歌曲"}]
+        ), {"langgraph_node": "model"}
+
+
+class FakeAIRadioToolCopilot(FakeCopilot):
+    async def astream_user_query(self, _query):
+        yield SimpleNamespace(name="fm_candidates_replace"), {
+            "langgraph_node": "tools"
+        }
+        yield SimpleNamespace(
+            content_blocks=[{"type": "text", "text": "已更新候选歌曲"}]
+        ), {"langgraph_node": "model"}
+
+
+class FakeAIRadioLifecycleToolCopilot(FakeCopilot):
+    async def astream_user_query(self, _query):
+        yield SimpleNamespace(name="ai_radio_activate"), {
+            "langgraph_node": "tools"
+        }
+        yield SimpleNamespace(
+            content_blocks=[{"type": "text", "text": "AI 电台已开启"}]
+        ), {"langgraph_node": "model"}
+
+
+class PausedStreamingCopilot(FakeCopilot):
+    def __init__(self):
+        super().__init__()
+        self.first_token_seen = asyncio.Event()
+        self.resume = asyncio.Event()
+
+    async def astream_user_query(self, _query):
+        yield SimpleNamespace(
+            content_blocks=[{"type": "text", "text": "我来"}]
+        ), {"langgraph_node": "model"}
+        self.first_token_seen.set()
+        await self.resume.wait()
+        yield SimpleNamespace(
+            content_blocks=[{"type": "text", "text": "我为您推荐了这些歌曲"}]
+        ), {"langgraph_node": "model"}
+
+
+def _palette_with_colors(window, base, text="#111111", highlight="#3366cc"):
+    pal = QPalette(QGuiApplication.palette())
+    pal.setColor(QPalette.ColorRole.Window, QColor(window))
+    pal.setColor(QPalette.ColorRole.Base, QColor(base))
+    pal.setColor(QPalette.ColorRole.Text, QColor(text))
+    pal.setColor(QPalette.ColorRole.WindowText, QColor(text))
+    pal.setColor(QPalette.ColorRole.ToolTipText, QColor(text))
+    pal.setColor(QPalette.ColorRole.ToolTipBase, QColor(base))
+    pal.setColor(QPalette.ColorRole.Highlight, QColor(highlight))
+    pal.setColor(QPalette.ColorRole.HighlightedText, QColor("#ffffff"))
+    return pal
 
 
 def test_show_bitrate(qtbot, app_mock):
@@ -16,8 +266,976 @@ def test_show_bitrate(qtbot, app_mock):
 def test_playlist_overlay(qtbot, app_mock):
     app_mock.playlist.playback_mode = PlaybackMode.one_loop
     app_mock.playlist.list.return_value = []
+    app_mock.ai = None
     w = PlaylistOverlay(app_mock)
     qtbot.addWidget(w)
     w.show()
     # assert no error.
     w.show_tab(0)
+    assert not w._ai_radio_btn.isEnabled()
+
+
+def test_playlist_overlay_enter_ai_radio(qtbot, app_mock, mocker):
+    app_mock.playlist.playback_mode = PlaybackMode.one_loop
+    app_mock.playlist.mode = PlaylistMode.normal
+    app_mock.ai = FakeAI()
+    app_mock.fm.is_active = False
+    app_mock.ui.ai_chat_overlay.show = mocker.MagicMock()
+    app_mock.ui.ai_chat_overlay.raise_ = mocker.MagicMock()
+    w = PlaylistOverlay(app_mock)
+    qtbot.addWidget(w)
+
+    w.enter_ai_radio()
+
+    assert app_mock.ai.radio is not None
+    assert app_mock.ai.activate_radio_calls == [True]
+    app_mock.ui.ai_chat_overlay.show.assert_called_once()
+
+
+def test_ai_chat_overlay_is_app_fullscreen(qtbot, app_mock):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+
+    overlay.show()
+    qtbot.waitUntil(lambda: overlay.size() == parent.size())
+
+    assert overlay.size() == parent.size()
+    assert overlay.layout().contentsMargins().left() == 0
+    assert overlay.layout().contentsMargins().top() == 0
+    assert overlay.layout().contentsMargins().right() == 0
+    assert overlay.layout().contentsMargins().bottom() == 0
+    assert overlay.body._header.text() == "AI Assistant"
+    assert not overlay.body._radio_status_label.isVisible()
+    assert not overlay.body._sidebar_panel.isVisible()
+    assert isinstance(overlay.body._new_thread_btn, TextButton)
+    assert isinstance(overlay.body._sidebar_btn, TextButton)
+    assert isinstance(overlay.body._collapse_btn, TextButton)
+
+    overlay.body._collapse_overlay()
+    assert not overlay.isVisible()
+
+
+def test_ai_chat_keeps_assistant_header_when_ai_radio_is_active(qtbot, app_mock):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = FakeAIRadio()
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+
+    overlay.show()
+
+    assert overlay.body._header.text() == "AI Assistant"
+    assert overlay.body._radio_status_label.isVisibleTo(overlay.body)
+    assert overlay.body._new_thread_btn.isVisibleTo(overlay.body)
+    assert overlay.body._sidebar_btn.isVisibleTo(overlay.body)
+    assert overlay.body._collapse_btn.isVisibleTo(overlay.body)
+
+
+def test_ai_chat_sidebar_button_toggles_inline_playlist(qtbot, app_mock, mocker):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = FakeAIRadio()
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+
+    overlay.show()
+    assert not overlay.body._sidebar_panel.isVisible()
+    assert isinstance(
+        overlay.body._playlist_sidebar.itemDelegate(),
+        FMCandidatePlaylistDelegate,
+    )
+    overlay.body._playlist_sidebar.scroll_to_current_song = mocker.MagicMock()
+
+    overlay.body._sidebar_btn.click()
+    assert overlay.body._sidebar_panel.isVisible()
+    assert overlay.body._sidebar_shadow.isVisible()
+    assert overlay.body._right_sidebar_stack.currentWidget() is (
+        overlay.body._playlist_sidebar
+    )
+    assert overlay.isVisible()
+    overlay.body._playlist_sidebar.scroll_to_current_song.assert_called_once()
+
+    overlay.body._sidebar_btn.click()
+    assert not overlay.body._sidebar_panel.isVisible()
+    assert not overlay.body._sidebar_shadow.isVisible()
+
+
+def test_ai_chat_radio_query_updates_playlist_sidebar(qtbot, app_mock, mocker):
+    app_mock.ai = FakeAI(FakeAIRadioToolCopilot())
+    app_mock.ai.radio = FakeAIRadio()
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    overlay.body._playlist_sidebar.scroll_to_current_song = mocker.MagicMock()
+
+    asyncio.run(overlay.body._chat_box.exec_user_query("换一批"))
+
+    assert overlay.body._sidebar_panel.isVisibleTo(overlay.body)
+    assert overlay.body._right_sidebar_stack.currentWidget() is (
+        overlay.body._playlist_sidebar
+    )
+    assert overlay.body._sidebar_status_label.text() == "Updating candidates"
+    assert overlay.body._sidebar_status_label.isVisibleTo(overlay.body)
+    overlay.body._playlist_sidebar.scroll_to_current_song.assert_called()
+    history_text = "\n".join(
+        label.toPlainText()
+        for label in overlay.body._chat_box.history_widget.findChildren(RoundedLabel)
+    )
+    assert "已更新候选歌曲" in history_text
+    tool_events = overlay.body._chat_box.history_widget.findChildren(
+        ChatToolEventCard
+    )
+    assert len(tool_events) == 1
+    assert "fm_candidates_replace" in tool_events[0].text()
+
+
+def test_ai_chat_radio_lifecycle_tool_opens_sidebar(qtbot, app_mock, mocker):
+    app_mock.ai = FakeAI(FakeAIRadioLifecycleToolCopilot())
+    app_mock.ai.radio = FakeAIRadio()
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    overlay.body._playlist_sidebar.scroll_to_current_song = mocker.MagicMock()
+
+    asyncio.run(overlay.body._chat_box.exec_user_query("开启 AI 电台"))
+
+    assert overlay.body._sidebar_panel.isVisibleTo(overlay.body)
+    assert overlay.body._right_sidebar_stack.currentWidget() is (
+        overlay.body._playlist_sidebar
+    )
+    overlay.body._playlist_sidebar.scroll_to_current_song.assert_called()
+    history_text = "\n".join(
+        label.toPlainText()
+        for label in overlay.body._chat_box.history_widget.findChildren(RoundedLabel)
+    )
+    assert "AI 电台已开启" in history_text
+    tool_events = overlay.body._chat_box.history_widget.findChildren(
+        ChatToolEventCard
+    )
+    assert len(tool_events) == 1
+    assert "ai_radio_activate" in tool_events[0].text()
+
+
+def test_ai_chat_body_and_sidebar_use_distinct_background_roles(qtbot, app_mock):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    qtbot.waitUntil(
+        lambda: overlay.body._artifact_sidebar._song_list_view.palette().color(
+            overlay.body._artifact_sidebar._song_list_view.palette().ColorRole.Window
+        )
+        == overlay.body.palette().color(overlay.body.palette().ColorRole.Base)
+    )
+
+    body_pal = overlay.body.palette()
+    panel_pal = overlay.body._sidebar_panel.palette()
+    sidebar_pal = overlay.body._right_sidebar_stack.palette()
+    artifact_view = overlay.body._artifact_sidebar._song_list_view
+    artifact_pal = artifact_view.palette()
+    artifact_viewport_pal = artifact_view.viewport().palette()
+
+    assert body_pal.color(body_pal.ColorRole.Window) == body_pal.color(
+        body_pal.ColorRole.Base
+    )
+    assert sidebar_pal.color(sidebar_pal.ColorRole.Window) == sidebar_pal.color(
+        sidebar_pal.ColorRole.Base
+    )
+    assert body_pal.color(body_pal.ColorRole.Window) != sidebar_pal.color(
+        sidebar_pal.ColorRole.Window
+    )
+    assert panel_pal.color(panel_pal.ColorRole.Window) == sidebar_pal.color(
+        sidebar_pal.ColorRole.Window
+    )
+    assert not overlay.body._sidebar_panel.autoFillBackground()
+    assert not overlay.body._right_sidebar_stack.autoFillBackground()
+    assert not overlay.body._playlist_sidebar.autoFillBackground()
+    assert not overlay.body._playlist_sidebar.viewport().autoFillBackground()
+    assert artifact_pal.color(artifact_pal.ColorRole.Window) == body_pal.color(
+        body_pal.ColorRole.Base
+    )
+    assert artifact_viewport_pal.color(
+        artifact_viewport_pal.ColorRole.Window
+    ) == body_pal.color(body_pal.ColorRole.Base)
+    assert not artifact_view.autoFillBackground()
+    assert not artifact_view.viewport().autoFillBackground()
+    history = overlay.body._chat_box.history_widget
+    history_pal = history._history_area.palette()
+    viewport_pal = history._history_area.viewport().palette()
+    content_pal = history.history_widget.palette()
+    assert history_pal.color(history_pal.ColorRole.Window) == body_pal.color(
+        body_pal.ColorRole.Base
+    )
+    assert viewport_pal.color(viewport_pal.ColorRole.Window) == body_pal.color(
+        body_pal.ColorRole.Base
+    )
+    assert content_pal.color(content_pal.ColorRole.Window) == body_pal.color(
+        body_pal.ColorRole.Base
+    )
+    input_pal = overlay.body._chat_box.input_widget.palette()
+    assert input_pal.color(input_pal.ColorRole.Window) != body_pal.color(
+        body_pal.ColorRole.Window
+    )
+    editor = overlay.body._chat_box.input_widget._editor
+    editor_pal = editor.palette()
+    editor_viewport_pal = editor.viewport().palette()
+    assert editor_pal.color(editor_pal.ColorRole.Window) == editor_pal.color(
+        editor_pal.ColorRole.Base
+    )
+    assert editor_viewport_pal.color(
+        editor_viewport_pal.ColorRole.Window
+    ) == editor_pal.color(editor_pal.ColorRole.Window)
+    assert editor.styleSheet()
+    assert not editor.autoFillBackground()
+    assert not editor.viewport().autoFillBackground()
+    send_btn = overlay.body._chat_box.input_widget._send_btn
+    assert isinstance(send_btn, ChatSendButton)
+    assert send_btn.text() == ""
+    assert send_btn.parent() is overlay.body._chat_box.input_widget
+
+
+def test_ai_chat_renders_assistant_markdown(qtbot):
+    history = ChatHistoryWidget()
+    qtbot.addWidget(history)
+
+    label = history.create_message_label("assistant", "**Bold**\n\n- item")
+
+    assert 'name="qrichtext"' in label.text()
+    assert "font-weight:700" in label.text()
+    assert "Bold" in label.text()
+    assert ">item</li>" in label.text()
+
+
+def test_ai_chat_user_message_has_limited_width(qtbot):
+    history = ChatHistoryWidget()
+    history.resize(900, 400)
+    qtbot.addWidget(history)
+    history.show()
+
+    user_label = history.create_message_label(
+        "user",
+        "这是一段比较长的用户输入，显示在对话流里时不应该铺满整行。",
+    )
+    assistant_label = history.create_message_label("assistant", "assistant")
+    qtbot.waitUntil(lambda: user_label.parent().width() > 400)
+
+    user_row = user_label.parent()
+    assert isinstance(user_row, ChatMessageRow)
+    assert user_row.role == "user"
+    assert user_label.maximumWidth() < user_row.width()
+    assert user_label.maximumWidth() == max(240, int(user_row.width() * 0.7))
+    assert assistant_label.maximumWidth() == 16777215
+
+
+def test_ai_chat_message_background_roles(qtbot):
+    original_palette = QGuiApplication.palette()
+    test_palette = _palette_with_colors("#eeeeee", "#ffffff")
+    QGuiApplication.setPalette(test_palette)
+    try:
+        history = ChatHistoryWidget()
+        qtbot.addWidget(history)
+
+        user_label = history.create_message_label("user", "hello")
+        assistant_label = history.create_message_label("assistant", "hello")
+
+        user_pal = user_label.palette()
+        assistant_pal = assistant_label.palette()
+        assert user_label.backgroundRole() == user_pal.ColorRole.Window
+        assert assistant_label.backgroundRole() == assistant_pal.ColorRole.Base
+        assert user_label._surface_visible
+        assert not assistant_label._surface_visible
+        assert user_pal.color(user_label.backgroundRole()) == test_palette.color(
+            test_palette.ColorRole.Window
+        )
+        assert assistant_pal.color(
+            assistant_label.backgroundRole()
+        ) == test_palette.color(test_palette.ColorRole.Base)
+        assert user_pal.color(user_label.backgroundRole()) != assistant_pal.color(
+            assistant_label.backgroundRole()
+        )
+    finally:
+        QGuiApplication.setPalette(original_palette)
+
+
+def test_ai_chat_tool_event_aligns_with_assistant_text(qtbot):
+    history = ChatHistoryWidget()
+    history.resize(900, 500)
+    qtbot.addWidget(history)
+    history.show()
+
+    assistant_label = history.create_message_label("assistant", "assistant")
+    tool_card = history.add_tool_event("Tool called: ai_radio_get_state")
+    qtbot.waitUntil(lambda: tool_card._label.x() > 0)
+
+    assert tool_card._label.mapTo(history.history_widget, QPoint(0, 0)).x() == (
+        assistant_label.viewport().mapTo(history.history_widget, QPoint(0, 0)).x()
+        + int(assistant_label.document().documentMargin())
+    )
+
+
+def test_ai_chat_refreshes_palette_roles(qtbot, app_mock):
+    original_palette = QGuiApplication.palette()
+    light_palette = _palette_with_colors("#f0f0f0", "#ffffff")
+    dark_palette = _palette_with_colors(
+        "#303030", "#202020", text="#eeeeee", highlight="#6d8dff"
+    )
+    QGuiApplication.setPalette(light_palette)
+    try:
+        app_mock.ai = FakeAI()
+        app_mock.ai.radio = FakeAIRadio()
+        app_mock.playlist.list.return_value = []
+        app_mock.theme_mgr = FakeThemeManager()
+        parent = QWidget()
+        parent.resize(QSize(960, 600))
+        parent.show()
+        qtbot.addWidget(parent)
+        app_mock.size.return_value = parent.size()
+        overlay = create_aichat_overlay(app_mock, parent=parent)
+        history = overlay.body._chat_box.history_widget
+        user_label = history.create_message_label("user", "hello")
+        assistant_label = history.create_message_label("assistant", "hello")
+        status_card = history.add_streaming_status("thinking")
+        tool_card = history.add_tool_event(
+            "Tool called: create_song_suggestions_artifact"
+        )
+        overlay.body._chat_box.input_widget.set_msg("AI Radio is active")
+
+        QGuiApplication.setPalette(dark_palette)
+        app_mock.theme_mgr.theme_changed.emit("dark")
+        qtbot.waitUntil(
+            lambda: overlay.body._sidebar_panel.palette().color(
+                overlay.body._sidebar_panel.palette().ColorRole.Window
+            ) == dark_palette.color(dark_palette.ColorRole.Window)
+        )
+
+        body_pal = overlay.body.palette()
+        sidebar_pal = overlay.body._sidebar_panel.palette()
+        input_widget = overlay.body._chat_box.input_widget
+        assert body_pal.color(body_pal.ColorRole.Window) == dark_palette.color(
+            dark_palette.ColorRole.Base
+        )
+        assert sidebar_pal.color(sidebar_pal.ColorRole.Window) == dark_palette.color(
+            dark_palette.ColorRole.Window
+        )
+        assert user_label.palette().color(
+            user_label.backgroundRole()
+        ) == dark_palette.color(dark_palette.ColorRole.Window)
+        assert assistant_label.palette().color(
+            assistant_label.backgroundRole()
+        ) == dark_palette.color(dark_palette.ColorRole.Base)
+        assert history._history_area.palette().color(
+            history._history_area.palette().ColorRole.Window
+        ) == dark_palette.color(dark_palette.ColorRole.Base)
+        assert input_widget.palette().color(
+            input_widget.palette().ColorRole.Window
+        ) == dark_palette.color(dark_palette.ColorRole.Window)
+        assert not overlay.body._playlist_sidebar.autoFillBackground()
+        assert not overlay.body._playlist_sidebar.viewport().autoFillBackground()
+        assert input_widget._msg_label.textFormat() == Qt.TextFormat.PlainText
+        assert input_widget._msg_label.text() == "AI Radio is active"
+        assert "color:" not in input_widget._msg_label.text()
+        assert input_widget._msg_label.palette().color(
+            input_widget._msg_label.palette().ColorRole.WindowText
+        ) == secondary_text_color(dark_palette)
+        assert status_card._label.palette().color(
+            status_card._label.palette().ColorRole.WindowText
+        ) == dark_palette.color(dark_palette.ColorRole.WindowText)
+        assert status_card.palette().color(
+            status_card.palette().ColorRole.Window
+        ) == dark_palette.color(dark_palette.ColorRole.Window)
+        assert tool_card._label.palette().color(
+            tool_card._label.palette().ColorRole.WindowText
+        ) == secondary_text_color(dark_palette)
+        assert overlay.body._radio_status_label.palette().color(
+            overlay.body._radio_status_label.palette().ColorRole.WindowText
+        ) == secondary_text_color(dark_palette)
+        border_color = surface_border_color(dark_palette, QPalette.ColorRole.Base)
+        assert border_color.alpha() > 0
+        assert border_color != dark_palette.color(dark_palette.ColorRole.Mid)
+    finally:
+        QGuiApplication.setPalette(original_palette)
+
+
+def test_ai_chat_theme_change_refreshes_after_delayed_palette(qtbot, app_mock):
+    original_palette = QGuiApplication.palette()
+    light_palette = _palette_with_colors("#f0f0f0", "#ffffff")
+    dark_palette = _palette_with_colors(
+        "#303030", "#202020", text="#eeeeee", highlight="#6d8dff"
+    )
+    QGuiApplication.setPalette(light_palette)
+    try:
+        app_mock.ai = FakeAI()
+        app_mock.ai.radio = None
+        app_mock.playlist.list.return_value = []
+        app_mock.theme_mgr = FakeThemeManager()
+        parent = QWidget()
+        parent.resize(QSize(960, 600))
+        parent.show()
+        qtbot.addWidget(parent)
+        app_mock.size.return_value = parent.size()
+        overlay = create_aichat_overlay(app_mock, parent=parent)
+
+        QTimer.singleShot(10, lambda: QGuiApplication.setPalette(dark_palette))
+        QTimer.singleShot(20, lambda: app_mock.theme_mgr.theme_changed.emit("dark"))
+
+        qtbot.waitUntil(
+            lambda: overlay.body.palette().color(
+                overlay.body.palette().ColorRole.Window
+            ) == dark_palette.color(dark_palette.ColorRole.Base)
+        )
+
+        history_area = overlay.body._chat_box.history_widget._history_area
+        assert history_area.palette().color(
+            history_area.palette().ColorRole.Window
+        ) == dark_palette.color(dark_palette.ColorRole.Base)
+        assert overlay.body._chat_box.input_widget.palette().color(
+            overlay.body._chat_box.input_widget.palette().ColorRole.Window
+        ) == dark_palette.color(dark_palette.ColorRole.Window)
+    finally:
+        QGuiApplication.setPalette(original_palette)
+
+
+def test_ai_chat_theme_change_reapplies_self_painted_palettes(qtbot, app_mock):
+    original_palette = QGuiApplication.palette()
+    light_palette = _palette_with_colors("#f0f0f0", "#ffffff")
+    dirty_palette = _palette_with_colors("#111111", "#121212")
+    QGuiApplication.setPalette(light_palette)
+    try:
+        app_mock.ai = FakeAI()
+        app_mock.ai.radio = None
+        app_mock.playlist.list.return_value = []
+        app_mock.theme_mgr = FakeThemeManager()
+        parent = QWidget()
+        parent.resize(QSize(960, 600))
+        parent.show()
+        qtbot.addWidget(parent)
+        app_mock.size.return_value = parent.size()
+        overlay = create_aichat_overlay(app_mock, parent=parent)
+
+        overlay.body._sidebar_panel.setPalette(dirty_palette)
+        overlay.body._chat_box.input_widget.setPalette(dirty_palette)
+        app_mock.theme_mgr.theme_changed.emit("light")
+
+        sidebar_pal = overlay.body._sidebar_panel.palette()
+        input_pal = overlay.body._chat_box.input_widget.palette()
+        assert sidebar_pal.color(sidebar_pal.ColorRole.Window) == light_palette.color(
+            light_palette.ColorRole.Window
+        )
+        assert input_pal.color(input_pal.ColorRole.Window) == light_palette.color(
+            light_palette.ColorRole.Window
+        )
+    finally:
+        QGuiApplication.setPalette(original_palette)
+
+
+def test_ai_chat_assistant_rows_keep_content_height(qtbot):
+    history = ChatHistoryWidget()
+    history.resize(900, 500)
+    qtbot.addWidget(history)
+    history.show()
+
+    first_label = history.create_message_label("assistant", "第一段回复")
+    second_label = history.create_message_label("assistant", "第二段回复")
+    first_row = first_label.parent()
+    second_row = second_label.parent()
+
+    qtbot.waitUntil(lambda: second_row.y() > first_row.y())
+
+    assert first_row.height() == first_row.sizeHint().height()
+    assert second_row.y() - first_row.y() == (
+        first_row.height() + history._history_layout.spacing()
+    )
+
+
+def test_ai_chat_emits_markdown_link_signal(qtbot):
+    history = ChatHistoryWidget()
+    qtbot.addWidget(history)
+    urls = []
+    history.link_activated.connect(urls.append)
+
+    label = history.create_message_label(
+        "assistant",
+        "[Song](fuo://song-suggestion?title=hello&artists=mary)",
+    )
+
+    label.link_activated.emit("fuo://song-suggestion?title=hello&artists=mary")
+    assert urls == ["fuo://song-suggestion?title=hello&artists=mary"]
+
+
+def test_ai_chat_history_renders_artifact_card(qtbot):
+    history = ChatHistoryWidget()
+    qtbot.addWidget(history)
+    artifact = CopilotArtifact(
+        identifier=1,
+        type="songs",
+        title="Night Songs",
+        songs=[
+            SongSuggestion(
+                title="hello world",
+                artists_name="mary",
+                description="",
+            )
+        ],
+    )
+
+    card = history.add_artifact(artifact)
+
+    assert isinstance(card, ChatArtifactCard)
+    assert card.artifact is artifact
+
+
+def test_ai_chat_shows_song_artifact_in_right_sidebar(qtbot, app_mock):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    artifact = CopilotArtifact(
+        identifier=1,
+        type="songs",
+        title="Night Songs",
+        songs=[
+            SongSuggestion(
+                title="hello world",
+                artists_name="mary",
+                description="",
+            )
+        ],
+    )
+
+    overlay.body.show_artifact(artifact)
+
+    assert overlay.body._sidebar_panel.isVisibleTo(overlay.body)
+    assert overlay.body._right_sidebar_stack.currentWidget() is (
+        overlay.body._artifact_sidebar
+    )
+    view = overlay.body._artifact_sidebar._song_list_view
+    assert isinstance(view, QListWidget)
+    assert view._radius == 8
+    model = view.model()
+    assert model.rowCount() == 1
+    item = view.item(0)
+    item_widget = view.itemWidget(item)
+    assert isinstance(item_widget, SongSuggestionItemWidget)
+    assert isinstance(item_widget.play_btn, PlayButton)
+    assert isinstance(item_widget.add_btn, PlusButton)
+    display_song = item.data(Qt.ItemDataRole.UserRole)
+    assert display_song.title == "hello world"
+    assert display_song.artists_name == "mary"
+    assert item_widget.song is display_song
+
+
+def test_ai_chat_parses_song_links():
+    suggestion = SongSuggestion(title="hello world", artists_name="mary", description="")
+
+    parsed_suggestion_info = parse_song_link_info(
+        song_suggestion_to_markdown_url(suggestion)
+    )
+    assert parsed_suggestion_info.kind == "suggestion"
+    parsed_suggestion = parsed_suggestion_info.model
+    assert isinstance(parsed_suggestion, SongSuggestion)
+    assert parsed_suggestion.title == "hello world"
+    assert parsed_suggestion.artists_name == "mary"
+    parsed_legacy_suggestion_info = parse_song_link_info(
+        "fuo://ai-song?title=hello&artists=mary"
+    )
+    assert parsed_legacy_suggestion_info.kind == "suggestion"
+    parsed_legacy_suggestion = parsed_legacy_suggestion_info.model
+    assert isinstance(parsed_legacy_suggestion, SongSuggestion)
+
+    parsed_song_info = parse_song_link_info(
+        "fuo://song?source=fake&identifier=1&title=hello&artists=mary"
+    )
+    assert parsed_song_info.kind == "resource"
+    parsed_song = parsed_song_info.model
+    assert isinstance(parsed_song, BriefSongModel)
+    assert parsed_song.source == "fake"
+    assert parsed_song.identifier == "1"
+
+    parsed_provider_song_info = parse_song_link_info("fuo://fake/songs/1")
+    assert parsed_provider_song_info.kind == "resource"
+    parsed_provider_song = parsed_provider_song_info.model
+    assert isinstance(parsed_provider_song, BriefSongModel)
+    assert parsed_provider_song.source == "fake"
+    assert parsed_provider_song.identifier == "1"
+
+    assert parse_song_link(song_suggestion_to_markdown_url(suggestion)) == (
+        parsed_suggestion
+    )
+
+
+def test_ai_chat_link_context_menu_differs_by_link_type(qtbot, app_mock, mocker):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    menus = []
+
+    class CapturingMenu(FakeMenu):
+        def exec(self, _pos):
+            menus.append([action.objectName() for action in self.actions()])
+
+    mocker.patch("feeluown.gui.uimain.ai_chat.QMenu", CapturingMenu)
+
+    overlay.body._on_link_context_menu_requested(
+        "fuo://song-suggestion?title=hello&artists=mary",
+        QPoint(0, 0),
+    )
+    overlay.body._on_link_context_menu_requested(
+        "fuo://fake/songs/1",
+        QPoint(0, 0),
+    )
+
+    assert "ai-chat-link-search" in menus[0]
+    assert "ai-chat-link-play" in menus[0]
+    assert "ai-chat-link-add-to-playlist" in menus[0]
+    assert "ai-chat-link-copy" in menus[0]
+    assert "ai-chat-link-search" not in menus[1]
+    assert "ai-chat-link-play" in menus[1]
+    assert "ai-chat-link-add-to-playlist" in menus[1]
+    assert "ai-chat-link-copy" in menus[1]
+
+
+def test_ai_chat_toolbar_starts_system_move(qtbot, app_mock, mocker):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    window = mocker.Mock()
+    window.startSystemMove.return_value = True
+    overlay.body._toolbar._window_handle = mocker.Mock(return_value=window)
+
+    overlay.show()
+    event = QMouseEvent(
+        QMouseEvent.Type.MouseButtonPress,
+        QPointF(1, 1),
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    overlay.body._toolbar.mousePressEvent(event)
+
+    window.startSystemMove.assert_called_once()
+
+
+def test_player_playlist_view_does_not_own_delegate(qtbot, app_mock):
+    app_mock.playlist.list.return_value = []
+    view = PlayerPlaylistView(app_mock)
+    qtbot.addWidget(view)
+
+    assert not isinstance(view.itemDelegate(), SongMiniCardListDelegate)
+
+
+def test_fm_candidate_delegate_marks_only_upcoming_playlist_songs(
+    qtbot,
+    app_mock,
+    song,
+    song1,
+    song2,
+):
+    PlayerPlaylistView._model = None
+    app_mock.ai = FakeAI()
+    app_mock.playlist.mode = PlaylistMode.fm
+    app_mock.playlist.list.return_value = [song, song1, song2]
+    app_mock.playlist.current_song = song
+    app_mock.playlist.current_song_index.return_value = 0
+    view = FakeDelegateView()
+    qtbot.addWidget(view)
+    delegate = FMCandidatePlaylistDelegate(app_mock, view)
+
+    assert not delegate.is_fm_candidate(FakeIndex(0))
+    assert delegate.is_fm_candidate(FakeIndex(1))
+    assert delegate.is_fm_candidate(FakeIndex(2))
+
+    app_mock.playlist.current_song_index.return_value = None
+    assert delegate.is_fm_candidate(FakeIndex(0))
+
+    app_mock.playlist.mode = PlaylistMode.normal
+    assert not delegate.is_fm_candidate(FakeIndex(1))
+
+
+def test_playlist_overlay_uses_fm_candidate_delegate_on_playlist_tab(
+    qtbot,
+    app_mock,
+):
+    PlayerPlaylistView._model = None
+    app_mock.playlist.playback_mode = PlaybackMode.one_loop
+    app_mock.playlist.mode = PlaylistMode.fm
+    app_mock.playlist.list.return_value = []
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = FakeAIRadio()
+    app_mock.fm.is_active = False
+    app_mock.size.return_value = QSize(960, 600)
+    w = PlaylistOverlay(app_mock)
+    qtbot.addWidget(w)
+
+    w.show()
+    w.show_tab(0)
+
+    assert isinstance(
+        w._player_playlist_view.itemDelegate(),
+        FMCandidatePlaylistDelegate,
+    )
+
+
+def test_ai_chat_overlay_toggles_titlebar_mode(qtbot, app_mock, mocker):
+    titlebar_mode = SimpleNamespace(
+        enter=mocker.MagicMock(),
+        exit=mocker.MagicMock(),
+        reapply=mocker.MagicMock(),
+    )
+    mocker.patch(
+        "feeluown.gui.uimain.ai_chat._create_titlebar_mode",
+        return_value=titlebar_mode,
+    )
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    assert isinstance(overlay, AIChatOverlay)
+
+    overlay.show()
+    overlay.hide()
+
+    titlebar_mode.enter.assert_called_once()
+    titlebar_mode.exit.assert_called_once()
+
+
+def test_ai_chat_overlay_reapplies_titlebar_mode_on_resize(qtbot, app_mock, mocker):
+    titlebar_mode = SimpleNamespace(
+        enter=mocker.MagicMock(),
+        exit=mocker.MagicMock(),
+        reapply=mocker.MagicMock(),
+    )
+    mocker.patch(
+        "feeluown.gui.uimain.ai_chat._create_titlebar_mode",
+        return_value=titlebar_mode,
+    )
+    app = QWidget()
+    app.ai = FakeAI()
+    app.ai.radio = None
+    app.theme_mgr = FakeThemeManager()
+    app.playlist = app_mock.playlist
+    app.playlist.mode_changed = Signal()
+    app.playlist.list.return_value = []
+    app.resize(QSize(960, 600))
+    app.show()
+    qtbot.addWidget(app)
+    overlay = create_aichat_overlay(app, parent=app)
+    assert isinstance(overlay, AIChatOverlay)
+
+    overlay.show()
+    app.resize(QSize(1000, 640))
+    qtbot.waitUntil(lambda: titlebar_mode.reapply.called)
+
+    titlebar_mode.reapply.assert_called_once()
+
+
+def test_ai_chat_overlay_skips_titlebar_mode_outside_macos(qtbot, app_mock, mocker):
+    mocker.patch("feeluown.gui.uimain.ai_chat.IS_MACOS", False)
+    sys.modules.pop("feeluown.gui.macos_titlebar", None)
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+
+    assert isinstance(overlay, AIChatOverlay)
+    assert overlay._titlebar_mode is None
+    assert "feeluown.gui.macos_titlebar" not in sys.modules
+
+
+def test_ai_chat_copilot_artifact_signal_renders_card(qtbot, app_mock):
+    app_mock.ai = FakeAI()
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+    artifact = CopilotArtifact(
+        identifier=1,
+        type="songs",
+        title="Night Songs",
+        songs=[
+            SongSuggestion(
+                title="hello world",
+                artists_name="mary",
+                description="",
+            )
+        ],
+    )
+
+    overlay.body._chat_box.copilot.artifact_added.emit(artifact)
+
+    qtbot.waitUntil(
+        lambda: bool(
+            overlay.body._chat_box.history_widget.findChildren(ChatArtifactCard)
+        )
+    )
+
+
+def test_ai_chat_renders_song_artifact_after_final_response(qtbot, app_mock):
+    app_mock.ai = FakeAI(FakeStreamingCopilot())
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+
+    asyncio.run(overlay.body._chat_box.exec_user_query("推荐几首华语经典歌曲"))
+
+    history = overlay.body._chat_box.history_widget
+    cards = history.findChildren(ChatArtifactCard)
+    tool_events = history.findChildren(ChatToolEventCard)
+    assert len(cards) == 1
+    assert len(tool_events) == 1
+    assert "create_song_suggestions_artifact" in tool_events[0].text()
+    assert cards[0].artifact.title == "Night Songs"
+    history_text = "\n".join(
+        label.toPlainText() for label in history.findChildren(RoundedLabel)
+    )
+    assert "我为您推荐了这些歌曲" in history_text
+    assert "我来" not in history_text
+    assert "我来我为您" not in history_text
+    tool_event_index = history._history_layout.indexOf(tool_events[0])
+    card_index = history._history_layout.indexOf(cards[0])
+    assert tool_event_index < card_index
+    last_history_widget = history._history_layout.itemAt(
+        history._history_layout.count() - 1
+    ).widget()
+    assert last_history_widget is cards[0]
+
+
+def test_ai_chat_shows_streaming_status_without_pre_tool_text(qtbot, app_mock):
+    copilot = PausedStreamingCopilot()
+    app_mock.ai = FakeAI(copilot)
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+
+    async def run_query():
+        task = asyncio.create_task(
+            overlay.body._chat_box.exec_user_query("推荐几首华语经典歌曲")
+        )
+        await asyncio.wait_for(copilot.first_token_seen.wait(), timeout=1)
+
+        history = overlay.body._chat_box.history_widget
+        status_cards = history.findChildren(ChatStreamingStatusCard)
+        assert len(status_cards) == 1
+        assert "AI is writing" in status_cards[0].text()
+        history_text = "\n".join(
+            label.toPlainText() for label in history.findChildren(RoundedLabel)
+        )
+        assert "我来" not in history_text
+
+        copilot.resume.set()
+        await asyncio.wait_for(task, timeout=1)
+
+    asyncio.run(run_query())
+
+    history = overlay.body._chat_box.history_widget
+    assert not history.findChildren(ChatStreamingStatusCard)
+    history_text = "\n".join(
+        label.toPlainText() for label in history.findChildren(RoundedLabel)
+    )
+    assert "我为您推荐了这些歌曲" in history_text
+
+
+def test_ai_chat_does_not_show_pre_tool_streaming_text(qtbot, app_mock):
+    app_mock.ai = FakeAI(FakeStreamingCopilot())
+    app_mock.ai.radio = None
+    app_mock.playlist.list.return_value = []
+    parent = QWidget()
+    parent.resize(QSize(960, 600))
+    parent.show()
+    qtbot.addWidget(parent)
+    app_mock.size.return_value = parent.size()
+    overlay = create_aichat_overlay(app_mock, parent=parent)
+
+    async def run_until_tool():
+        chat_box = overlay.body._chat_box
+        chat_box.history_widget.add_message("user", "推荐几首华语经典歌曲")
+        chat_box._collecting_artifacts = True
+        chat_box._pending_artifacts = []
+        response_message = ""
+        async for token, metadata in chat_box.copilot.astream_user_query("query"):
+            node = metadata["langgraph_node"]
+            if node == "model":
+                for block in token.content_blocks:
+                    if block["type"] == "text":
+                        response_message += block["text"]
+            elif node == "tools":
+                chat_box._collecting_artifacts = False
+                return response_message
+
+    pre_tool_text = asyncio.run(run_until_tool())
+    history = overlay.body._chat_box.history_widget
+    history_text = "\n".join(
+        label.toPlainText() for label in history.findChildren(RoundedLabel)
+    )
+
+    assert pre_tool_text == "我来"
+    assert "我来" not in history_text

--- a/tests/player/test_fm.py
+++ b/tests/player/test_fm.py
@@ -79,6 +79,26 @@ async def test_multiple_eof_reached_signal(app_mock, song, mocker):
 
 
 @pytest.mark.asyncio
+async def test_fm_mode_accepts_async_fetch(app_mock, song, mocker):
+    async def fetch(number):
+        assert number == 3
+        return [song] * 3
+
+    mock_fm_add = mocker.patch.object(Playlist, 'fm_add')
+    app_mock.playlist = Playlist(app_mock)
+    app_mock.task_mgr = TaskManager(app_mock)
+    fm = FM(app_mock)
+    fm.activate(fetch)
+    task_spec = app_mock.task_mgr.get_or_create(fm._fetch_songs_task_name)
+    await task_spec._task
+    for _ in range(20):
+        if mock_fm_add.called:
+            break
+        await asyncio.sleep(0.01)
+    assert mock_fm_add.called
+
+
+@pytest.mark.asyncio
 async def test_reactivate_fm_mode_after_playing_other_songs(
         app_mock, song, song1, mocker):
 

--- a/tests/player/test_fm_candidates.py
+++ b/tests/player/test_fm_candidates.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock
+
+from feeluown.player import Playlist, PlaylistMode
+from feeluown.player.fm_candidates import FMCandidateManager
+
+
+def create_candidate_manager():
+    app = MagicMock()
+    app.playlist = Playlist(app)
+    app.playlist.mode = PlaylistMode.fm
+    return app, FMCandidateManager(app)
+
+
+def test_fm_candidates_remove_and_keep_upcoming_songs(song, song1, song2, song3):
+    app, candidates = create_candidate_manager()
+    app.playlist.fm_add(song)
+    app.playlist.fm_add(song1)
+    app.playlist.fm_add(song2)
+    app.playlist.fm_add(song3)
+    app.playlist._current_song = song
+
+    ok = candidates.remove([2])
+
+    assert ok is True
+    assert app.playlist.list() == [song, song1, song3]
+
+    ok = candidates.keep([2])
+
+    assert ok is True
+    assert app.playlist.list() == [song, song3]
+
+
+def test_fm_candidates_clear_and_append(song, song1, song2):
+    app, candidates = create_candidate_manager()
+    app.playlist.fm_add(song)
+    app.playlist.fm_add(song1)
+    app.playlist._current_song = song
+
+    ok = candidates.clear()
+
+    assert ok is True
+    assert app.playlist.list() == [song]
+
+    ok = candidates.append([song2])
+
+    assert ok is True
+    assert candidates.list_candidates() == [song2]
+    assert app.playlist.list() == [song, song2]
+
+
+def test_fm_candidates_replace_keeps_selected_positions(song, song1, song2, song3):
+    app, candidates = create_candidate_manager()
+    app.playlist.fm_add(song)
+    app.playlist.fm_add(song1)
+    app.playlist.fm_add(song2)
+    app.playlist._current_song = song
+
+    ok = candidates.replace([song3], keep_positions=[2])
+
+    assert ok is True
+    assert candidates.list_candidates() == [song2, song3]
+    assert app.playlist.list() == [song, song2, song3]
+
+
+def test_fm_candidates_reject_operations_outside_fm(song):
+    app = MagicMock()
+    app.playlist = Playlist(app)
+    app.playlist.add(song)
+    candidates = FMCandidateManager(app)
+
+    ok = candidates.clear()
+
+    assert ok is False
+    assert app.playlist.list() == [song]

--- a/tests/player/test_playlist.py
+++ b/tests/player/test_playlist.py
@@ -316,6 +316,33 @@ async def test_playlist_fm_mode_play_previous(app_mock, song, song1):
     assert pl.mode is PlaylistMode.fm
 
 
+def test_playlist_fm_candidates_are_songs_after_current_song(
+        app_mock, song, song1, song2):
+    pl = Playlist(app_mock)
+    pl.mode = PlaylistMode.fm
+    pl.fm_add(song)
+    pl.fm_add(song1)
+    pl.fm_add(song2)
+    pl._current_song = song
+
+    assert pl.current_song_index() == 0
+    assert pl.list_fm_candidates() == [song1, song2]
+
+    pl._current_song = song1
+    assert pl.current_song_index() == 1
+    assert pl.list_fm_candidates() == [song2]
+
+
+def test_playlist_fm_candidates_are_empty_outside_fm(
+        app_mock, song, song1):
+    pl = Playlist(app_mock)
+    pl.add(song)
+    pl.add(song1)
+    pl._current_song = song
+
+    assert pl.list_fm_candidates() == []
+
+
 @pytest.mark.asyncio
 async def test_playlist_eof_reached(app_mock, song, mocker,
                                     mock_a_set_cursong):


### PR DESCRIPTION
## Overview

This PR adds an in-app AI Assistant and introduces AI Radio as a Copilot-controlled FM flow. The assistant is the user-facing control surface: users can chat with AI, see streaming progress and tool calls, inspect song artifacts, open the playlist/sidebar, and manage AI Radio without leaving the assistant page.

## Main Changes

### 1. AI Assistant UI

- Rework the AI chat surface into an app-fullscreen assistant overlay instead of a standalone dialog.
- Add an assistant toolbar with new-thread, sidebar, and collapse actions.
- Use macOS native-titlebar handling only on macOS so the assistant can be shown without a regular titlebar there.
- Add a right sidebar for the current playlist and AI-produced song artifacts.
- Render assistant replies as markdown/rich text, including song links.
- Show streaming/tool-call progress so users can tell when AI is writing or using a tool.
- Polish the chat layout with palette-based colors, rounded surfaces, bounded user messages, consistent spacing, input styling, and sidebar separation.
- Support different link behavior for AI song suggestions (`fuo://song-suggestion...`) and real provider resources (`fuo://netease/songs/...`), including context menus.

### 2. AI Radio and FM/Playlist Refactor

- Add `AIRadioSession` under `feeluown.ai` and attach the active session to `app.ai.radio`.
- Wire AI Radio into the existing FM flow instead of adding a separate playback mode.
- Treat playlist/FM candidates as the single source of truth: in FM mode, songs after the current song are candidates.
- Keep candidate storage and mutation in playlist/FM (`app.fm.candidates`), not inside AI Radio.
- Remove the AI Radio-local prefetched candidate queue; AI Radio now recommends/matches songs, while playlist/FM owns candidate state.
- Add playlist helpers for current-song indexing and FM candidate listing.
- Add reusable FM candidate presentation in the playlist, including a candidate badge that can apply to AI Radio and future radio modes.
- Match AI song suggestions into real provider songs conservatively in small batches before inserting them into FM candidates.
- Preserve AI Radio session preferences/avoidances so user feedback can influence future automatic recommendations.

### 3. Copilot Tools and AI-Controlled Operations

- Extend Copilot with structured song suggestions and song-list artifacts.
- Add `ai_radio_*` tools for radio lifecycle/state/preferences:
  - `ai_radio_activate`
  - `ai_radio_deactivate`
  - `ai_radio_get_state`
  - `ai_radio_update_preferences`
- Add `fm_candidates_*` tools for candidate mutation through the FM candidate manager:
  - `fm_candidates_clear`
  - `fm_candidates_remove`
  - `fm_candidates_keep`
  - `fm_candidates_append`
  - `fm_candidates_replace`
- Add `playback_*` tools for basic playback control:
  - `playback_get_state`
  - `playback_next_track`
  - `playback_previous_track`
  - `playback_pause`
  - `playback_resume`
  - `playback_toggle`
  - `playback_stop`
  - `playback_set_volume`
  - `playback_adjust_volume`
- Rename the suggestion playback tool to `play_song_suggestion` so its input type is explicit.
- Keep command-style radio/candidate tools returning `bool`; use `ai_radio_get_state` when the assistant needs the updated state.
- Add tool-call observability in the assistant UI and automatically reveal the playlist sidebar for AI Radio/FM candidate tool calls.
- Add song suggestion artifacts that users can open from the chat and inspect in the sidebar.

### 4. Supporting UI/Runtime Infrastructure

- Add reusable overlay options for app overlays.
- Add macOS native-titlebar support and an example showing the native titlebar mode.
- Avoid importing macOS titlebar/`ctypes` code on non-macOS paths.
- Add thumbnail/network-status related UI support used by the updated assistant and surrounding UI.
- Add i18n entries for the new assistant, AI Radio, tool-call, artifact, and FM candidate labels.
- Update settings so the AI Radio prompt remains configurable.
- Update related resource/link parsing and serialization support needed by assistant song links and artifacts.

### 5. Tests and Coverage

- Add unit tests for AI Radio session behavior, FM candidate operations, preference updates, playback tools, and Copilot tools.
- Add UI tests for the assistant overlay, toolbar/sidebar behavior, markdown rendering, streaming behavior, tool-call display, song links, artifact sidebar, palette refresh, and candidate badges.
- Add coverage for playlist/FM candidate semantics so future radio modes can reuse the same model.
- Add supporting tests for i18n, media/resource helpers, library search/matching, MCP behavior, thumbnail cache, and related UI components touched by this PR.

## Tests

- `uv run make test`
  - `347 passed, 5 skipped, 20 warnings`
- GitHub Actions are passing on Ubuntu, macOS, and Windows for Python 3.10 and 3.14.