### PR TITLE
feat(gui): add mini player AI chat

### DIFF
--- a/feeluown/gui/components/dynamic_island.py
+++ b/feeluown/gui/components/dynamic_island.py
@@ -81,6 +81,7 @@ class DynamicIslandStatusBar(QWidget):
         self._anim_current = 0  # current animated width
         self._has_song = False
         self._visibility_suppressed = False
+        self._available_width = None
         self._compact_text = ""
         self._position = _number_or_zero(self._app.player.position)
         self._duration = _number_or_zero(self._app.player.duration)
@@ -161,7 +162,7 @@ class DynamicIslandStatusBar(QWidget):
                 Qt.AlignmentFlag.AlignVCenter,
             )
             self._trailing_widget.hide()
-        self.setFixedWidth(self._calc_compact_width())
+        self._set_width(self._calc_compact_width())
 
     def _connect_signals(self):
         """Wire up player and lyric signals."""
@@ -203,6 +204,21 @@ class DynamicIslandStatusBar(QWidget):
             self.hide()
         else:
             self._sync_current_state()
+
+    def set_available_width(self, width):
+        """Limit the island width to the space provided by its parent."""
+        self._available_width = None if width is None else max(1, int(width))
+        if self._animating:
+            self._anim_current = self._constrain_width(self._anim_current)
+            self._anim_from = self._anim_current
+            self._anim_to = self._constrain_width(self._anim_to)
+            self._set_width(self._anim_current)
+            return
+
+        if self._expansion_state == "expanded":
+            self._set_width(self._expanded_width())
+        else:
+            self._set_width(self._calc_compact_width())
 
     # ---- protected slots ----
 
@@ -377,7 +393,7 @@ class DynamicIslandStatusBar(QWidget):
         return CONTENT_SPACING + max(widget.width(), widget.sizeHint().width())
 
     def _expanded_width(self):
-        return EXPANDED_WIDTH + self._trailing_width()
+        return self._constrain_width(EXPANDED_WIDTH + self._trailing_width())
 
     def _playback_progress(self):
         if not self._duration:
@@ -457,7 +473,7 @@ class DynamicIslandStatusBar(QWidget):
 
         # Adjust width to fit new lyric text
         if not self._animating:
-            self.setFixedWidth(self._calc_compact_width())
+            self._set_width(self._calc_compact_width())
 
     def _start_expand(self):
         """Begin expanding toward the expanded state."""
@@ -501,7 +517,7 @@ class DynamicIslandStatusBar(QWidget):
             self._anim_current = self._anim_to
             done = True
 
-        self.setFixedWidth(int(self._anim_current))
+        self._set_width(self._anim_current)
 
         # Switch content visibility at progress threshold
         total = abs(self._anim_to - self._anim_from)
@@ -549,7 +565,16 @@ class DynamicIslandStatusBar(QWidget):
         """Finalize the state after animation completes."""
         if self._anim_to == self._expanded_width():
             self._switch_to_expanded()
-            self.setFixedWidth(self._expanded_width())
+            self._set_width(self._expanded_width())
         else:
             self._switch_to_compact()
-            self.setFixedWidth(self._calc_compact_width())
+            self._set_width(self._calc_compact_width())
+
+    def _constrain_width(self, width):
+        width = max(1, int(width))
+        if self._available_width is not None:
+            return min(width, self._available_width)
+        return width
+
+    def _set_width(self, width):
+        self.setFixedWidth(self._constrain_width(width))

--- a/feeluown/gui/components/dynamic_island.py
+++ b/feeluown/gui/components/dynamic_island.py
@@ -67,9 +67,10 @@ class DynamicIslandStatusBar(QWidget):
     Uses system palette colors and reuses existing components.
     """
 
-    def __init__(self, app: "GuiApp", parent=None):
+    def __init__(self, app: "GuiApp", parent=None, trailing_widget=None):
         super().__init__(parent=parent)
         self._app = app
+        self._trailing_widget = trailing_widget
 
         # Hover and animation state
         self._hovered = False
@@ -79,6 +80,7 @@ class DynamicIslandStatusBar(QWidget):
         self._anim_to = 0  # target width
         self._anim_current = 0  # current animated width
         self._has_song = False
+        self._visibility_suppressed = False
         self._compact_text = ""
         self._position = _number_or_zero(self._app.player.position)
         self._duration = _number_or_zero(self._app.player.duration)
@@ -151,6 +153,14 @@ class DynamicIslandStatusBar(QWidget):
         )
         self._layout.addWidget(self._song_label, 1)
         self._layout.addWidget(self._control_widget)
+        if self._trailing_widget is not None:
+            self._trailing_widget.setParent(self)
+            self._layout.addWidget(
+                self._trailing_widget,
+                0,
+                Qt.AlignmentFlag.AlignVCenter,
+            )
+            self._trailing_widget.hide()
         self.setFixedWidth(self._calc_compact_width())
 
     def _connect_signals(self):
@@ -186,6 +196,13 @@ class DynamicIslandStatusBar(QWidget):
         )
 
     # ---- public methods ----
+
+    def set_visibility_suppressed(self, suppressed):
+        self._visibility_suppressed = suppressed
+        if suppressed:
+            self.hide()
+        else:
+            self._sync_current_state()
 
     # ---- protected slots ----
 
@@ -230,7 +247,7 @@ class DynamicIslandStatusBar(QWidget):
 
         state = self._app.player.state
         if state != State.stopped:
-            self.show()
+            self._show_if_allowed()
         if state == State.paused:
             self._start_expand()
         elif state == State.playing and not self._hovered:
@@ -242,11 +259,11 @@ class DynamicIslandStatusBar(QWidget):
             self.hide()
         elif state == State.paused:
             if self._has_song:
-                self.show()
+                self._show_if_allowed()
             self._start_expand()
         elif state == State.playing:
             if self._has_song:
-                self.show()
+                self._show_if_allowed()
             if not self._hovered:
                 self._start_compact()
 
@@ -348,15 +365,28 @@ class DynamicIslandStatusBar(QWidget):
         return max(
             60,
             (
-                EXPANDED_WIDTH - PADDING_LEFT - PADDING_RIGHT -
+                COMPACT_MAX_WIDTH - PADDING_LEFT - PADDING_RIGHT -
                 COVER_COMPACT - CONTENT_SPACING
             ),
         )
+
+    def _trailing_width(self):
+        widget = self._trailing_widget
+        if widget is None:
+            return 0
+        return CONTENT_SPACING + max(widget.width(), widget.sizeHint().width())
+
+    def _expanded_width(self):
+        return EXPANDED_WIDTH + self._trailing_width()
 
     def _playback_progress(self):
         if not self._duration:
             return 0
         return max(0.0, min(1.0, self._position / self._duration))
+
+    def _show_if_allowed(self):
+        if not self._visibility_suppressed:
+            self.show()
 
     def _draw_progress_background(self, painter, rect, radius, palette):
         progress = self._playback_progress()
@@ -437,7 +467,7 @@ class DynamicIslandStatusBar(QWidget):
             return  # already expanding
 
         self._anim_from = self.width()
-        self._anim_to = EXPANDED_WIDTH
+        self._anim_to = self._expanded_width()
         self._anim_current = self._anim_from
         self._animating = True
         if not self._anim_timer.isActive():
@@ -495,6 +525,8 @@ class DynamicIslandStatusBar(QWidget):
         self._lyric_label.hide()
         self._song_label.show()
         self._control_widget.show()
+        if self._trailing_widget is not None:
+            self._trailing_widget.show()
         self._cover.setFixedSize(COVER_EXPANDED, COVER_EXPANDED)
         self._expansion_state = "expanded"
 
@@ -505,6 +537,8 @@ class DynamicIslandStatusBar(QWidget):
         self._lyric_label.show()
         self._song_label.hide()
         self._control_widget.hide()
+        if self._trailing_widget is not None:
+            self._trailing_widget.hide()
         self._cover.setFixedSize(COVER_COMPACT, COVER_COMPACT)
         self._expansion_state = "compact"
         self._set_compact_text(
@@ -513,9 +547,9 @@ class DynamicIslandStatusBar(QWidget):
 
     def _finalize_state(self):
         """Finalize the state after animation completes."""
-        if self._anim_to == EXPANDED_WIDTH:
+        if self._anim_to == self._expanded_width():
             self._switch_to_expanded()
-            self.setFixedWidth(EXPANDED_WIDTH)
+            self.setFixedWidth(self._expanded_width())
         else:
             self._switch_to_compact()
             self.setFixedWidth(self._calc_compact_width())

--- a/feeluown/gui/debug.py
+++ b/feeluown/gui/debug.py
@@ -118,6 +118,7 @@ def create_mini_player_debug_app():
         playlist=_MiniPlayerDebugPlaylist(),
         live_lyric=_MiniPlayerDebugLiveLyric(),
         library=SimpleNamespace(get=lambda _source: None),
+        ai=None,
     )
 
 

--- a/feeluown/gui/uimain/ai_chat.py
+++ b/feeluown/gui/uimain/ai_chat.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from PyQt6.QtCore import QEvent, QMargins, QRectF, QSize, Qt, QTimer, pyqtSignal
@@ -26,7 +27,6 @@ from PyQt6.QtWidgets import (
 )
 
 from feeluown.ai import SongSuggestion
-from feeluown.app.gui_app import GuiApp
 from feeluown.gui.components.search import create_search_result_view
 from feeluown.gui.helpers import IS_MACOS, secondary_text_color
 from feeluown.gui.widgets import PlayButton, PlusButton
@@ -51,6 +51,9 @@ from feeluown.gui.components.overlay import AppOverlayContainer, AppOverlayOptio
 from feeluown.library import BriefSongModel, ModelState, ResolveFailed, parse_line
 from feeluown.i18n import t
 from feeluown.utils import aio
+
+if TYPE_CHECKING:
+    from feeluown.app.gui_app import GuiApp
 
 logger = logging.getLogger(__name__)
 
@@ -461,16 +464,35 @@ class AIChatBox(QWidget):
     working_state_changed = pyqtSignal(bool)
     playlist_sidebar_requested = pyqtSignal()
 
-    def __init__(self, app, parent=None):
+    def __init__(
+        self,
+        app,
+        parent=None,
+        status_widget=True,
+        history_fixed_height=None,
+        input_editor_min_height=80,
+        input_editor_max_height=300,
+        input_contents_margins=(14, 10, 12, 6),
+        placeholder_text=None,
+    ):
         super().__init__(parent=parent)
         self._app = app
         self.copilot = self._app.ai.get_copilot()
+        self._placeholder_text = placeholder_text
 
         self.history_widget = ChatHistoryWidget(self)
-        self._dynamic_island = DynamicIslandStatusBar(app)
+        if history_fixed_height is not None:
+            self.history_widget.setFixedHeight(history_fixed_height)
+        if status_widget is True:
+            self._dynamic_island = DynamicIslandStatusBar(app)
+        else:
+            self._dynamic_island = status_widget
         self.input_widget = ChatInputWidget(
             self,
             status_widget=self._dynamic_island,
+            editor_min_height=input_editor_min_height,
+            editor_max_height=input_editor_max_height,
+            contents_margins=input_contents_margins,
         )
         self._collecting_artifacts = False
         self._pending_artifacts = []
@@ -605,7 +627,9 @@ class AIChatBox(QWidget):
         return self._app.ai.get_active_radio()
 
     def _refresh_context(self, *_):
-        if self._get_active_ai_radio() is not None:
+        if self._placeholder_text is not None:
+            self.input_widget.set_placeholder(self._placeholder_text)
+        elif self._get_active_ai_radio() is not None:
             self.input_widget.set_placeholder(t("ai-radio-input-placeholder"))
         else:
             self.input_widget.set_placeholder(t("ai-chat-input-placeholder"))

--- a/feeluown/gui/uimain/mini_mode.py
+++ b/feeluown/gui/uimain/mini_mode.py
@@ -6,19 +6,84 @@ from PyQt6.QtGui import QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractButton,
     QAbstractSlider,
+    QFrame,
     QMenu,
+    QPlainTextEdit,
+    QScrollArea,
+    QSizePolicy,
+    QTextBrowser,
+    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
 from feeluown.gui.components.dynamic_island import DynamicIslandStatusBar
 from feeluown.gui.helpers import IS_MACOS
+from feeluown.gui.uimain.ai_chat import AIChatBox
+from feeluown.gui.widgets.ai_chat import draw_round_surface
+from feeluown.gui.widgets.selfpaint_btn import AIIconButton
 from feeluown.i18n import t
 
 if TYPE_CHECKING:
     from feeluown.app.gui_app import GuiApp
 
 logger = logging.getLogger(__name__)
+
+
+class MiniAIChatPanel(QFrame):
+    """Compact AI chat panel used inside mini mode."""
+
+    collapse_requested = pyqtSignal()
+
+    def __init__(self, app: "GuiApp", parent=None):
+        super().__init__(parent=parent)
+        self._app = app
+
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setFixedWidth(340)
+        self.setAutoFillBackground(False)
+
+        self._ai_btn = AIIconButton(
+            length=24,
+            padding=0.22,
+            colorful=True,
+            parent=self,
+        )
+        self._ai_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._ai_btn.clicked.connect(self.collapse_requested.emit)
+        self.island = DynamicIslandStatusBar(
+            app,
+            parent=self,
+            trailing_widget=self._ai_btn,
+        )
+        self.chat_box = AIChatBox(
+            app,
+            self,
+            status_widget=self.island,
+            history_fixed_height=160,
+            input_editor_min_height=34,
+            input_editor_max_height=76,
+            input_contents_margins=(10, 8, 8, 5),
+            placeholder_text=t("mini-ai-chat-input-placeholder"),
+        )
+        self.history_widget = self.chat_box.history_widget
+        self.input_widget = self.chat_box.input_widget
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+        layout.addWidget(self.chat_box)
+
+    def focus_input(self):
+        self.input_widget.focus_editor()
+
+    async def exec_user_query(self, query: str):
+        await self.chat_box.exec_user_query(query)
+
+    def paintEvent(self, event):
+        draw_round_surface(self)
+        super().paintEvent(event)
 
 
 class MiniModeWindow(QWidget):
@@ -49,27 +114,42 @@ class MiniModeWindow(QWidget):
         self.setAutoFillBackground(False)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
-        self.island = DynamicIslandStatusBar(app, parent=self)
-        self.island.installEventFilter(self)
-        for child in self.island.findChildren(QWidget):
-            child.installEventFilter(self)
+        self._ai_btn = AIIconButton(
+            length=24,
+            padding=0.22,
+            colorful=True,
+            parent=self,
+        )
+        self._ai_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._chat_panel = None
+        if self._app.ai is None:
+            self._ai_btn.setDisabled(True)
+            self._ai_btn.setToolTip(t("ai-configure-tooltip"))
+        else:
+            self._ai_btn.clicked.connect(self._toggle_ai_chat_panel)
+        self.island = DynamicIslandStatusBar(
+            app,
+            parent=self,
+            trailing_widget=self._ai_btn,
+        )
+        self._install_event_filters(self.island)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
-        layout.addWidget(self.island)
+        layout.setSpacing(8)
+        layout.addWidget(self.island, 0, Qt.AlignmentFlag.AlignHCenter)
 
         QShortcut(QKeySequence.StandardKey.Cancel, self).activated.connect(
-            self.exit_requested.emit
+            self._on_cancel_requested
         )
 
     def showEvent(self, event):
-        self._resize_to_island()
+        self._resize_to_content()
         self.island.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
         super().showEvent(event)
 
     def resizeEvent(self, event):
-        self._resize_to_island()
+        self._resize_to_content()
         super().resizeEvent(event)
 
     def mousePressEvent(self, event):
@@ -96,6 +176,8 @@ class MiniModeWindow(QWidget):
 
     def eventFilter(self, obj, event):
         if isinstance(obj, QWidget) and event.type() == QEvent.Type.ContextMenu:
+            if self._is_chat_panel_child(obj):
+                return False
             self._show_context_menu(event.globalPos())
             return True
         if isinstance(obj, QWidget) and event.type() in (
@@ -109,8 +191,42 @@ class MiniModeWindow(QWidget):
             QEvent.Type.Show,
             QEvent.Type.Hide,
         ):
-            self._resize_to_island()
+            self._resize_to_content()
         return super().eventFilter(obj, event)
+
+    def _toggle_ai_chat_panel(self):
+        if self._chat_panel is not None and self._chat_panel.isVisible():
+            self._hide_ai_chat_panel()
+        else:
+            self._show_ai_chat_panel()
+
+    def _show_ai_chat_panel(self):
+        if self._chat_panel is None:
+            self._chat_panel = MiniAIChatPanel(self._app, self)
+            self._chat_panel.collapse_requested.connect(self._hide_ai_chat_panel)
+            self._install_event_filters(self._chat_panel)
+            self.layout().addWidget(
+                self._chat_panel,
+                0,
+                Qt.AlignmentFlag.AlignHCenter,
+            )
+        self.island.set_visibility_suppressed(True)
+        self._chat_panel.show()
+        self._chat_panel.focus_input()
+        self._resize_to_content()
+
+    def _hide_ai_chat_panel(self):
+        if self._chat_panel is not None:
+            self._chat_panel.hide()
+        self.island.set_visibility_suppressed(False)
+        self._resize_to_content()
+        self.island.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
+
+    def _on_cancel_requested(self):
+        if self._chat_panel is not None and self._chat_panel.isVisible():
+            self._hide_ai_chat_panel()
+        else:
+            self.exit_requested.emit()
 
     def _show_context_menu(self, global_pos):
         menu = QMenu(self)
@@ -165,17 +281,63 @@ class MiniModeWindow(QWidget):
             return False
 
     def _is_interactive_drag_source(self, obj):
-        if isinstance(obj, (QAbstractButton, QAbstractSlider)):
+        if self._is_chat_panel_child(obj):
+            return True
+        if isinstance(
+            obj,
+            (
+                QAbstractButton,
+                QAbstractSlider,
+                QPlainTextEdit,
+                QTextBrowser,
+                QTextEdit,
+                QScrollArea,
+            ),
+        ):
             return True
         parent = obj.parent() if isinstance(obj, QWidget) else None
         while isinstance(parent, QWidget):
-            if isinstance(parent, (QAbstractButton, QAbstractSlider)):
+            if isinstance(
+                parent,
+                (
+                    QAbstractButton,
+                    QAbstractSlider,
+                    QPlainTextEdit,
+                    QTextBrowser,
+                    QTextEdit,
+                    QScrollArea,
+                ),
+            ):
                 return True
             parent = parent.parent()
         return False
 
+    def _install_event_filters(self, widget):
+        widget.installEventFilter(self)
+        for child in widget.findChildren(QWidget):
+            child.installEventFilter(self)
+
+    def _is_chat_panel_child(self, obj):
+        panel = self._chat_panel
+        if panel is None or not isinstance(obj, QWidget):
+            return False
+        if obj is panel:
+            return True
+        parent = obj.parent()
+        while isinstance(parent, QWidget):
+            if parent is panel:
+                return True
+            parent = parent.parent()
+        return False
+
+    def _resize_to_content(self):
+        self.layout().activate()
+        size = self.sizeHint()
+        if size.isValid() and self.size() != size:
+            self.setFixedSize(size)
+
     def _resize_to_island(self):
-        self.setFixedSize(self.island.size())
+        self._resize_to_content()
 
 
 class MiniModeManager(QObject):

--- a/feeluown/gui/uimain/mini_mode.py
+++ b/feeluown/gui/uimain/mini_mode.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+MINI_CHAT_DEFAULT_WIDTH = 340
+MINI_CHAT_MIN_WIDTH = 280
+RESIZE_MARGIN = 8
+
 
 class MiniAIChatPanel(QFrame):
     """Compact AI chat panel used inside mini mode."""
@@ -40,8 +44,11 @@ class MiniAIChatPanel(QFrame):
         self._app = app
 
         self.setFrameShape(QFrame.Shape.NoFrame)
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        self.setFixedWidth(340)
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Preferred,
+        )
+        self.setMinimumWidth(MINI_CHAT_MIN_WIDTH)
         self.setAutoFillBackground(False)
 
         self._ai_btn = AIIconButton(
@@ -73,7 +80,7 @@ class MiniAIChatPanel(QFrame):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(8)
-        layout.addWidget(self.chat_box)
+        layout.addWidget(self.chat_box, 1)
 
     def focus_input(self):
         self.input_widget.focus_editor()
@@ -96,6 +103,13 @@ class MiniModeWindow(QWidget):
         self._app = app
         self._drag_global_pos = None
         self._using_system_move = False
+        self._resize_global_pos = None
+        self._resize_start_geometry = None
+        self._resize_edges = None
+        self._using_system_resize = False
+        self._chat_width = None
+        self._chat_mode = False
+        self._resizing_to_content = False
 
         if IS_MACOS:
             flags = (
@@ -153,18 +167,27 @@ class MiniModeWindow(QWidget):
         super().resizeEvent(event)
 
     def mousePressEvent(self, event):
+        if self._handle_resize_event(self, event):
+            event.accept()
+            return
         if self._handle_drag_event(self, event):
             event.accept()
             return
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
+        if self._handle_resize_event(self, event):
+            event.accept()
+            return
         if self._handle_drag_event(self, event):
             event.accept()
             return
         super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event):
+        if self._handle_resize_event(self, event):
+            event.accept()
+            return
         if self._handle_drag_event(self, event):
             event.accept()
             return
@@ -185,6 +208,8 @@ class MiniModeWindow(QWidget):
             QEvent.Type.MouseMove,
             QEvent.Type.MouseButtonRelease,
         ):
+            if self._handle_resize_event(obj, event):
+                return True
             return self._handle_drag_event(obj, event)
         elif obj is self.island and event.type() in (
             QEvent.Type.Resize,
@@ -195,12 +220,13 @@ class MiniModeWindow(QWidget):
         return super().eventFilter(obj, event)
 
     def _toggle_ai_chat_panel(self):
-        if self._chat_panel is not None and self._chat_panel.isVisible():
+        if self._chat_mode:
             self._hide_ai_chat_panel()
         else:
             self._show_ai_chat_panel()
 
     def _show_ai_chat_panel(self):
+        self._chat_mode = True
         if self._chat_panel is None:
             self._chat_panel = MiniAIChatPanel(self._app, self)
             self._chat_panel.collapse_requested.connect(self._hide_ai_chat_panel)
@@ -208,22 +234,28 @@ class MiniModeWindow(QWidget):
             self.layout().addWidget(
                 self._chat_panel,
                 0,
-                Qt.AlignmentFlag.AlignHCenter,
             )
         self.island.set_visibility_suppressed(True)
+        self.setMinimumSize(0, 0)
+        self.setMaximumSize(16777215, 16777215)
         self._chat_panel.show()
         self._chat_panel.focus_input()
+        if self._chat_width is None:
+            self._chat_width = max(MINI_CHAT_DEFAULT_WIDTH, self.width())
+        self.resize(self._chat_width, self.height())
         self._resize_to_content()
 
     def _hide_ai_chat_panel(self):
+        self._chat_mode = False
         if self._chat_panel is not None:
+            self._chat_width = self.width()
             self._chat_panel.hide()
         self.island.set_visibility_suppressed(False)
         self._resize_to_content()
         self.island.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
 
     def _on_cancel_requested(self):
-        if self._chat_panel is not None and self._chat_panel.isVisible():
+        if self._chat_mode:
             self._hide_ai_chat_panel()
         else:
             self.exit_requested.emit()
@@ -271,12 +303,92 @@ class MiniModeWindow(QWidget):
 
         return False
 
+    def _handle_resize_event(self, _obj, event):
+        if not self._chat_mode_active():
+            return False
+
+        global_pos = event.globalPosition().toPoint()
+        if event.type() == QEvent.Type.MouseMove:
+            if self._using_system_resize:
+                return True
+            if self._resize_start_geometry is not None:
+                self._resize_manually(global_pos)
+                return True
+            edges = self._resize_edges_at(global_pos)
+            if edges is not None:
+                self.setCursor(Qt.CursorShape.SizeHorCursor)
+            else:
+                self.unsetCursor()
+            return False
+
+        if event.type() == QEvent.Type.MouseButtonPress:
+            if event.button() != Qt.MouseButton.LeftButton:
+                return False
+            edges = self._resize_edges_at(global_pos)
+            if edges is None:
+                return False
+            if self._start_system_resize(edges):
+                self._using_system_resize = True
+            else:
+                self._resize_global_pos = global_pos
+                self._resize_start_geometry = self.frameGeometry()
+                self._resize_edges = edges
+            return True
+
+        if event.type() == QEvent.Type.MouseButtonRelease:
+            if self._using_system_resize or self._resize_start_geometry is not None:
+                self._using_system_resize = False
+                self._resize_global_pos = None
+                self._resize_start_geometry = None
+                self._resize_edges = None
+                return True
+        return False
+
+    def _resize_edges_at(self, global_pos):
+        geometry = self.frameGeometry()
+        if global_pos.x() <= geometry.left() + RESIZE_MARGIN:
+            return Qt.Edge.LeftEdge
+        if global_pos.x() >= geometry.right() - RESIZE_MARGIN:
+            return Qt.Edge.RightEdge
+        return None
+
+    def _resize_manually(self, global_pos):
+        start_geometry = self._resize_start_geometry
+        start_pos = self._resize_global_pos
+        if start_geometry is None or start_pos is None:
+            return
+
+        delta_x = global_pos.x() - start_pos.x()
+        width = start_geometry.width()
+        if self._resize_edges == Qt.Edge.LeftEdge:
+            width -= delta_x
+        else:
+            width += delta_x
+
+        width = max(self.minimumWidth(), width)
+        if self.maximumWidth() < 16777215:
+            width = min(self.maximumWidth(), width)
+        if self._resize_edges == Qt.Edge.LeftEdge:
+            x = start_geometry.right() - width + 1
+        else:
+            x = start_geometry.x()
+        self.setGeometry(x, start_geometry.y(), width, self.height())
+
     def _start_system_move(self):
         handle = self.windowHandle()
         if handle is None:
             return False
         try:
             return bool(handle.startSystemMove())
+        except RuntimeError:
+            return False
+
+    def _start_system_resize(self, edges):
+        handle = self.windowHandle()
+        if handle is None:
+            return False
+        try:
+            return bool(handle.startSystemResize(edges))
         except RuntimeError:
             return False
 
@@ -331,10 +443,24 @@ class MiniModeWindow(QWidget):
         return False
 
     def _resize_to_content(self):
-        self.layout().activate()
-        size = self.sizeHint()
-        if size.isValid() and self.size() != size:
-            self.setFixedSize(size)
+        if self._resizing_to_content:
+            return
+        self._resizing_to_content = True
+        try:
+            self.layout().activate()
+            size = self.sizeHint()
+            if not size.isValid():
+                return
+            if self._chat_mode_active():
+                if self.height() != size.height():
+                    self.resize(self.width(), size.height())
+            elif self.size() != size:
+                self.setFixedSize(size)
+        finally:
+            self._resizing_to_content = False
+
+    def _chat_mode_active(self):
+        return self._chat_mode
 
     def _resize_to_island(self):
         self._resize_to_content()

--- a/feeluown/gui/uimain/mini_mode.py
+++ b/feeluown/gui/uimain/mini_mode.py
@@ -267,7 +267,16 @@ class MiniModeWindow(QWidget):
         menu.exec(global_pos)
 
     def _handle_drag_event(self, obj, event):
-        if self._is_interactive_drag_source(obj):
+        drag_active = (
+            self._drag_global_pos is not None or self._using_system_move
+        )
+        if self._is_interactive_drag_source(obj) and not (
+            drag_active
+            or (
+                self.isVisible()
+                and self._is_window_side(event.globalPosition().toPoint())
+            )
+        ):
             self._drag_global_pos = None
             self._using_system_move = False
             return False
@@ -316,7 +325,7 @@ class MiniModeWindow(QWidget):
                 return True
             edges = self._resize_edges_at(global_pos)
             if edges is not None:
-                self.setCursor(Qt.CursorShape.SizeHorCursor)
+                self.setCursor(self._resize_cursor(edges))
             else:
                 self.unsetCursor()
             return False
@@ -346,11 +355,36 @@ class MiniModeWindow(QWidget):
 
     def _resize_edges_at(self, global_pos):
         geometry = self.frameGeometry()
-        if global_pos.x() <= geometry.left() + RESIZE_MARGIN:
-            return Qt.Edge.LeftEdge
-        if global_pos.x() >= geometry.right() - RESIZE_MARGIN:
-            return Qt.Edge.RightEdge
+        left = global_pos.x() <= geometry.left() + RESIZE_MARGIN
+        right = global_pos.x() >= geometry.right() - RESIZE_MARGIN
+        top = global_pos.y() <= geometry.top() + RESIZE_MARGIN
+        bottom = global_pos.y() >= geometry.bottom() - RESIZE_MARGIN
+        if left and top:
+            return Qt.Edge.LeftEdge | Qt.Edge.TopEdge
+        if right and top:
+            return Qt.Edge.RightEdge | Qt.Edge.TopEdge
+        if left and bottom:
+            return Qt.Edge.LeftEdge | Qt.Edge.BottomEdge
+        if right and bottom:
+            return Qt.Edge.RightEdge | Qt.Edge.BottomEdge
         return None
+
+    def _resize_cursor(self, edges):
+        if edges in (
+            Qt.Edge.LeftEdge | Qt.Edge.TopEdge,
+            Qt.Edge.RightEdge | Qt.Edge.BottomEdge,
+        ):
+            return Qt.CursorShape.SizeFDiagCursor
+        return Qt.CursorShape.SizeBDiagCursor
+
+    def _is_window_side(self, global_pos):
+        geometry = self.frameGeometry()
+        return (
+            global_pos.x() <= geometry.left() + RESIZE_MARGIN
+            or global_pos.x() >= geometry.right() - RESIZE_MARGIN
+            or global_pos.y() <= geometry.top() + RESIZE_MARGIN
+            or global_pos.y() >= geometry.bottom() - RESIZE_MARGIN
+        )
 
     def _resize_manually(self, global_pos):
         start_geometry = self._resize_start_geometry
@@ -360,19 +394,31 @@ class MiniModeWindow(QWidget):
 
         delta_x = global_pos.x() - start_pos.x()
         width = start_geometry.width()
-        if self._resize_edges == Qt.Edge.LeftEdge:
+        height = start_geometry.height()
+        if self._resize_edges & Qt.Edge.LeftEdge:
             width -= delta_x
-        else:
+        elif self._resize_edges & Qt.Edge.RightEdge:
             width += delta_x
+        if self._resize_edges & Qt.Edge.TopEdge:
+            height -= global_pos.y() - start_pos.y()
+        elif self._resize_edges & Qt.Edge.BottomEdge:
+            height += global_pos.y() - start_pos.y()
 
         width = max(self.minimumWidth(), width)
         if self.maximumWidth() < 16777215:
             width = min(self.maximumWidth(), width)
-        if self._resize_edges == Qt.Edge.LeftEdge:
+        height = max(self.minimumHeight(), height)
+        if self.maximumHeight() < 16777215:
+            height = min(self.maximumHeight(), height)
+        if self._resize_edges & Qt.Edge.LeftEdge:
             x = start_geometry.right() - width + 1
         else:
             x = start_geometry.x()
-        self.setGeometry(x, start_geometry.y(), width, self.height())
+        if self._resize_edges & Qt.Edge.TopEdge:
+            y = start_geometry.bottom() - height + 1
+        else:
+            y = start_geometry.y()
+        self.setGeometry(x, y, width, height)
 
     def _start_system_move(self):
         handle = self.windowHandle()
@@ -443,7 +489,11 @@ class MiniModeWindow(QWidget):
         return False
 
     def _resize_to_content(self):
-        if self._resizing_to_content:
+        if (
+            self._resizing_to_content
+            or self._using_system_resize
+            or self._resize_start_geometry is not None
+        ):
             return
         self._resizing_to_content = True
         try:

--- a/feeluown/gui/widgets/ai_chat.py
+++ b/feeluown/gui/widgets/ai_chat.py
@@ -712,6 +712,28 @@ class ChatInputWidget(QWidget):
             footer_layout.addWidget(self._msg_label, 1)
         footer_layout.addWidget(self._send_btn, 0, Qt.AlignmentFlag.AlignRight)
         layout.addLayout(footer_layout)
+        self._footer_layout = footer_layout
+        QTimer.singleShot(0, self._update_status_widget_width)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._update_status_widget_width()
+
+    def _update_status_widget_width(self):
+        status_widget = self._status_widget
+        if status_widget is None or not hasattr(
+            status_widget, "set_available_width"
+        ):
+            return
+        footer_width = self._footer_layout.geometry().width()
+        if footer_width <= 0:
+            return
+        available_width = (
+            footer_width
+            - self._send_btn.sizeHint().width()
+            - self._footer_layout.spacing()
+        )
+        status_widget.set_available_width(max(1, available_width))
 
     def paintEvent(self, event):
         draw_round_surface(self, self._radius)

--- a/feeluown/gui/widgets/ai_chat.py
+++ b/feeluown/gui/widgets/ai_chat.py
@@ -86,11 +86,11 @@ class ChatInputEditor(QPlainTextEdit):
 
     enter_pressed = pyqtSignal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, min_height=30, max_height=300):
         super().__init__(parent)
         self.setWordWrapMode(QTextOption.WrapMode.WrapAtWordBoundaryOrAnywhere)
-        self.setMinimumHeight(30)
-        self.setMaximumHeight(300)  # TODO: set maximum height based on parent size
+        self.setMinimumHeight(min_height)
+        self.setMaximumHeight(max_height)
         self.textChanged.connect(self.adjust_height)
         self.adjust_height()
         # The size policy matters
@@ -605,10 +605,22 @@ class ChatInputWidget(QWidget):
 
     send_clicked = pyqtSignal(str)  # emits query text
 
-    def __init__(self, parent=None, status_widget=None):
+    def __init__(
+        self,
+        parent=None,
+        status_widget=None,
+        editor_min_height=80,
+        editor_max_height=300,
+        contents_margins=(14, 10, 12, 6),
+    ):
         super().__init__(parent=parent)
         self._radius = SurfaceRadius
-        self._editor = ChatInputEditor(self)
+        self._contents_margins = contents_margins
+        self._editor = ChatInputEditor(
+            self,
+            min_height=editor_min_height,
+            max_height=editor_max_height,
+        )
         self._editor.setPlaceholderText(t("ai-chat-input-placeholder"))
         self._editor.setFrameShape(QFrame.Shape.NoFrame)
         self._editor.setObjectName("ai_chat_input_editor")
@@ -634,7 +646,6 @@ class ChatInputWidget(QWidget):
 
         self._editor.enter_pressed.connect(self._on_enter_pressed)
         self._send_btn.clicked.connect(self._on_send_clicked)
-        self._editor.setMinimumHeight(80)
         self.setAutoFillBackground(False)
         self._apply_palette()
         self.setup_ui()
@@ -682,7 +693,7 @@ class ChatInputWidget(QWidget):
         self._msg_label.setTextFormat(Qt.TextFormat.PlainText)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(14, 10, 12, 6)
+        layout.setContentsMargins(*self._contents_margins)
         layout.setSpacing(4)
         layout.addWidget(self._editor)
 
@@ -727,6 +738,9 @@ class ChatInputWidget(QWidget):
 
     def get_input(self):
         return self._editor.toPlainText()
+
+    def focus_editor(self):
+        self._editor.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
 
     def enable_send(self, enabled):
         self._send_btn.setEnabled(enabled)

--- a/feeluown/gui/widgets/selfpaint_btn.py
+++ b/feeluown/gui/widgets/selfpaint_btn.py
@@ -269,11 +269,29 @@ class RecentlyPlayedButton(SelfPaintAbstractIconTextButton):
 
 
 class AIButton(SelfPaintAbstractIconTextButton):
-    def __init__(self, *args, **kwargs):
-        super().__init__("AI", *args, **kwargs)
-        self.ai_icon = AIIconDrawer(self.height(), self._padding)
+    def __init__(self, text="AI", colorful=False, *args, **kwargs):
+        super().__init__(text, *args, **kwargs)
+        if not text:
+            self.setFixedWidth(self.height())
+        self.ai_icon = AIIconDrawer(
+            self.height(), self._padding, colorful=colorful
+        )
 
     def draw_icon(self, painter):
+        self.ai_icon.draw(painter, self.palette())
+
+
+class AIIconButton(SelfPaintAbstractSquareButton):
+    def __init__(self, colorful=False, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ai_icon = AIIconDrawer(
+            self.height(), self._padding, colorful=colorful
+        )
+
+    def paintEvent(self, _):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        self.paint_round_bg_when_hover(painter)
         self.ai_icon.draw(painter, self.palette())
 
 

--- a/feeluown/i18n/assets/en-US/app.ftl
+++ b/feeluown/i18n/assets/en-US/app.ftl
@@ -239,6 +239,7 @@ track-fallback-failed = { -provider(capitalization: "uppercase") } “{ $provide
 # feeluown.gui.widgets.ai_chat
 # ----------------------------------------
 ai-chat-input-placeholder = Chat with the assistant
+mini-ai-chat-input-placeholder = Control playback with AI
 ai-chat-send-button = Send
 
 # feeluown.gui.widgets.cover_label

--- a/feeluown/i18n/assets/ja-JP/app.ftl
+++ b/feeluown/i18n/assets/ja-JP/app.ftl
@@ -234,6 +234,7 @@ track-fallback-failed = プロバイダー “{ $providerName }” で利用可�
 # feeluown.gui.widgets.ai_chat
 # ----------------------------------------
 ai-chat-input-placeholder = アシスタントとおしゃべり
+mini-ai-chat-input-placeholder = AI で再生を操作
 ai-chat-send-button = 送信
 
 # feeluown.gui.widgets.cover_label

--- a/feeluown/i18n/assets/zh-CN/app.ftl
+++ b/feeluown/i18n/assets/zh-CN/app.ftl
@@ -234,6 +234,7 @@ track-fallback-failed = 提供方 “{ $providerName }” 没有找到可用的�
 # feeluown.gui.widgets.ai_chat
 # ----------------------------------------
 ai-chat-input-placeholder = 和助手聊聊
+mini-ai-chat-input-placeholder = 用 AI 控制播放
 ai-chat-send-button = 发送
 
 # feeluown.gui.widgets.cover_label

--- a/tests/gui/uimain/test_uimain.py
+++ b/tests/gui/uimain/test_uimain.py
@@ -1190,7 +1190,9 @@ def test_mini_mode_window_prefers_system_move(qtbot, app_mock, monkeypatch):
     assert not window._using_system_move
 
 
-def test_mini_mode_window_resizes_from_right_edge(qtbot, app_mock, monkeypatch):
+def test_mini_mode_window_resizes_from_bottom_right_corner(
+    qtbot, app_mock, monkeypatch
+):
     _prepare_dynamic_island_app(app_mock)
     app_mock.ai = FakeAI()
     window = MiniModeWindow(app_mock)
@@ -1200,8 +1202,11 @@ def test_mini_mode_window_resizes_from_right_edge(qtbot, app_mock, monkeypatch):
     monkeypatch.setattr(window, "_start_system_resize", lambda _edges: False)
 
     start_geometry = window.frameGeometry()
-    start_pos = QPointF(start_geometry.right(), start_geometry.center().y())
-    moved_pos = QPointF(start_geometry.right() + 40, start_geometry.center().y())
+    start_pos = QPointF(start_geometry.right(), start_geometry.bottom())
+    moved_pos = QPointF(
+        start_geometry.right() + 40,
+        start_geometry.bottom() + 20,
+    )
 
     assert window._handle_resize_event(
         window,
@@ -1217,6 +1222,43 @@ def test_mini_mode_window_resizes_from_right_edge(qtbot, app_mock, monkeypatch):
     )
 
     assert window.width() == start_geometry.width() + 40
+    assert window.height() == start_geometry.height() + 20
+
+
+def test_mini_mode_window_moves_from_edge_middle(qtbot, app_mock, monkeypatch):
+    _prepare_dynamic_island_app(app_mock)
+    app_mock.ai = FakeAI()
+    window = MiniModeWindow(app_mock)
+    qtbot.addWidget(window)
+    window.show()
+    window._toggle_ai_chat_panel()
+    monkeypatch.setattr(window, "_start_system_move", lambda: False)
+
+    start_geometry = window.frameGeometry()
+    edge_pos = QPointF(start_geometry.right(), start_geometry.center().y())
+    moved_pos = QPointF(edge_pos.x() + 40, edge_pos.y() + 20)
+
+    assert not window._handle_resize_event(
+        window,
+        _FakeMouseEvent(QEvent.Type.MouseButtonPress, edge_pos),
+    )
+    assert window._handle_drag_event(
+        window,
+        _FakeMouseEvent(QEvent.Type.MouseButtonPress, edge_pos),
+    )
+    assert window._handle_drag_event(
+        window,
+        _FakeMouseEvent(QEvent.Type.MouseMove, moved_pos),
+    )
+    assert window._handle_drag_event(
+        window,
+        _FakeMouseEvent(QEvent.Type.MouseButtonRelease, moved_pos),
+    )
+
+    assert window.pos() == QPoint(
+        start_geometry.x() + 40,
+        start_geometry.y() + 20,
+    )
 
 
 def test_mini_mode_window_does_not_drag_from_controls(qtbot, app_mock):

--- a/tests/gui/uimain/test_uimain.py
+++ b/tests/gui/uimain/test_uimain.py
@@ -40,7 +40,11 @@ from feeluown.gui.components.dynamic_island import (
     EXPANDED_WIDTH,
     VOLUME_STEP,
 )
-from feeluown.gui.uimain.mini_mode import MiniModeManager, MiniModeWindow
+from feeluown.gui.uimain.mini_mode import (
+    MiniAIChatPanel,
+    MiniModeManager,
+    MiniModeWindow,
+)
 from feeluown.gui.uimain.lyric import LyricWindow
 from feeluown.gui.uimain.playlist_overlay import PlaylistOverlay
 from feeluown.gui.widgets.ai_chat import (
@@ -54,6 +58,7 @@ from feeluown.gui.widgets.ai_chat import (
     surface_border_color,
 )
 from feeluown.gui.widgets import PlayButton, PlusButton
+from feeluown.gui.widgets.selfpaint_btn import AIIconButton
 from feeluown.gui.widgets.song_minicard_list import SongMiniCardListDelegate
 from feeluown.gui.widgets.textbtn import TextButton
 
@@ -1055,6 +1060,11 @@ def test_mini_mode_window_is_frameless_and_uses_island(qtbot, app_mock):
     margins = window.layout().contentsMargins()
 
     assert isinstance(window.island, DynamicIslandStatusBar)
+    assert isinstance(window._ai_btn, AIIconButton)
+    assert window._ai_btn.parent() is window.island
+    assert window._ai_btn.width() == window._ai_btn.height()
+    assert window._ai_btn.ai_icon.colorful
+    assert window._ai_btn.isHidden()
     assert window.windowFlags() & Qt.WindowType.FramelessWindowHint
     assert window.windowFlags() & Qt.WindowType.WindowStaysOnTopHint
     assert window.testAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
@@ -1062,6 +1072,56 @@ def test_mini_mode_window_is_frameless_and_uses_island(qtbot, app_mock):
     assert margins.top() == 0
     assert margins.right() == 0
     assert margins.bottom() == 0
+
+
+def test_mini_mode_window_disables_ai_button_without_ai(qtbot, app_mock):
+    _prepare_dynamic_island_app(app_mock)
+    app_mock.ai = None
+    window = MiniModeWindow(app_mock)
+    qtbot.addWidget(window)
+
+    assert not window._ai_btn.isEnabled()
+    assert window._chat_panel is None
+
+
+def test_mini_mode_window_toggles_compact_ai_panel(qtbot, app_mock):
+    _prepare_dynamic_island_app(app_mock)
+    app_mock.player.current_metadata = {
+        "title": "Song",
+        "artists": ["Mary"],
+        "artwork": "",
+        "source": "fake",
+    }
+    app_mock.ai = FakeAI()
+    window = MiniModeWindow(app_mock)
+    qtbot.addWidget(window)
+    window.show()
+    assert window._ai_btn.isHidden()
+    window.island._start_expand()
+    while window.island._animating:
+        window.island._tick_animation()
+    window._resize_to_content()
+    compact_size = window.size()
+
+    assert not window._ai_btn.isHidden()
+    window._ai_btn.click()
+
+    assert isinstance(window._chat_panel, MiniAIChatPanel)
+    assert window._chat_panel.isVisibleTo(window)
+    assert window.island.isHidden()
+    assert window._chat_panel.island.parent() is window._chat_panel.input_widget
+    assert window.width() >= window._chat_panel.width()
+    assert window.height() > compact_size.height()
+
+    window.island._on_player_state_changed(State.playing)
+
+    assert window.island.isHidden()
+
+    window._chat_panel._ai_btn.click()
+
+    assert not window._chat_panel.isVisible()
+    assert not window.island.isHidden()
+    assert window.height() == compact_size.height()
 
 
 def test_mini_mode_window_drags_from_island_body(qtbot, app_mock, monkeypatch):
@@ -1134,6 +1194,27 @@ def test_mini_mode_window_does_not_drag_from_controls(qtbot, app_mock):
     assert window.pos() == QPoint(100, 120)
 
 
+def test_mini_mode_window_does_not_drag_from_chat_input(qtbot, app_mock):
+    _prepare_dynamic_island_app(app_mock)
+    app_mock.ai = FakeAI()
+    window = MiniModeWindow(app_mock)
+    qtbot.addWidget(window)
+    window.move(100, 120)
+    window._toggle_ai_chat_panel()
+    editor = window._chat_panel.input_widget._editor
+
+    window._handle_drag_event(
+        editor,
+        _FakeMouseEvent(QEvent.Type.MouseButtonPress, QPointF(10, 10)),
+    )
+    window._handle_drag_event(
+        editor,
+        _FakeMouseEvent(QEvent.Type.MouseMove, QPointF(25, 28)),
+    )
+
+    assert window.pos() == QPoint(100, 120)
+
+
 def test_mini_mode_window_intercepts_child_context_menu(
     qtbot, app_mock, monkeypatch
 ):
@@ -1150,6 +1231,28 @@ def test_mini_mode_window_intercepts_child_context_menu(
 
     assert handled
     assert positions == [QPoint(20, 30)]
+
+
+def test_mini_ai_chat_panel_renders_streaming_response(qtbot, app_mock):
+    _prepare_dynamic_island_app(app_mock)
+    app_mock.ai = FakeAI(FakeStreamingCopilot())
+    panel = MiniAIChatPanel(app_mock)
+    qtbot.addWidget(panel)
+
+    asyncio.run(panel.exec_user_query("推荐几首华语经典歌曲"))
+
+    history_text = "\n".join(
+        label.toPlainText() for label in panel.history_widget.findChildren(
+            RoundedLabel
+        )
+    )
+    tool_events = panel.history_widget.findChildren(ChatToolEventCard)
+    assert "推荐几首华语经典歌曲" in history_text
+    assert "我为您推荐了这些歌曲" in history_text
+    assert "我来" not in history_text
+    assert len(tool_events) == 1
+    assert "create_song_suggestions_artifact" in tool_events[0].text()
+    assert panel.input_widget._editor.minimumHeight() == 34
 
 
 def test_mini_mode_manager_hides_and_restores_main_window(qtbot, app_mock):

--- a/tests/gui/uimain/test_uimain.py
+++ b/tests/gui/uimain/test_uimain.py
@@ -1012,6 +1012,20 @@ def test_dynamic_island_progress_updates_only_when_expanded(qtbot, app_mock, moc
     update.assert_called_once()
 
 
+def test_dynamic_island_respects_available_width(qtbot, app_mock):
+    _prepare_dynamic_island_app(app_mock)
+    island = DynamicIslandStatusBar(app_mock)
+    qtbot.addWidget(island)
+    island.set_available_width(180)
+
+    island._start_expand()
+    while island._animating:
+        island._tick_animation()
+
+    assert island.width() == 180
+    assert island._expanded_width() == 180
+
+
 class _FakeMouseEvent:
     def __init__(
         self,
@@ -1176,6 +1190,35 @@ def test_mini_mode_window_prefers_system_move(qtbot, app_mock, monkeypatch):
     assert not window._using_system_move
 
 
+def test_mini_mode_window_resizes_from_right_edge(qtbot, app_mock, monkeypatch):
+    _prepare_dynamic_island_app(app_mock)
+    app_mock.ai = FakeAI()
+    window = MiniModeWindow(app_mock)
+    qtbot.addWidget(window)
+    window.show()
+    window._toggle_ai_chat_panel()
+    monkeypatch.setattr(window, "_start_system_resize", lambda _edges: False)
+
+    start_geometry = window.frameGeometry()
+    start_pos = QPointF(start_geometry.right(), start_geometry.center().y())
+    moved_pos = QPointF(start_geometry.right() + 40, start_geometry.center().y())
+
+    assert window._handle_resize_event(
+        window,
+        _FakeMouseEvent(QEvent.Type.MouseButtonPress, start_pos),
+    )
+    assert window._handle_resize_event(
+        window,
+        _FakeMouseEvent(QEvent.Type.MouseMove, moved_pos),
+    )
+    assert window._handle_resize_event(
+        window,
+        _FakeMouseEvent(QEvent.Type.MouseButtonRelease, moved_pos),
+    )
+
+    assert window.width() == start_geometry.width() + 40
+
+
 def test_mini_mode_window_does_not_drag_from_controls(qtbot, app_mock):
     _prepare_dynamic_island_app(app_mock)
     window = MiniModeWindow(app_mock)
@@ -1253,6 +1296,24 @@ def test_mini_ai_chat_panel_renders_streaming_response(qtbot, app_mock):
     assert len(tool_events) == 1
     assert "create_song_suggestions_artifact" in tool_events[0].text()
     assert panel.input_widget._editor.minimumHeight() == 34
+
+
+def test_mini_ai_chat_island_fits_input_footer(qtbot, app_mock):
+    _prepare_dynamic_island_app(app_mock)
+    app_mock.ai = FakeAI()
+    panel = MiniAIChatPanel(app_mock)
+    qtbot.addWidget(panel)
+    panel.resize(340, panel.sizeHint().height())
+    panel.show()
+    qtbot.wait(0)
+
+    footer = panel.input_widget._footer_layout
+    available_width = (
+        footer.geometry().width()
+        - panel.input_widget._send_btn.sizeHint().width()
+        - footer.spacing()
+    )
+    assert panel.island.width() <= available_width
 
 
 def test_mini_mode_manager_hides_and_restores_main_window(qtbot, app_mock):


### PR DESCRIPTION
## Summary
- add a compact AI chat mode for the mini player
- embed the dynamic island status widget inside the mini AI input area
- add an icon-only colorful AI control with matching island hover behavior
- make dynamic island visibility suppressible to avoid duplicate islands while the mini chat is open

## Tests
- uv run pytest tests/gui/uimain/test_uimain.py -q
- uv run flake8 feeluown/gui/components/dynamic_island.py feeluown/gui/uimain/mini_mode.py feeluown/gui/uimain/ai_chat.py feeluown/gui/widgets/ai_chat.py feeluown/gui/widgets/selfpaint_btn.py tests/gui/uimain/test_uimain.py