### PR TITLE
AI: Prefer standby providers when matching song suggestions

### DIFF
--- a/feeluown/ai/matcher.py
+++ b/feeluown/ai/matcher.py
@@ -1,10 +1,5 @@
 from feeluown.app import App
-from feeluown.library import (
-    BriefSongModel,
-    get_standby_score,
-    STANDBY_FULL_SCORE,
-    STANDBY_DEFAULT_MIN_SCORE,
-)
+from feeluown.library import BriefSongModel, SongStandbyOptions
 
 
 class SongSuggestionMatcher:
@@ -17,16 +12,8 @@ class SongSuggestionMatcher:
         This API is in alpha stage.
         """
         origin = suggestion.to_brief_song()
-        title, artists_name = suggestion.title, suggestion.artists_name
-        candidates = []
-        async for result in self._app.library.a_search(f"{title} {artists_name}"):
-            if result is None:
-                continue
-            for standby in result.songs:
-                score = get_standby_score(origin, standby)
-                if score == STANDBY_FULL_SCORE:
-                    return standby
-                elif score >= STANDBY_DEFAULT_MIN_SCORE:
-                    candidates.append((score, standby))
-        sorted_candidates = sorted(candidates, key=lambda x: x[0], reverse=True)
-        return sorted_candidates[0][1] if sorted_candidates else None
+        standbys = await self._app.library.a_list_song_standby_v3(
+            origin,
+            SongStandbyOptions(single_full_score_per_source=True),
+        )
+        return standbys[0] if standbys else None

--- a/feeluown/library/library.py
+++ b/feeluown/library/library.py
@@ -252,23 +252,62 @@ class Library:
         """List song standbys without preparing media."""
         if options is None:
             options = SongStandbyOptions()
-        if options.source_in is None:
-            pvd_ids = self._providers_standby or [pvd.identifier for pvd in self.list()]
-        else:
-            pvd_ids = [
-                pvd.identifier for pvd in self._filter(identifier_in=options.source_in)
-            ]
-        score_fn = options.score_fn or get_standby_score
-        limit_per_source = max(options.limit_per_source, 1)
 
         q = "{} {}".format(song.title_display, song.artists_name_display)
         if not q.strip():
             return []
 
-        standbys = []
+        if options.source_in is not None:
+            pvd_ids = self._get_registered_provider_ids(options.source_in)
+            return await self._a_list_song_standby_v3_from_sources(
+                song, q, pvd_ids, options
+            )
+
+        standby_pvd_ids = self._get_registered_provider_ids(self._providers_standby)
+        if standby_pvd_ids:
+            standbys = await self._a_list_song_standby_v3_from_sources(
+                song, q, standby_pvd_ids, options
+            )
+            if standbys:
+                return standbys
+
+        standby_pvd_id_set = set(standby_pvd_ids)
+        other_pvd_ids = [
+            pvd.identifier
+            for pvd in self.list()
+            if pvd.identifier not in standby_pvd_id_set
+        ]
+        return await self._a_list_song_standby_v3_from_sources(
+            song, q, other_pvd_ids, options
+        )
+
+    def _get_registered_provider_ids(self, source_in):
+        if not source_in:
+            return []
+        registered_provider_ids = {pvd.identifier for pvd in self.list()}
+        return [
+            source
+            for source in dict.fromkeys(source_in)
+            if source in registered_provider_ids
+        ]
+
+    async def _a_list_song_standby_v3_from_sources(
+        self,
+        song,
+        query,
+        source_in,
+        options,
+    ) -> List[BriefSongModel]:
+        if not source_in:
+            return []
+
+        score_fn = options.score_fn or get_standby_score
+        limit_per_source = max(options.limit_per_source, 1)
+
+        scored_standbys = []
         standby_counter = Counter()
         full_score_sources = set()
-        async for result in self.a_search(q, source_in=pvd_ids):
+        async for result in self.a_search(query, source_in=source_in):
             if result is None:
                 continue
             for standby in result.songs:
@@ -285,17 +324,23 @@ class Library:
                     options.single_full_score_per_source
                     and score == STANDBY_FULL_SCORE
                 ):
-                    standbys = [s for s in standbys if s.source != source]
-                    standbys.append(standby)
+                    scored_standbys = [
+                        (s, s_score)
+                        for s, s_score in scored_standbys
+                        if s.source != source
+                    ]
+                    scored_standbys.append((standby, score))
                     standby_counter[source] = 1
                     full_score_sources.add(source)
                     continue
                 if standby_counter[source] >= limit_per_source:
                     continue
                 if score >= options.min_score:
-                    standbys.append(standby)
+                    scored_standbys.append((standby, score))
                     standby_counter[source] += 1
-        return standbys
+
+        scored_standbys.sort(key=lambda item: item[1], reverse=True)
+        return [standby for standby, _ in scored_standbys]
 
     async def a_list_song_standby_v2(
         self,

--- a/tests/ai/test_matcher.py
+++ b/tests/ai/test_matcher.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+import pytest
+
+from feeluown.ai import SongSuggestion
+from feeluown.ai.matcher import SongSuggestionMatcher
+from feeluown.library import BriefSongModel, Library, Provider, SimpleSearchResult
+
+
+class SearchProvider(Provider):
+    def __init__(self, identifier, songs):
+        self._identifier = identifier
+        self._songs = songs
+        self.search_calls = []
+
+    @property
+    def identifier(self):
+        return self._identifier
+
+    @property
+    def name(self):
+        return self._identifier
+
+    def search(self, keyword, **kwargs):
+        self.search_calls.append((keyword, kwargs))
+        return SimpleSearchResult(q=keyword, songs=self._songs)
+
+
+def create_song(identifier, source, title="Song", artists_name="Artist"):
+    return BriefSongModel(
+        identifier=identifier,
+        source=source,
+        title=title,
+        artists_name=artists_name,
+    )
+
+
+def create_matcher_app(library):
+    return SimpleNamespace(library=library)
+
+
+@pytest.mark.asyncio
+async def test_matcher_prefers_configured_standby_provider():
+    library = Library(providers_standby=["standby"])
+    normal = SearchProvider("normal", [create_song("normal-song", "normal")])
+    standby = SearchProvider("standby", [create_song("standby-song", "standby")])
+    library.register(normal)
+    library.register(standby)
+    matcher = SongSuggestionMatcher(create_matcher_app(library))
+
+    song = await matcher.match(
+        SongSuggestion(title="Song", artists_name="Artist", description="")
+    )
+
+    assert song.identifier == "standby-song"
+    assert standby.search_calls
+    assert normal.search_calls == []
+
+
+@pytest.mark.asyncio
+async def test_matcher_falls_back_when_standby_provider_has_no_match():
+    library = Library(providers_standby=["standby"])
+    normal = SearchProvider("normal", [create_song("normal-song", "normal")])
+    standby = SearchProvider(
+        "standby",
+        [create_song("standby-mismatch", "standby", title="Other")],
+    )
+    library.register(normal)
+    library.register(standby)
+    matcher = SongSuggestionMatcher(create_matcher_app(library))
+
+    song = await matcher.match(
+        SongSuggestion(title="Song", artists_name="Artist", description="")
+    )
+
+    assert song.identifier == "normal-song"
+    assert standby.search_calls
+    assert normal.search_calls

--- a/tests/library/test_library.py
+++ b/tests/library/test_library.py
@@ -4,6 +4,7 @@ from feeluown.library import (
     ModelType,
     BriefAlbumModel,
     BriefSongModel,
+    Library,
     Provider,
     Media,
     SimpleSearchResult,
@@ -229,3 +230,100 @@ async def test_library_a_list_song_standby_v3_keeps_one_full_score_per_source(li
     )
 
     assert [standby.identifier for standby in standbys] == ["full-score"]
+
+
+@pytest.mark.asyncio
+async def test_library_a_list_song_standby_v3_prefers_standby_providers():
+    class SearchProvider(Provider):
+        def __init__(self, identifier):
+            self._identifier = identifier
+            self.search_calls = []
+
+        @property
+        def identifier(self):
+            return self._identifier
+
+        @property
+        def name(self):
+            return self._identifier
+
+        def search(self, keyword, **kwargs):
+            self.search_calls.append((keyword, kwargs))
+            return SimpleSearchResult(
+                q=keyword,
+                songs=[
+                    BriefSongModel(
+                        identifier=f"{self.identifier}-song",
+                        source=self.identifier,
+                        title="Song",
+                        artists_name="Artist",
+                    )
+                ],
+            )
+
+    library = Library(providers_standby=["standby"])
+    normal = SearchProvider("normal")
+    standby_provider = SearchProvider("standby")
+    library.register(normal)
+    library.register(standby_provider)
+    song = BriefSongModel(
+        identifier="origin",
+        source="origin",
+        title="Song",
+        artists_name="Artist",
+    )
+
+    standbys = await library.a_list_song_standby_v3(song)
+
+    assert [song.identifier for song in standbys] == ["standby-song"]
+    assert standby_provider.search_calls
+    assert normal.search_calls == []
+
+
+@pytest.mark.asyncio
+async def test_library_a_list_song_standby_v3_falls_back_to_other_providers():
+    class SearchProvider(Provider):
+        def __init__(self, identifier, title="Song"):
+            self._identifier = identifier
+            self._title = title
+            self.search_calls = []
+
+        @property
+        def identifier(self):
+            return self._identifier
+
+        @property
+        def name(self):
+            return self._identifier
+
+        def search(self, keyword, **kwargs):
+            self.search_calls.append((keyword, kwargs))
+            return SimpleSearchResult(
+                q=keyword,
+                songs=[
+                    BriefSongModel(
+                        identifier=f"{self.identifier}-song",
+                        source=self.identifier,
+                        title=self._title,
+                        artists_name="Artist",
+                    )
+                ],
+            )
+
+    library = Library(providers_standby=["standby"])
+    normal = SearchProvider("normal")
+    standby_provider = SearchProvider("standby", title="Other")
+    library.register(normal)
+    library.register(standby_provider)
+    song = BriefSongModel(
+        identifier="origin",
+        source="origin",
+        title="Song",
+        artists_name="Artist",
+    )
+
+    standbys = await library.a_list_song_standby_v3(song)
+
+    assert [song.identifier for song in standbys] == ["normal-song"]
+    assert standby_provider.search_calls
+    assert normal.search_calls


### PR DESCRIPTION
## Summary

- Prefer providers configured in `app.config.PROVIDERS_STANDBY` when matching AI `SongSuggestion` objects to real songs.
- Fall back to other registered providers only when configured standby providers do not produce an acceptable match.
- Add matcher tests for standby-provider preference and fallback behavior.

## Tests

- `uv run make test`
  - `349 passed, 5 skipped, 20 warnings`